### PR TITLE
Use "Web" rather than "Open" Annotation?

### DIFF
--- a/protocol/wd/index.html
+++ b/protocol/wd/index.html
@@ -150,7 +150,7 @@ The Web Annotation Protocol is defined using the following basic principles:
 <p>
 <dl>
   <dt>Web Server</dt><dd>A program that accepts connections in order to service HTTP requests by sending HTTP responses.</dd>
-  <dt>Annotation</dt><dd>A web resource that follows the Open Annotation Data Model [[annotation-model]]</dd>
+  <dt>Annotation</dt><dd>A web resource that follows the Web Annotation Data Model [[annotation-model]]</dd>
   <dt>Annotation Server</dt><dd>A Web Server that also makes available and allows the management of Annotations via the protocol described in this document</dd>
   <dt>Annotation Client</dt><dd>A program that establishes connections to Annotation Servers for the purpose of retrieving and managing Annotations via the protocol described in this document</dd>
   <dt>Annotation Container</dt><dd>An LDP Container used to manage Annotations</dd>


### PR DESCRIPTION
The protocol document has several instances of "Open Annotation" (and some of those instances specifically qualify "... Data Model"). It appears that in some cases, "Open Annotation" should be "Web Annotation". This PR changes one instance of "Open Annotation" to "Web Annotation"; perhaps others changes should also be made.
