### PR TITLE
ED's URL should be "live" spec

### DIFF
--- a/protocol/wd/index.html
+++ b/protocol/wd/index.html
@@ -51,7 +51,7 @@
           previousPublishDate:  "",
           previousURI:          "",
           publishDate:          "2014-06-18", 
-          edDraftURI:           "http://w3c.github.io/web-annotation/",
+          edDraftURI:           "http://w3c.github.io/web-annotation/protocol/wd/",
           wg:                   "Web Annotation Working Group",
           wgURI:                "http://www.w3.org/annotation/",
           wgPublicList:         "public-annotation",


### PR DESCRIPTION
Make the ED's URL the "live" version of the spec rather than a generic document.
