### PR TITLE
Change @id/@type to id/type

### DIFF
--- a/model/wd/index-nametemplate.html
+++ b/model/wd/index-nametemplate.html
@@ -257,7 +257,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the Annotation
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Annotation
 <br/>An Annotation SHOULD have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
   <br/>An Annotation MUST have at least the <code>Annotation</code> class, and MAY have other classes.</td></tr>
@@ -265,7 +265,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <br/>The <code>Annotation</code> class MUST be associated with an Annotation using <code>@type</code>.</td></tr>
 <tr><td>body</td><td>Relationship<br/>Property</td><td>oa:hasBody</td><td>The relationship between an Annotation and its Body
 <br/>There SHOULD be 1 or more <code>body</code> relationships or properties associated with an Annotation but there MAY be 0.
-<div class="note">When the <code>body</code> is a relationship (it is a URI) it MUST be given as the value of an <code>@id</code> property of an object in the JSON-LD serialization.</div>
+<div class="note">When the <code>body</code> is a relationship (it is a URI) it MUST be given as the value of an <code>id</code> property of an object in the JSON-LD serialization.</div>
 </td></tr>
 <tr><td>target</td><td>Relationship</td><td>oa:hasTarget</td><td>The relationship between an Annotation and its Target
 <br/>There MUST be 1 or more <code>target</code> relationships associated with an Annotation.
@@ -283,9 +283,9 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <div class="tab_jsonld">
 <pre class="example highlight" title="Basic Annotation Model (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/post1"},
+  "body": {"id": "http://example.org/post1"},
   "target": "http://example.com/page1" 
 }
 </pre>
@@ -344,13 +344,13 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <div class="tab_jsonld">
 <pre class="example highlight" title="Creation Information (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "creator": "http://example.org/user1",
   "created": "2015-01-28T12:00:00Z",
   "generator": "http://example.org/client1",
   "generated": "2015-02-04T12:00:00Z",
-  "body": {"@id": "http://example.net/review1"},
+  "body": {"id": "http://example.net/review1"},
   "target": "http://example.com/restaurant1"
 }
 </pre>  
@@ -388,7 +388,7 @@ More information about the agents involved in the creation of an Annotation is n
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the agent
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the agent
 <br/>An Agent SHOULD have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br/>An Agent SHOULD have at least 1 class, from those below.</td></tr>
@@ -418,21 +418,21 @@ More information about the agents involved in the creation of an Annotation is n
 <div class="tab_jsonld">
 <pre class="example highlight" title="Creation Agents (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "creator": {
-    "@id": "http://example.org/user1",
+    "id": "http://example.org/user1",
     "@type": "Person",
     "name": "My Pseudonym",
     "nick": "pseudo"
   },
   "generator": {
-    "@id": "http://example.org/client1",
+    "id": "http://example.org/client1",
     "@type": "SoftwareAgent",
     "name": "Code v2.1",
     "homepage": "http://example.org/client1/homepage1"
   },
-  "body": {"@id": "http://example.net/review1"},
+  "body": {"id": "http://example.net/review1"},
   "target": "http://example.com/restaurant1"
 }
 </pre>
@@ -514,10 +514,10 @@ For more information about how Motivations can be inter-related and new Motivati
 <div class="tab_jsonld">
 <pre class="example highlight" title="Motivations (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "oa:Annotation",
   "motivation": "describing",
-  "body": {"@id": "http://example.org/description1"},
+  "body": {"id": "http://example.org/description1"},
   "target": "http://example.com/resource1"
 }
 </pre>
@@ -556,8 +556,8 @@ For more information about how Motivations can be inter-related and new Motivati
 <h4>Model</h4>
 
 <table class="model">
-  <tr><td>@id</td><td>Property</td><td> - </td><td>The URI that identifies the Body or Target resource.
-<br/>External Bodies or Targets MUST have exactly 1 <code>@id</code> with the value of the resource's URI.
+  <tr><td>id</td><td>Property</td><td> - </td><td>The URI that identifies the Body or Target resource.
+<br/>External Bodies or Targets MUST have exactly 1 <code>id</code> with the value of the resource's URI.
   </td></tr>
   <tr><td>language</td><td>Property</td><td>dc:language</td><td>The language of the textual body's content
   <br/>The Body or Target SHOULD have exactly 1 language associated with it, but MAY have 0 or more.  The value of the property SHOULD be a language code following the [[rfc5646]] specifiction.</td></tr>
@@ -577,15 +577,15 @@ For more information about how Motivations can be inter-related and new Motivati
 <div class="tab_jsonld">
 <pre class="example highlight" title="External Resources (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "oa:Annotation",
   "body": {
-    "@id": "http://example.org/analysis1.mp3",
+    "id": "http://example.org/analysis1.mp3",
     "format": "audio/mpeg",
     "language": "fr"
   },
   "target": {
-    "@id": "http://example.gov/patent1.pdf",
+    "id": "http://example.gov/patent1.pdf",
     "format": "application/pdf",
     "language": "en"
   }
@@ -643,27 +643,27 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <div class="tab_jsonld">
 <pre class="example highlight" title="Creation Information (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "creator": {
-    "@id": "http://example.org/agent1",
+    "id": "http://example.org/agent1",
     "@type": "Person",
     "name": "A. Person",
     "nick": "agent1"
   },
   "body": {
-    "@id": "http://example.org/walkthrough1",
+    "id": "http://example.org/walkthrough1",
     "creator": {
-      "@id": "http://example.org/user1",
+      "id": "http://example.org/user1",
       "@type": "Person",
       "name": "B. Person",
       "nick": "agent2"
     }
   },
   "target": {
-    "@id": "http://example.com/game1",
+    "id": "http://example.com/game1",
     "creator": {
-      "@id": "http://example.com/company1",
+      "id": "http://example.com/company1",
       "@type": "Organization",
       "name": "Game Company"
     }
@@ -736,14 +736,14 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <div class="tab_jsonld">
 <pre class="example highlight" title="Typing of Body and Target (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type":"Annotation",
   "body": {
-    "@id":"http://example.org/video1",
+    "id":"http://example.org/video1",
     "@type":"Video"
   },
   "target": {
-    "@id": "http://example.org/site1",
+    "id": "http://example.org/site1",
     "@type": "Text"
   }
 }
@@ -779,8 +779,8 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
-  <tr><td>@id</td><td>Property</td><td> - </td><td>The Fragment URI that identifies the segment of the Body or Target resource.
-<br/>External Bodies or Targets MUST have exactly 1 <code>@id</code> with the value of the resource's URI, and this MAY be a Fragment URI.
+  <tr><td>id</td><td>Property</td><td> - </td><td>The Fragment URI that identifies the segment of the Body or Target resource.
+<br/>External Bodies or Targets MUST have exactly 1 <code>id</code> with the value of the resource's URI, and this MAY be a Fragment URI.
   </td></tr>
 </table>
 
@@ -813,13 +813,13 @@ For more information regarding the use of Fragment URIs, please see the Best Pra
 <div class="tab_jsonld">
 <pre class="example highlight" title="Fragment URIs (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",  
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "body": {
-    "@id": "http://example.org/description1"
+    "id": "http://example.org/description1"
   },
   "target": {
-    "@id": "http://example.com/image1#xywh=100,100,300,300"
+    "id": "http://example.com/image1#xywh=100,100,300,300"
   }
 }
 </pre>
@@ -857,7 +857,7 @@ The fundamental features of a textual body are:
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the textual body
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the textual body
 <br/>The Body MAY have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br/>The Body MAY have the <code>TextualBody</code> class, and MAY have other classes.</td></tr>
@@ -883,7 +883,7 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 <div class="tab_jsonld">
 <pre class="example highlight" title="Textual Body (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type":"Annotation",
   "body": {
     "@type" : "TextualBody",
@@ -944,7 +944,7 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 <div class="tab_jsonld">
 <pre class="example highlight" title="Tagging (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type":"Annotation",
   "motivation": "bookmarking",
   "body": {
@@ -999,7 +999,7 @@ There are several restrictions on when this form may be used and how it is to be
 </ul>
 </p>
 
-<p class="note">In order for the <code>body</code> value to be a URI, it MUST be in the <code>{"@id": "URI"}</code> form, otherwise it will be considered a string literal.  However, as <code>target</code> MUST NOT be a string literal, it MAY be given as either a string or in the JSON object form.</p>
+<p class="note">In order for the <code>body</code> value to be a URI, it MUST be in the <code>{"id": "URI"}</code> form, otherwise it will be considered a string literal.  However, as <code>target</code> MUST NOT be a string literal, it MAY be given as either a string or in the JSON object form.</p>
 
 <div class="issue">
 An alternative that would allow clients to avoid type checking and make the model more coherent under consideration is to use a separate property, <code>bodyText</code>, to record the text of the body.
@@ -1023,7 +1023,7 @@ An alternative that would allow clients to avoid type checking and make the mode
 <div class="tab_jsonld">
 <pre class="example highlight" title="String Body (JSON-LD)">
 {
-	"@id": "http://example.org/anno%%anno%%",
+	"id": "http://example.org/anno%%anno%%",
 	"@type":"oa:Annotation",
 	"body": "Comment text",
 	"target": "http://example.org/target1"
@@ -1082,7 +1082,7 @@ The diagrams and examples in this section only depict one of these, however the 
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
 <br/>A Specific Resource MAY have exactly 1 http/https URI that identifies it, or MAY have no identity.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
   <br/>The Specific Resource MAY have the <code>SpecificResource</code>.</td></tr>
@@ -1106,11 +1106,11 @@ The diagrams and examples in this section only depict one of these, however the 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Specific Resources (JSON)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/comment1"},
+  "body": {"id": "http://example.org/comment1"},
   "target": {
-    "@id": "http://example.org/region1",
+    "id": "http://example.org/region1",
     "@type": "SpecificResource",
     "source": "http://example.org/image1"
   }
@@ -1162,14 +1162,14 @@ The diagrams and examples in this section only depict one of these, however the 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Resource with Role (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "body": {
     "role": "tagging",
     "source": "http://example.org/city1"
   },
   "target": {
-    "@id": "http://example.org/photo1",
+    "id": "http://example.org/photo1",
     "@type": "Image"
   }
 }
@@ -1222,7 +1222,7 @@ The diagrams and examples in this section only depict one of these, however the 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Selectors (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "body": {
     "source": "http://example.org/page1",
@@ -1307,9 +1307,9 @@ A Fragment URI may be reconstructed by concatenating the <code>source</code>, a 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Fragment Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "target": {"@id": "http://example.org/image1"},
+  "target": {"id": "http://example.org/image1"},
   "body": {
     "source": "http://example.org/video1",
     "role": "describing",
@@ -1391,9 +1391,9 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Text Quote Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/comment1"},
+  "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/page1",
     "selector": {
@@ -1470,9 +1470,9 @@ The use of this Selector does not require text to be copied from the Source docu
 <div class="tab_jsonld">
 <pre class="example highlight" title="Text Position Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/review1"},
+  "body": {"id": "http://example.org/review1"},
   "target": {
     "source": "http://example.org/ebook1",
     "selector": {
@@ -1539,9 +1539,9 @@ Similar to the Text Position Selector, the Data Position Selector uses the same 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Data Position Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/note1"},
+  "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/diskimg1",
     "selector": {
@@ -1614,13 +1614,13 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <div class="tab_jsonld">
 <pre class="example highlight" title="SVG Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/road1"},
+  "body": {"id": "http://example.org/road1"},
   "target": {
     "source": "http://example.org/map1",
     "selector": {
-      "@id": "http://example.org/svg1",
+      "id": "http://example.org/svg1",
       "@type": "SvgSelector"
     }
   }
@@ -1655,9 +1655,9 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <div class="tab_jsonld">
 <pre class="example highlight" title="SVG Selector, embedded (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/road1"},
+  "body": {"id": "http://example.org/road1"},
   "target": {
     "source": "http://example.org/map1",
     "selector": {
@@ -1723,13 +1723,13 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <div class="tab_jsonld">
 <pre class="example highlight" title="State (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/note1"},
+  "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/page1",
     "state": {
-      "@id": "http://example.org/state1"
+      "id": "http://example.org/state1"
     }
   }
 }
@@ -1786,9 +1786,9 @@ representation, appropriate for the Annotation.
 <div class="tab_jsonld">
 <pre class="example highlight" title="Time State (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/note1"},
+  "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/page1",
     "state": {
@@ -1852,9 +1852,9 @@ of the headers to be replayed when obtaining the representation. </p>
 <div class="tab_jsonld">
 <pre class="example highlight" title="HTTP Request State (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/description1"},
+  "body": {"id": "http://example.org/description1"},
   "target": {
     "source": "http://example.org/resource1",
     "state": {
@@ -1922,13 +1922,13 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <div class="tab_jsonld">
 <pre class="example highlight" title="CSS Style (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "stylesheet": {
-    "@id": "http://example.org/style1",
+    "id": "http://example.org/style1",
     "@type": "CssStylesheet"
   },
-  "body": {"@id": "http://example.org/comment1"},
+  "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/document1",
     "styleClass": "red"
@@ -1967,14 +1967,14 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <div class="tab_jsonld">
 <pre class="example highlight" title="CSS Style, embedded (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "stylesheet": {
     "@type": ["CssStylesheet", "EmbeddedContent"],
     "value": ".red { color: red }",
     "format": "text/css"
   },
-  "body": {"@id": "http://example.org/body1"},
+  "body": {"id": "http://example.org/body1"},
   "target": {
     "source": "http://example.org/target1",
     "styleClass": "red"
@@ -2031,9 +2031,9 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <div class="tab_jsonld">
 <pre class="example highlight" title="Scope (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/note1"},
+  "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/image1",
     "scope": "http://example.org/page1"
@@ -2084,7 +2084,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <div class="tab_jsonld">
 <pre class="example highlight" title="Annotations without a Body (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "oa:Annotation",
   "target": "http://example.org/ebook1"
 }
@@ -2127,7 +2127,7 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div class="tab_jsonld">
 <pre class="example highlight" title="Multiple Bodies or Targets (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "body": [
     { 
@@ -2207,17 +2207,17 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div class="tab_jsonld">
 <pre class="example hightlight" title="Choice (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "body": {
     "@type": "Choice",
     "members": [
       { 
-        "@id": "http://example.org/note1",
+        "id": "http://example.org/note1",
         "language": "en"
       },
       {
-        "@id": "http://example.org/note2",
+        "id": "http://example.org/note2",
         "language": "fr"
       }
     ]
@@ -2274,9 +2274,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div class="tab_jsonld">
 <pre class="example highlight" title="Composite (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/comparison1"},
+  "body": {"id": "http://example.org/comparison1"},
   "target": {
     "@type": "Composite",
     "item": [
@@ -2330,9 +2330,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div class="tab_jsonld">
 <pre class="example highlight" title="List (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/comment1"},
+  "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/page1",
     "selector": {
@@ -2415,6 +2415,8 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
     "iana":    "http://www.iana.org/assignments/relation/",
     "owl":     "http://www.w3.org/2002/07/owl#",
     "as":      "http://www.w3.org/ns/activitystreams#",
+
+    "id":      "@id",
 
     "Annotation":           "oa:Annotation",
     "Dataset":              "dctypes:Dataset",
@@ -2524,25 +2526,25 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
 <div class="tab_jsonld">
 <pre class="example highlight" title="Complete Example (JSON-LD)">
 {
-  "@id": "http://example.org/anno%%anno%%",
+  "id": "http://example.org/anno%%anno%%",
   "@type": "Annotation",
   "motivation": "commenting",
   "creator": {
-    "@id": "http://example.org/user1",
+    "id": "http://example.org/user1",
     "@type": "Person",
     "name": "A. Person",
     "nick": "user1"
   },
   "created": "2015-10-13T13:00:00Z",
   "generator": {
-    "@id": "http://example.org/client1",
+    "id": "http://example.org/client1",
     "@type": "SoftwareAgent",
     "name": "Code v2.1",
     "homepage": "http://example.org/homepage1"
   },
   "generated": "2015-10-14T15:13:28Z",
   "stylesheet": {
-    "@id": "http://example.org/stylesheet1",
+    "id": "http://example.org/stylesheet1",
     "@type": "CssStylesheet"
   },
 
@@ -2567,12 +2569,12 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
           "@type": "SpecificResource", 
           "role": "describing",
           "source": {
-            "@id": "http://example.org/comment1",
+            "id": "http://example.org/comment1",
             "@type": "Audio",
             "format": "audio/mpeg",
             "language": "de",
             "creator": {
-              "@id": "http://example.org/user2",
+              "id": "http://example.org/user2",
               "@type": "Person"
             }
           }

--- a/model/wd/index-nametemplate.html
+++ b/model/wd/index-nametemplate.html
@@ -259,10 +259,10 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Annotation
 <br/>An Annotation SHOULD have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
   <br/>An Annotation MUST have at least the <code>Annotation</code> class, and MAY have other classes.</td></tr>
 <tr><td>Annotation</td><td>Class</td><td>oa:Annotation</td><td>The class for Web Annotations
-<br/>The <code>Annotation</code> class MUST be associated with an Annotation using <code>@type</code>.</td></tr>
+<br/>The <code>Annotation</code> class MUST be associated with an Annotation using <code>type</code>.</td></tr>
 <tr><td>body</td><td>Relationship<br/>Property</td><td>oa:hasBody</td><td>The relationship between an Annotation and its Body
 <br/>There SHOULD be 1 or more <code>body</code> relationships or properties associated with an Annotation but there MAY be 0.
 <div class="note">When the <code>body</code> is a relationship (it is a URI) it MUST be given as the value of an <code>id</code> property of an object in the JSON-LD serialization.</div>
@@ -284,7 +284,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <pre class="example highlight" title="Basic Annotation Model (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/post1"},
   "target": "http://example.com/page1" 
 }
@@ -345,7 +345,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <pre class="example highlight" title="Creation Information (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "creator": "http://example.org/user1",
   "created": "2015-01-28T12:00:00Z",
   "generator": "http://example.org/client1",
@@ -390,7 +390,7 @@ More information about the agents involved in the creation of an Annotation is n
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the agent
 <br/>An Agent SHOULD have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br/>An Agent SHOULD have at least 1 class, from those below.</td></tr>
 
 <tr><td>Person</td><td>Class</td><td>foaf:Person</td><td>The class for a human agent, typically used as the class of the <code>creator</code> of the Annotation</td></tr>
@@ -419,16 +419,16 @@ More information about the agents involved in the creation of an Annotation is n
 <pre class="example highlight" title="Creation Agents (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "creator": {
     "id": "http://example.org/user1",
-    "@type": "Person",
+    "type": "Person",
     "name": "My Pseudonym",
     "nick": "pseudo"
   },
   "generator": {
     "id": "http://example.org/client1",
-    "@type": "SoftwareAgent",
+    "type": "SoftwareAgent",
     "name": "Code v2.1",
     "homepage": "http://example.org/client1/homepage1"
   },
@@ -515,7 +515,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <pre class="example highlight" title="Motivations (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "oa:Annotation",
+  "type": "oa:Annotation",
   "motivation": "describing",
   "body": {"id": "http://example.org/description1"},
   "target": "http://example.com/resource1"
@@ -578,7 +578,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <pre class="example highlight" title="External Resources (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "oa:Annotation",
+  "type": "oa:Annotation",
   "body": {
     "id": "http://example.org/analysis1.mp3",
     "format": "audio/mpeg",
@@ -644,10 +644,10 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <pre class="example highlight" title="Creation Information (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "creator": {
     "id": "http://example.org/agent1",
-    "@type": "Person",
+    "type": "Person",
     "name": "A. Person",
     "nick": "agent1"
   },
@@ -655,7 +655,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
     "id": "http://example.org/walkthrough1",
     "creator": {
       "id": "http://example.org/user1",
-      "@type": "Person",
+      "type": "Person",
       "name": "B. Person",
       "nick": "agent2"
     }
@@ -664,7 +664,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
     "id": "http://example.com/game1",
     "creator": {
       "id": "http://example.com/company1",
-      "@type": "Organization",
+      "type": "Organization",
       "name": "Game Company"
     }
   }
@@ -716,7 +716,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:class</td><td>The type of the Body resource.
+<tr><td>type</td><td>Relationship</td><td>rdf:class</td><td>The type of the Body resource.
   <br/>The Body MAY have a type, and if so, it SHOULD be drawn from the list below.</td></tr>
 <tr><td>Dataset</td><td>Class</td><td>dctypes:Dataset</td><td>The class for a resource which encodes data in a defined structure</td></tr>
 <tr><td>Image</td><td>Class</td><td>dctypes:StillImage</td><td>The class for image resources, primarily intended to be seen</td></tr>
@@ -737,14 +737,14 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <pre class="example highlight" title="Typing of Body and Target (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type":"Annotation",
+  "type":"Annotation",
   "body": {
     "id":"http://example.org/video1",
-    "@type":"Video"
+    "type":"Video"
   },
   "target": {
     "id": "http://example.org/site1",
-    "@type": "Text"
+    "type": "Text"
   }
 }
 </pre>
@@ -814,7 +814,7 @@ For more information regarding the use of Fragment URIs, please see the Best Pra
 <pre class="example highlight" title="Fragment URIs (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
     "id": "http://example.org/description1"
   },
@@ -859,7 +859,7 @@ The fundamental features of a textual body are:
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the textual body
 <br/>The Body MAY have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br/>The Body MAY have the <code>TextualBody</code> class, and MAY have other classes.</td></tr>
 <tr><td>TextualBody</td><td>Class</td><td>oa:TextualBody</td><td>A class assigned to the Body for embedding textual resources within the Annotation.</td></tr>
 <tr><td>text</td><td>Property</td><td>oa:text</td><td>The character sequence of the content.<br/>
@@ -884,9 +884,9 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 <pre class="example highlight" title="Textual Body (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type":"Annotation",
+  "type":"Annotation",
   "body": {
-    "@type" : "TextualBody",
+    "type" : "TextualBody",
     "text" : "&lt;p&gt;Comment text&lt;/p&gt;",
     "format" : "text/html",
     "language" : "en"
@@ -945,7 +945,7 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 <pre class="example highlight" title="Tagging (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type":"Annotation",
+  "type":"Annotation",
   "motivation": "bookmarking",
   "body": {
     "text" : "readme",
@@ -1024,7 +1024,7 @@ An alternative that would allow clients to avoid type checking and make the mode
 <pre class="example highlight" title="String Body (JSON-LD)">
 {
 	"id": "http://example.org/anno%%anno%%",
-	"@type":"oa:Annotation",
+	"type":"oa:Annotation",
 	"body": "Comment text",
 	"target": "http://example.org/target1"
 }
@@ -1084,7 +1084,7 @@ The diagrams and examples in this section only depict one of these, however the 
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
 <br/>A Specific Resource MAY have exactly 1 http/https URI that identifies it, or MAY have no identity.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
   <br/>The Specific Resource MAY have the <code>SpecificResource</code>.</td></tr>
 <tr><td>SpecificResource</td><td>Class</td><td>oa:SpecificResource</td><td>The class for Specific Resources
 <br/>The <code>SpecificResource</code> class SHOULD be associated with a Specific Resource to be clear as to its role as a more specific region or state of another resource.</td></tr>
@@ -1107,11 +1107,11 @@ The diagrams and examples in this section only depict one of these, however the 
 <pre class="example highlight" title="Specific Resources (JSON)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/comment1"},
   "target": {
     "id": "http://example.org/region1",
-    "@type": "SpecificResource",
+    "type": "SpecificResource",
     "source": "http://example.org/image1"
   }
 }
@@ -1163,14 +1163,14 @@ The diagrams and examples in this section only depict one of these, however the 
 <pre class="example highlight" title="Resource with Role (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
     "role": "tagging",
     "source": "http://example.org/city1"
   },
   "target": {
     "id": "http://example.org/photo1",
-    "@type": "Image"
+    "type": "Image"
   }
 }
 </pre>
@@ -1223,7 +1223,7 @@ The diagrams and examples in this section only depict one of these, however the 
 <pre class="example highlight" title="Selectors (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
     "source": "http://example.org/page1",
     "selector": "http://example.org/paraselector1"
@@ -1308,13 +1308,13 @@ A Fragment URI may be reconstructed by concatenating the <code>source</code>, a 
 <pre class="example highlight" title="Fragment Selector (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "target": {"id": "http://example.org/image1"},
   "body": {
     "source": "http://example.org/video1",
     "role": "describing",
     "selector": {
-      "@type": "FragmentSelector",
+      "type": "FragmentSelector",
       "conformsTo": "http://www.w3.org/TR/media-frags/",
       "value": "t=30,60"
     }
@@ -1392,12 +1392,12 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 <pre class="example highlight" title="Text Quote Selector (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/page1",
     "selector": {
-      "@type": "TextQuoteSelector",
+      "type": "TextQuoteSelector",
       "exact": "anotation",
       "prefix": "this is an ",
       "suffix": " that has some"
@@ -1471,12 +1471,12 @@ The use of this Selector does not require text to be copied from the Source docu
 <pre class="example highlight" title="Text Position Selector (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/review1"},
   "target": {
     "source": "http://example.org/ebook1",
     "selector": {
-      "@type": "TextPositionSelector",
+      "type": "TextPositionSelector",
       "start": 412,
       "end": 795
     }
@@ -1540,12 +1540,12 @@ Similar to the Text Position Selector, the Data Position Selector uses the same 
 <pre class="example highlight" title="Data Position Selector (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/diskimg1",
     "selector": {
-      "@type": "oa:DataPositionSelector",
+      "type": "oa:DataPositionSelector",
       "start": 4096,
       "end": 4104
     }
@@ -1615,13 +1615,13 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <pre class="example highlight" title="SVG Selector (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/road1"},
   "target": {
     "source": "http://example.org/map1",
     "selector": {
       "id": "http://example.org/svg1",
-      "@type": "SvgSelector"
+      "type": "SvgSelector"
     }
   }
 }
@@ -1656,12 +1656,12 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <pre class="example highlight" title="SVG Selector, embedded (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/road1"},
   "target": {
     "source": "http://example.org/map1",
     "selector": {
-      "@type": ["SvgSelector", "EmbeddedContent"],
+      "type": ["SvgSelector", "EmbeddedContent"],
       "text": "&lt;svg:svg&gt; ... &lt;/svg:svg&gt;",
       "format": "image/svg+xml"
     }
@@ -1724,7 +1724,7 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <pre class="example highlight" title="State (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/page1",
@@ -1787,12 +1787,12 @@ representation, appropriate for the Annotation.
 <pre class="example highlight" title="Time State (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/page1",
     "state": {
-      "@type": "TimeState",
+      "type": "TimeState",
       "cached": "http://archive.example.org/copy1",
       "sourceDate": "2015-07-20T13:30:00Z"
     }
@@ -1853,12 +1853,12 @@ of the headers to be replayed when obtaining the representation. </p>
 <pre class="example highlight" title="HTTP Request State (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/description1"},
   "target": {
     "source": "http://example.org/resource1",
     "state": {
-      "@type": "HttpRequestState",
+      "type": "HttpRequestState",
       "value": "Accept: application/pdf"
     }
   }
@@ -1923,10 +1923,10 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="CSS Style (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "stylesheet": {
     "id": "http://example.org/style1",
-    "@type": "CssStylesheet"
+    "type": "CssStylesheet"
   },
   "body": {"id": "http://example.org/comment1"},
   "target": {
@@ -1968,9 +1968,9 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="CSS Style, embedded (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "stylesheet": {
-    "@type": ["CssStylesheet", "EmbeddedContent"],
+    "type": ["CssStylesheet", "EmbeddedContent"],
     "value": ".red { color: red }",
     "format": "text/css"
   },
@@ -2032,7 +2032,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="Scope (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/image1",
@@ -2085,7 +2085,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="Annotations without a Body (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "oa:Annotation",
+  "type": "oa:Annotation",
   "target": "http://example.org/ebook1"
 }
 </pre>
@@ -2128,7 +2128,7 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <pre class="example highlight" title="Multiple Bodies or Targets (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": [
     { 
       "role": "describing",
@@ -2208,9 +2208,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <pre class="example hightlight" title="Choice (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
-    "@type": "Choice",
+    "type": "Choice",
     "members": [
       { 
         "id": "http://example.org/note1",
@@ -2275,10 +2275,10 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <pre class="example highlight" title="Composite (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/comparison1"},
   "target": {
-    "@type": "Composite",
+    "type": "Composite",
     "item": [
       "http://example.org/comic1",
       "http://example.org/comic2"
@@ -2331,12 +2331,12 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <pre class="example highlight" title="List (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/page1",
     "selector": {
-      "@type": "List",
+      "type": "List",
       "members": [
         "http://example.org/paraselector1",
         "http://example.org/offsetselector1"
@@ -2417,6 +2417,7 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
     "as":      "http://www.w3.org/ns/activitystreams#",
 
     "id":      "@id",
+    "type":    "@type",
 
     "Annotation":           "oa:Annotation",
     "Dataset":              "dctypes:Dataset",
@@ -2527,38 +2528,38 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
 <pre class="example highlight" title="Complete Example (JSON-LD)">
 {
   "id": "http://example.org/anno%%anno%%",
-  "@type": "Annotation",
+  "type": "Annotation",
   "motivation": "commenting",
   "creator": {
     "id": "http://example.org/user1",
-    "@type": "Person",
+    "type": "Person",
     "name": "A. Person",
     "nick": "user1"
   },
   "created": "2015-10-13T13:00:00Z",
   "generator": {
     "id": "http://example.org/client1",
-    "@type": "SoftwareAgent",
+    "type": "SoftwareAgent",
     "name": "Code v2.1",
     "homepage": "http://example.org/homepage1"
   },
   "generated": "2015-10-14T15:13:28Z",
   "stylesheet": {
     "id": "http://example.org/stylesheet1",
-    "@type": "CssStylesheet"
+    "type": "CssStylesheet"
   },
 
   "body": [
     {
-      "@type": "TextualBody",
+      "type": "TextualBody",
       "role": "tagging",
       "text": "love"
     },
     {
-      "@type": "Choice",
+      "type": "Choice",
       "members": [
         {
-          "@type": "TextualBody",
+          "type": "TextualBody",
           "role": "describing",
           "text": "I really love this particular bit of text in this XML. No really.",
           "format": "text/plain",
@@ -2566,16 +2567,16 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
           "creator": "http://example.org/user1"
         },
         {
-          "@type": "SpecificResource", 
+          "type": "SpecificResource", 
           "role": "describing",
           "source": {
             "id": "http://example.org/comment1",
-            "@type": "Audio",
+            "type": "Audio",
             "format": "audio/mpeg",
             "language": "de",
             "creator": {
               "id": "http://example.org/user2",
-              "@type": "Person"
+              "type": "Person"
             }
           }
         }
@@ -2583,28 +2584,28 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
     }
   ],
   "target": {
-    "@type": "SpecificResource",
+    "type": "SpecificResource",
     "styleClass": "mystyle",
     "source": "http://example.com/document1",
     "state": [
       {
-        "@type": "HttpRequestState",
+        "type": "HttpRequestState",
         "value": "Accept: application/xml"
       },
       {
-        "@type": "TimeState",
+        "type": "TimeState",
         "sourceDate": "2015-09-25T12:00:00Z"
       }
     ],
     "selector": {
-      "@type": "List",
+      "type": "List",
       "members": [
         {
-          "@type": "FragmentSelector",
+          "type": "FragmentSelector",
           "value": "xpointer(/doc/body/section[2]/para[1])"
         },
         {
-          "@type": "TextPositionSelector",
+          "type": "TextPositionSelector",
           "start": 6,
           "end": 27
         }

--- a/model/wd/index-respec.html
+++ b/model/wd/index-respec.html
@@ -257,7 +257,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the Annotation
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Annotation
 <br/>An Annotation SHOULD have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
   <br/>An Annotation MUST have at least the <code>Annotation</code> class, and MAY have other classes.</td></tr>
@@ -265,7 +265,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <br/>The <code>Annotation</code> class MUST be associated with an Annotation using <code>@type</code>.</td></tr>
 <tr><td>body</td><td>Relationship<br/>Property</td><td>oa:hasBody</td><td>The relationship between an Annotation and its Body
 <br/>There SHOULD be 1 or more <code>body</code> relationships or properties associated with an Annotation but there MAY be 0.
-<div class="note">When the <code>body</code> is a relationship (it is a URI) it MUST be given as the value of an <code>@id</code> property of an object in the JSON-LD serialization.</div>
+<div class="note">When the <code>body</code> is a relationship (it is a URI) it MUST be given as the value of an <code>id</code> property of an object in the JSON-LD serialization.</div>
 </td></tr>
 <tr><td>target</td><td>Relationship</td><td>oa:hasTarget</td><td>The relationship between an Annotation and its Target
 <br/>There MUST be 1 or more <code>target</code> relationships associated with an Annotation.
@@ -283,9 +283,9 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <div class="tab_jsonld">
 <pre class="example highlight" title="Basic Annotation Model (JSON-LD)">
 {
-  "@id": "http://example.org/anno1",
+  "id": "http://example.org/anno1",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/post1"},
+  "body": {"id": "http://example.org/post1"},
   "target": "http://example.com/page1" 
 }
 </pre>
@@ -344,13 +344,13 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <div class="tab_jsonld">
 <pre class="example highlight" title="Creation Information (JSON-LD)">
 {
-  "@id": "http://example.org/anno2",
+  "id": "http://example.org/anno2",
   "@type": "Annotation",
   "creator": "http://example.org/user1",
   "created": "2015-01-28T12:00:00Z",
   "generator": "http://example.org/client1",
   "generated": "2015-02-04T12:00:00Z",
-  "body": {"@id": "http://example.net/review1"},
+  "body": {"id": "http://example.net/review1"},
   "target": "http://example.com/restaurant1"
 }
 </pre>  
@@ -388,7 +388,7 @@ More information about the agents involved in the creation of an Annotation is n
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the agent
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the agent
 <br/>An Agent SHOULD have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br/>An Agent SHOULD have at least 1 class, from those below.</td></tr>
@@ -418,21 +418,21 @@ More information about the agents involved in the creation of an Annotation is n
 <div class="tab_jsonld">
 <pre class="example highlight" title="Creation Agents (JSON-LD)">
 {
-  "@id": "http://example.org/anno3",
+  "id": "http://example.org/anno3",
   "@type": "Annotation",
   "creator": {
-    "@id": "http://example.org/user1",
+    "id": "http://example.org/user1",
     "@type": "Person",
     "name": "My Pseudonym",
     "nick": "pseudo"
   },
   "generator": {
-    "@id": "http://example.org/client1",
+    "id": "http://example.org/client1",
     "@type": "SoftwareAgent",
     "name": "Code v2.1",
     "homepage": "http://example.org/client1/homepage1"
   },
-  "body": {"@id": "http://example.net/review1"},
+  "body": {"id": "http://example.net/review1"},
   "target": "http://example.com/restaurant1"
 }
 </pre>
@@ -514,10 +514,10 @@ For more information about how Motivations can be inter-related and new Motivati
 <div class="tab_jsonld">
 <pre class="example highlight" title="Motivations (JSON-LD)">
 {
-  "@id": "http://example.org/anno4",
+  "id": "http://example.org/anno4",
   "@type": "oa:Annotation",
   "motivation": "describing",
-  "body": {"@id": "http://example.org/description1"},
+  "body": {"id": "http://example.org/description1"},
   "target": "http://example.com/resource1"
 }
 </pre>
@@ -556,8 +556,8 @@ For more information about how Motivations can be inter-related and new Motivati
 <h4>Model</h4>
 
 <table class="model">
-  <tr><td>@id</td><td>Property</td><td> - </td><td>The URI that identifies the Body or Target resource.
-<br/>External Bodies or Targets MUST have exactly 1 <code>@id</code> with the value of the resource's URI.
+  <tr><td>id</td><td>Property</td><td> - </td><td>The URI that identifies the Body or Target resource.
+<br/>External Bodies or Targets MUST have exactly 1 <code>id</code> with the value of the resource's URI.
   </td></tr>
   <tr><td>language</td><td>Property</td><td>dc:language</td><td>The language of the textual body's content
   <br/>The Body or Target SHOULD have exactly 1 language associated with it, but MAY have 0 or more.  The value of the property SHOULD be a language code following the [[rfc5646]] specifiction.</td></tr>
@@ -577,15 +577,15 @@ For more information about how Motivations can be inter-related and new Motivati
 <div class="tab_jsonld">
 <pre class="example highlight" title="External Resources (JSON-LD)">
 {
-  "@id": "http://example.org/anno5",
+  "id": "http://example.org/anno5",
   "@type": "oa:Annotation",
   "body": {
-    "@id": "http://example.org/analysis1.mp3",
+    "id": "http://example.org/analysis1.mp3",
     "format": "audio/mpeg",
     "language": "fr"
   },
   "target": {
-    "@id": "http://example.gov/patent1.pdf",
+    "id": "http://example.gov/patent1.pdf",
     "format": "application/pdf",
     "language": "en"
   }
@@ -643,27 +643,27 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <div class="tab_jsonld">
 <pre class="example highlight" title="Creation Information (JSON-LD)">
 {
-  "@id": "http://example.org/anno6",
+  "id": "http://example.org/anno6",
   "@type": "Annotation",
   "creator": {
-    "@id": "http://example.org/agent1",
+    "id": "http://example.org/agent1",
     "@type": "Person",
     "name": "A. Person",
     "nick": "agent1"
   },
   "body": {
-    "@id": "http://example.org/walkthrough1",
+    "id": "http://example.org/walkthrough1",
     "creator": {
-      "@id": "http://example.org/user1",
+      "id": "http://example.org/user1",
       "@type": "Person",
       "name": "B. Person",
       "nick": "agent2"
     }
   },
   "target": {
-    "@id": "http://example.com/game1",
+    "id": "http://example.com/game1",
     "creator": {
-      "@id": "http://example.com/company1",
+      "id": "http://example.com/company1",
       "@type": "Organization",
       "name": "Game Company"
     }
@@ -736,14 +736,14 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <div class="tab_jsonld">
 <pre class="example highlight" title="Typing of Body and Target (JSON-LD)">
 {
-  "@id": "http://example.org/anno7",
+  "id": "http://example.org/anno7",
   "@type":"Annotation",
   "body": {
-    "@id":"http://example.org/video1",
+    "id":"http://example.org/video1",
     "@type":"Video"
   },
   "target": {
-    "@id": "http://example.org/site1",
+    "id": "http://example.org/site1",
     "@type": "Text"
   }
 }
@@ -779,8 +779,8 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
-  <tr><td>@id</td><td>Property</td><td> - </td><td>The Fragment URI that identifies the segment of the Body or Target resource.
-<br/>External Bodies or Targets MUST have exactly 1 <code>@id</code> with the value of the resource's URI, and this MAY be a Fragment URI.
+  <tr><td>id</td><td>Property</td><td> - </td><td>The Fragment URI that identifies the segment of the Body or Target resource.
+<br/>External Bodies or Targets MUST have exactly 1 <code>id</code> with the value of the resource's URI, and this MAY be a Fragment URI.
   </td></tr>
 </table>
 
@@ -813,13 +813,13 @@ For more information regarding the use of Fragment URIs, please see the Best Pra
 <div class="tab_jsonld">
 <pre class="example highlight" title="Fragment URIs (JSON-LD)">
 {
-  "@id": "http://example.org/anno8",  
+  "id": "http://example.org/anno8",
   "@type": "Annotation",
   "body": {
-    "@id": "http://example.org/description1"
+    "id": "http://example.org/description1"
   },
   "target": {
-    "@id": "http://example.com/image1#xywh=100,100,300,300"
+    "id": "http://example.com/image1#xywh=100,100,300,300"
   }
 }
 </pre>
@@ -857,7 +857,7 @@ The fundamental features of a textual body are:
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the textual body
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the textual body
 <br/>The Body MAY have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br/>The Body MAY have the <code>TextualBody</code> class, and MAY have other classes.</td></tr>
@@ -883,7 +883,7 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 <div class="tab_jsonld">
 <pre class="example highlight" title="Textual Body (JSON-LD)">
 {
-  "@id": "http://example.org/anno9",
+  "id": "http://example.org/anno9",
   "@type":"Annotation",
   "body": {
     "@type" : "TextualBody",
@@ -944,7 +944,7 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 <div class="tab_jsonld">
 <pre class="example highlight" title="Tagging (JSON-LD)">
 {
-  "@id": "http://example.org/anno10",
+  "id": "http://example.org/anno10",
   "@type":"Annotation",
   "motivation": "bookmarking",
   "body": {
@@ -999,7 +999,7 @@ There are several restrictions on when this form may be used and how it is to be
 </ul>
 </p>
 
-<p class="note">In order for the <code>body</code> value to be a URI, it MUST be in the <code>{"@id": "URI"}</code> form, otherwise it will be considered a string literal.  However, as <code>target</code> MUST NOT be a string literal, it MAY be given as either a string or in the JSON object form.</p>
+<p class="note">In order for the <code>body</code> value to be a URI, it MUST be in the <code>{"id": "URI"}</code> form, otherwise it will be considered a string literal.  However, as <code>target</code> MUST NOT be a string literal, it MAY be given as either a string or in the JSON object form.</p>
 
 <div class="issue">
 An alternative that would allow clients to avoid type checking and make the model more coherent under consideration is to use a separate property, <code>bodyText</code>, to record the text of the body.
@@ -1023,7 +1023,7 @@ An alternative that would allow clients to avoid type checking and make the mode
 <div class="tab_jsonld">
 <pre class="example highlight" title="String Body (JSON-LD)">
 {
-	"@id": "http://example.org/anno11",
+	"id": "http://example.org/anno11",
 	"@type":"oa:Annotation",
 	"body": "Comment text",
 	"target": "http://example.org/target1"
@@ -1082,7 +1082,7 @@ The diagrams and examples in this section only depict one of these, however the 
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
 <br/>A Specific Resource MAY have exactly 1 http/https URI that identifies it, or MAY have no identity.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
   <br/>The Specific Resource MAY have the <code>SpecificResource</code>.</td></tr>
@@ -1106,11 +1106,11 @@ The diagrams and examples in this section only depict one of these, however the 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Specific Resources (JSON)">
 {
-  "@id": "http://example.org/anno12",
+  "id": "http://example.org/anno12",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/comment1"},
+  "body": {"id": "http://example.org/comment1"},
   "target": {
-    "@id": "http://example.org/region1",
+    "id": "http://example.org/region1",
     "@type": "SpecificResource",
     "source": "http://example.org/image1"
   }
@@ -1162,14 +1162,14 @@ The diagrams and examples in this section only depict one of these, however the 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Resource with Role (JSON-LD)">
 {
-  "@id": "http://example.org/anno13",
+  "id": "http://example.org/anno13",
   "@type": "Annotation",
   "body": {
     "role": "tagging",
     "source": "http://example.org/city1"
   },
   "target": {
-    "@id": "http://example.org/photo1",
+    "id": "http://example.org/photo1",
     "@type": "Image"
   }
 }
@@ -1222,7 +1222,7 @@ The diagrams and examples in this section only depict one of these, however the 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Selectors (JSON-LD)">
 {
-  "@id": "http://example.org/anno14",
+  "id": "http://example.org/anno14",
   "@type": "Annotation",
   "body": {
     "source": "http://example.org/page1",
@@ -1307,9 +1307,9 @@ A Fragment URI may be reconstructed by concatenating the <code>source</code>, a 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Fragment Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno15",
+  "id": "http://example.org/anno15",
   "@type": "Annotation",
-  "target": {"@id": "http://example.org/image1"},
+  "target": {"id": "http://example.org/image1"},
   "body": {
     "source": "http://example.org/video1",
     "role": "describing",
@@ -1391,9 +1391,9 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Text Quote Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno16",
+  "id": "http://example.org/anno16",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/comment1"},
+  "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/page1",
     "selector": {
@@ -1470,9 +1470,9 @@ The use of this Selector does not require text to be copied from the Source docu
 <div class="tab_jsonld">
 <pre class="example highlight" title="Text Position Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno17",
+  "id": "http://example.org/anno17",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/review1"},
+  "body": {"id": "http://example.org/review1"},
   "target": {
     "source": "http://example.org/ebook1",
     "selector": {
@@ -1539,9 +1539,9 @@ Similar to the Text Position Selector, the Data Position Selector uses the same 
 <div class="tab_jsonld">
 <pre class="example highlight" title="Data Position Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno18",
+  "id": "http://example.org/anno18",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/note1"},
+  "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/diskimg1",
     "selector": {
@@ -1614,13 +1614,13 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <div class="tab_jsonld">
 <pre class="example highlight" title="SVG Selector (JSON-LD)">
 {
-  "@id": "http://example.org/anno19",
+  "id": "http://example.org/anno19",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/road1"},
+  "body": {"id": "http://example.org/road1"},
   "target": {
     "source": "http://example.org/map1",
     "selector": {
-      "@id": "http://example.org/svg1",
+      "id": "http://example.org/svg1",
       "@type": "SvgSelector"
     }
   }
@@ -1655,9 +1655,9 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <div class="tab_jsonld">
 <pre class="example highlight" title="SVG Selector, embedded (JSON-LD)">
 {
-  "@id": "http://example.org/anno20",
+  "id": "http://example.org/anno20",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/road1"},
+  "body": {"id": "http://example.org/road1"},
   "target": {
     "source": "http://example.org/map1",
     "selector": {
@@ -1723,13 +1723,13 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <div class="tab_jsonld">
 <pre class="example highlight" title="State (JSON-LD)">
 {
-  "@id": "http://example.org/anno21",
+  "id": "http://example.org/anno21",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/note1"},
+  "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/page1",
     "state": {
-      "@id": "http://example.org/state1"
+      "id": "http://example.org/state1"
     }
   }
 }
@@ -1786,9 +1786,9 @@ representation, appropriate for the Annotation.
 <div class="tab_jsonld">
 <pre class="example highlight" title="Time State (JSON-LD)">
 {
-  "@id": "http://example.org/anno22",
+  "id": "http://example.org/anno22",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/note1"},
+  "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/page1",
     "state": {
@@ -1852,9 +1852,9 @@ of the headers to be replayed when obtaining the representation. </p>
 <div class="tab_jsonld">
 <pre class="example highlight" title="HTTP Request State (JSON-LD)">
 {
-  "@id": "http://example.org/anno23",
+  "id": "http://example.org/anno23",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/description1"},
+  "body": {"id": "http://example.org/description1"},
   "target": {
     "source": "http://example.org/resource1",
     "state": {
@@ -1922,13 +1922,13 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <div class="tab_jsonld">
 <pre class="example highlight" title="CSS Style (JSON-LD)">
 {
-  "@id": "http://example.org/anno24",
+  "id": "http://example.org/anno24",
   "@type": "Annotation",
   "stylesheet": {
-    "@id": "http://example.org/style1",
+    "id": "http://example.org/style1",
     "@type": "CssStylesheet"
   },
-  "body": {"@id": "http://example.org/comment1"},
+  "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/document1",
     "styleClass": "red"
@@ -1967,14 +1967,14 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <div class="tab_jsonld">
 <pre class="example highlight" title="CSS Style, embedded (JSON-LD)">
 {
-  "@id": "http://example.org/anno25",
+  "id": "http://example.org/anno25",
   "@type": "Annotation",
   "stylesheet": {
     "@type": ["CssStylesheet", "EmbeddedContent"],
     "value": ".red { color: red }",
     "format": "text/css"
   },
-  "body": {"@id": "http://example.org/body1"},
+  "body": {"id": "http://example.org/body1"},
   "target": {
     "source": "http://example.org/target1",
     "styleClass": "red"
@@ -2031,9 +2031,9 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <div class="tab_jsonld">
 <pre class="example highlight" title="Scope (JSON-LD)">
 {
-  "@id": "http://example.org/anno26",
+  "id": "http://example.org/anno26",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/note1"},
+  "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/image1",
     "scope": "http://example.org/page1"
@@ -2084,7 +2084,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <div class="tab_jsonld">
 <pre class="example highlight" title="Annotations without a Body (JSON-LD)">
 {
-  "@id": "http://example.org/anno27",
+  "id": "http://example.org/anno27",
   "@type": "oa:Annotation",
   "target": "http://example.org/ebook1"
 }
@@ -2127,7 +2127,7 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div class="tab_jsonld">
 <pre class="example highlight" title="Multiple Bodies or Targets (JSON-LD)">
 {
-  "@id": "http://example.org/anno28",
+  "id": "http://example.org/anno28",
   "@type": "Annotation",
   "body": [
     { 
@@ -2207,17 +2207,17 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div class="tab_jsonld">
 <pre class="example hightlight" title="Choice (JSON-LD)">
 {
-  "@id": "http://example.org/anno29",
+  "id": "http://example.org/anno29",
   "@type": "Annotation",
   "body": {
     "@type": "Choice",
     "members": [
       { 
-        "@id": "http://example.org/note1",
+        "id": "http://example.org/note1",
         "language": "en"
       },
       {
-        "@id": "http://example.org/note2",
+        "id": "http://example.org/note2",
         "language": "fr"
       }
     ]
@@ -2274,9 +2274,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div class="tab_jsonld">
 <pre class="example highlight" title="Composite (JSON-LD)">
 {
-  "@id": "http://example.org/anno30",
+  "id": "http://example.org/anno30",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/comparison1"},
+  "body": {"id": "http://example.org/comparison1"},
   "target": {
     "@type": "Composite",
     "item": [
@@ -2330,9 +2330,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div class="tab_jsonld">
 <pre class="example highlight" title="List (JSON-LD)">
 {
-  "@id": "http://example.org/anno31",
+  "id": "http://example.org/anno31",
   "@type": "Annotation",
-  "body": {"@id": "http://example.org/comment1"},
+  "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/page1",
     "selector": {
@@ -2415,6 +2415,8 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
     "iana":    "http://www.iana.org/assignments/relation/",
     "owl":     "http://www.w3.org/2002/07/owl#",
     "as":      "http://www.w3.org/ns/activitystreams#",
+
+    "id":      "@id",
 
     "Annotation":           "oa:Annotation",
     "Dataset":              "dctypes:Dataset",
@@ -2524,25 +2526,25 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
 <div class="tab_jsonld">
 <pre class="example highlight" title="Complete Example (JSON-LD)">
 {
-  "@id": "http://example.org/anno32",
+  "id": "http://example.org/anno32",
   "@type": "Annotation",
   "motivation": "commenting",
   "creator": {
-    "@id": "http://example.org/user1",
+    "id": "http://example.org/user1",
     "@type": "Person",
     "name": "A. Person",
     "nick": "user1"
   },
   "created": "2015-10-13T13:00:00Z",
   "generator": {
-    "@id": "http://example.org/client1",
+    "id": "http://example.org/client1",
     "@type": "SoftwareAgent",
     "name": "Code v2.1",
     "homepage": "http://example.org/homepage1"
   },
   "generated": "2015-10-14T15:13:28Z",
   "stylesheet": {
-    "@id": "http://example.org/stylesheet1",
+    "id": "http://example.org/stylesheet1",
     "@type": "CssStylesheet"
   },
 
@@ -2567,12 +2569,12 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
           "@type": "SpecificResource", 
           "role": "describing",
           "source": {
-            "@id": "http://example.org/comment1",
+            "id": "http://example.org/comment1",
             "@type": "Audio",
             "format": "audio/mpeg",
             "language": "de",
             "creator": {
-              "@id": "http://example.org/user2",
+              "id": "http://example.org/user2",
               "@type": "Person"
             }
           }

--- a/model/wd/index-respec.html
+++ b/model/wd/index-respec.html
@@ -259,10 +259,10 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Annotation
 <br/>An Annotation SHOULD have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
   <br/>An Annotation MUST have at least the <code>Annotation</code> class, and MAY have other classes.</td></tr>
 <tr><td>Annotation</td><td>Class</td><td>oa:Annotation</td><td>The class for Web Annotations
-<br/>The <code>Annotation</code> class MUST be associated with an Annotation using <code>@type</code>.</td></tr>
+<br/>The <code>Annotation</code> class MUST be associated with an Annotation using <code>type</code>.</td></tr>
 <tr><td>body</td><td>Relationship<br/>Property</td><td>oa:hasBody</td><td>The relationship between an Annotation and its Body
 <br/>There SHOULD be 1 or more <code>body</code> relationships or properties associated with an Annotation but there MAY be 0.
 <div class="note">When the <code>body</code> is a relationship (it is a URI) it MUST be given as the value of an <code>id</code> property of an object in the JSON-LD serialization.</div>
@@ -284,7 +284,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <pre class="example highlight" title="Basic Annotation Model (JSON-LD)">
 {
   "id": "http://example.org/anno1",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/post1"},
   "target": "http://example.com/page1" 
 }
@@ -345,7 +345,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <pre class="example highlight" title="Creation Information (JSON-LD)">
 {
   "id": "http://example.org/anno2",
-  "@type": "Annotation",
+  "type": "Annotation",
   "creator": "http://example.org/user1",
   "created": "2015-01-28T12:00:00Z",
   "generator": "http://example.org/client1",
@@ -390,7 +390,7 @@ More information about the agents involved in the creation of an Annotation is n
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the agent
 <br/>An Agent SHOULD have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br/>An Agent SHOULD have at least 1 class, from those below.</td></tr>
 
 <tr><td>Person</td><td>Class</td><td>foaf:Person</td><td>The class for a human agent, typically used as the class of the <code>creator</code> of the Annotation</td></tr>
@@ -419,16 +419,16 @@ More information about the agents involved in the creation of an Annotation is n
 <pre class="example highlight" title="Creation Agents (JSON-LD)">
 {
   "id": "http://example.org/anno3",
-  "@type": "Annotation",
+  "type": "Annotation",
   "creator": {
     "id": "http://example.org/user1",
-    "@type": "Person",
+    "type": "Person",
     "name": "My Pseudonym",
     "nick": "pseudo"
   },
   "generator": {
     "id": "http://example.org/client1",
-    "@type": "SoftwareAgent",
+    "type": "SoftwareAgent",
     "name": "Code v2.1",
     "homepage": "http://example.org/client1/homepage1"
   },
@@ -515,7 +515,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <pre class="example highlight" title="Motivations (JSON-LD)">
 {
   "id": "http://example.org/anno4",
-  "@type": "oa:Annotation",
+  "type": "oa:Annotation",
   "motivation": "describing",
   "body": {"id": "http://example.org/description1"},
   "target": "http://example.com/resource1"
@@ -578,7 +578,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <pre class="example highlight" title="External Resources (JSON-LD)">
 {
   "id": "http://example.org/anno5",
-  "@type": "oa:Annotation",
+  "type": "oa:Annotation",
   "body": {
     "id": "http://example.org/analysis1.mp3",
     "format": "audio/mpeg",
@@ -644,10 +644,10 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <pre class="example highlight" title="Creation Information (JSON-LD)">
 {
   "id": "http://example.org/anno6",
-  "@type": "Annotation",
+  "type": "Annotation",
   "creator": {
     "id": "http://example.org/agent1",
-    "@type": "Person",
+    "type": "Person",
     "name": "A. Person",
     "nick": "agent1"
   },
@@ -655,7 +655,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
     "id": "http://example.org/walkthrough1",
     "creator": {
       "id": "http://example.org/user1",
-      "@type": "Person",
+      "type": "Person",
       "name": "B. Person",
       "nick": "agent2"
     }
@@ -664,7 +664,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
     "id": "http://example.com/game1",
     "creator": {
       "id": "http://example.com/company1",
-      "@type": "Organization",
+      "type": "Organization",
       "name": "Game Company"
     }
   }
@@ -716,7 +716,7 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 
 <table class="model">
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:class</td><td>The type of the Body resource.
+<tr><td>type</td><td>Relationship</td><td>rdf:class</td><td>The type of the Body resource.
   <br/>The Body MAY have a type, and if so, it SHOULD be drawn from the list below.</td></tr>
 <tr><td>Dataset</td><td>Class</td><td>dctypes:Dataset</td><td>The class for a resource which encodes data in a defined structure</td></tr>
 <tr><td>Image</td><td>Class</td><td>dctypes:StillImage</td><td>The class for image resources, primarily intended to be seen</td></tr>
@@ -737,14 +737,14 @@ The datetime MUST be expressed in the <a href="http://www.w3.org/TR/xmlschema-2/
 <pre class="example highlight" title="Typing of Body and Target (JSON-LD)">
 {
   "id": "http://example.org/anno7",
-  "@type":"Annotation",
+  "type":"Annotation",
   "body": {
     "id":"http://example.org/video1",
-    "@type":"Video"
+    "type":"Video"
   },
   "target": {
     "id": "http://example.org/site1",
-    "@type": "Text"
+    "type": "Text"
   }
 }
 </pre>
@@ -814,7 +814,7 @@ For more information regarding the use of Fragment URIs, please see the Best Pra
 <pre class="example highlight" title="Fragment URIs (JSON-LD)">
 {
   "id": "http://example.org/anno8",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
     "id": "http://example.org/description1"
   },
@@ -859,7 +859,7 @@ The fundamental features of a textual body are:
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the textual body
 <br/>The Body MAY have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br/>The Body MAY have the <code>TextualBody</code> class, and MAY have other classes.</td></tr>
 <tr><td>TextualBody</td><td>Class</td><td>oa:TextualBody</td><td>A class assigned to the Body for embedding textual resources within the Annotation.</td></tr>
 <tr><td>text</td><td>Property</td><td>oa:text</td><td>The character sequence of the content.<br/>
@@ -884,9 +884,9 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 <pre class="example highlight" title="Textual Body (JSON-LD)">
 {
   "id": "http://example.org/anno9",
-  "@type":"Annotation",
+  "type":"Annotation",
   "body": {
-    "@type" : "TextualBody",
+    "type" : "TextualBody",
     "text" : "&lt;p&gt;Comment text&lt;/p&gt;",
     "format" : "text/html",
     "language" : "en"
@@ -945,7 +945,7 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 <pre class="example highlight" title="Tagging (JSON-LD)">
 {
   "id": "http://example.org/anno10",
-  "@type":"Annotation",
+  "type":"Annotation",
   "motivation": "bookmarking",
   "body": {
     "text" : "readme",
@@ -1024,7 +1024,7 @@ An alternative that would allow clients to avoid type checking and make the mode
 <pre class="example highlight" title="String Body (JSON-LD)">
 {
 	"id": "http://example.org/anno11",
-	"@type":"oa:Annotation",
+	"type":"oa:Annotation",
 	"body": "Comment text",
 	"target": "http://example.org/target1"
 }
@@ -1084,7 +1084,7 @@ The diagrams and examples in this section only depict one of these, however the 
 <tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
 <br/>A Specific Resource MAY have exactly 1 http/https URI that identifies it, or MAY have no identity.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
   <br/>The Specific Resource MAY have the <code>SpecificResource</code>.</td></tr>
 <tr><td>SpecificResource</td><td>Class</td><td>oa:SpecificResource</td><td>The class for Specific Resources
 <br/>The <code>SpecificResource</code> class SHOULD be associated with a Specific Resource to be clear as to its role as a more specific region or state of another resource.</td></tr>
@@ -1107,11 +1107,11 @@ The diagrams and examples in this section only depict one of these, however the 
 <pre class="example highlight" title="Specific Resources (JSON)">
 {
   "id": "http://example.org/anno12",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/comment1"},
   "target": {
     "id": "http://example.org/region1",
-    "@type": "SpecificResource",
+    "type": "SpecificResource",
     "source": "http://example.org/image1"
   }
 }
@@ -1163,14 +1163,14 @@ The diagrams and examples in this section only depict one of these, however the 
 <pre class="example highlight" title="Resource with Role (JSON-LD)">
 {
   "id": "http://example.org/anno13",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
     "role": "tagging",
     "source": "http://example.org/city1"
   },
   "target": {
     "id": "http://example.org/photo1",
-    "@type": "Image"
+    "type": "Image"
   }
 }
 </pre>
@@ -1223,7 +1223,7 @@ The diagrams and examples in this section only depict one of these, however the 
 <pre class="example highlight" title="Selectors (JSON-LD)">
 {
   "id": "http://example.org/anno14",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
     "source": "http://example.org/page1",
     "selector": "http://example.org/paraselector1"
@@ -1308,13 +1308,13 @@ A Fragment URI may be reconstructed by concatenating the <code>source</code>, a 
 <pre class="example highlight" title="Fragment Selector (JSON-LD)">
 {
   "id": "http://example.org/anno15",
-  "@type": "Annotation",
+  "type": "Annotation",
   "target": {"id": "http://example.org/image1"},
   "body": {
     "source": "http://example.org/video1",
     "role": "describing",
     "selector": {
-      "@type": "FragmentSelector",
+      "type": "FragmentSelector",
       "conformsTo": "http://www.w3.org/TR/media-frags/",
       "value": "t=30,60"
     }
@@ -1392,12 +1392,12 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 <pre class="example highlight" title="Text Quote Selector (JSON-LD)">
 {
   "id": "http://example.org/anno16",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/page1",
     "selector": {
-      "@type": "TextQuoteSelector",
+      "type": "TextQuoteSelector",
       "exact": "anotation",
       "prefix": "this is an ",
       "suffix": " that has some"
@@ -1471,12 +1471,12 @@ The use of this Selector does not require text to be copied from the Source docu
 <pre class="example highlight" title="Text Position Selector (JSON-LD)">
 {
   "id": "http://example.org/anno17",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/review1"},
   "target": {
     "source": "http://example.org/ebook1",
     "selector": {
-      "@type": "TextPositionSelector",
+      "type": "TextPositionSelector",
       "start": 412,
       "end": 795
     }
@@ -1540,12 +1540,12 @@ Similar to the Text Position Selector, the Data Position Selector uses the same 
 <pre class="example highlight" title="Data Position Selector (JSON-LD)">
 {
   "id": "http://example.org/anno18",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/diskimg1",
     "selector": {
-      "@type": "oa:DataPositionSelector",
+      "type": "oa:DataPositionSelector",
       "start": 4096,
       "end": 4104
     }
@@ -1615,13 +1615,13 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <pre class="example highlight" title="SVG Selector (JSON-LD)">
 {
   "id": "http://example.org/anno19",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/road1"},
   "target": {
     "source": "http://example.org/map1",
     "selector": {
       "id": "http://example.org/svg1",
-      "@type": "SvgSelector"
+      "type": "SvgSelector"
     }
   }
 }
@@ -1656,12 +1656,12 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <pre class="example highlight" title="SVG Selector, embedded (JSON-LD)">
 {
   "id": "http://example.org/anno20",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/road1"},
   "target": {
     "source": "http://example.org/map1",
     "selector": {
-      "@type": ["SvgSelector", "EmbeddedContent"],
+      "type": ["SvgSelector", "EmbeddedContent"],
       "text": "&lt;svg:svg&gt; ... &lt;/svg:svg&gt;",
       "format": "image/svg+xml"
     }
@@ -1724,7 +1724,7 @@ There MAY be exactly 1 <code>text</code> property associated with the Selector, 
 <pre class="example highlight" title="State (JSON-LD)">
 {
   "id": "http://example.org/anno21",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/page1",
@@ -1787,12 +1787,12 @@ representation, appropriate for the Annotation.
 <pre class="example highlight" title="Time State (JSON-LD)">
 {
   "id": "http://example.org/anno22",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/page1",
     "state": {
-      "@type": "TimeState",
+      "type": "TimeState",
       "cached": "http://archive.example.org/copy1",
       "sourceDate": "2015-07-20T13:30:00Z"
     }
@@ -1853,12 +1853,12 @@ of the headers to be replayed when obtaining the representation. </p>
 <pre class="example highlight" title="HTTP Request State (JSON-LD)">
 {
   "id": "http://example.org/anno23",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/description1"},
   "target": {
     "source": "http://example.org/resource1",
     "state": {
-      "@type": "HttpRequestState",
+      "type": "HttpRequestState",
       "value": "Accept: application/pdf"
     }
   }
@@ -1923,10 +1923,10 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="CSS Style (JSON-LD)">
 {
   "id": "http://example.org/anno24",
-  "@type": "Annotation",
+  "type": "Annotation",
   "stylesheet": {
     "id": "http://example.org/style1",
-    "@type": "CssStylesheet"
+    "type": "CssStylesheet"
   },
   "body": {"id": "http://example.org/comment1"},
   "target": {
@@ -1968,9 +1968,9 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="CSS Style, embedded (JSON-LD)">
 {
   "id": "http://example.org/anno25",
-  "@type": "Annotation",
+  "type": "Annotation",
   "stylesheet": {
-    "@type": ["CssStylesheet", "EmbeddedContent"],
+    "type": ["CssStylesheet", "EmbeddedContent"],
     "value": ".red { color: red }",
     "format": "text/css"
   },
@@ -2032,7 +2032,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="Scope (JSON-LD)">
 {
   "id": "http://example.org/anno26",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/note1"},
   "target": {
     "source": "http://example.org/image1",
@@ -2085,7 +2085,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="Annotations without a Body (JSON-LD)">
 {
   "id": "http://example.org/anno27",
-  "@type": "oa:Annotation",
+  "type": "oa:Annotation",
   "target": "http://example.org/ebook1"
 }
 </pre>
@@ -2128,7 +2128,7 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <pre class="example highlight" title="Multiple Bodies or Targets (JSON-LD)">
 {
   "id": "http://example.org/anno28",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": [
     { 
       "role": "describing",
@@ -2208,9 +2208,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <pre class="example hightlight" title="Choice (JSON-LD)">
 {
   "id": "http://example.org/anno29",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
-    "@type": "Choice",
+    "type": "Choice",
     "members": [
       { 
         "id": "http://example.org/note1",
@@ -2275,10 +2275,10 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <pre class="example highlight" title="Composite (JSON-LD)">
 {
   "id": "http://example.org/anno30",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/comparison1"},
   "target": {
-    "@type": "Composite",
+    "type": "Composite",
     "item": [
       "http://example.org/comic1",
       "http://example.org/comic2"
@@ -2331,12 +2331,12 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <pre class="example highlight" title="List (JSON-LD)">
 {
   "id": "http://example.org/anno31",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {"id": "http://example.org/comment1"},
   "target": {
     "source": "http://example.org/page1",
     "selector": {
-      "@type": "List",
+      "type": "List",
       "members": [
         "http://example.org/paraselector1",
         "http://example.org/offsetselector1"
@@ -2417,6 +2417,7 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
     "as":      "http://www.w3.org/ns/activitystreams#",
 
     "id":      "@id",
+    "type":    "@type",
 
     "Annotation":           "oa:Annotation",
     "Dataset":              "dctypes:Dataset",
@@ -2527,38 +2528,38 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
 <pre class="example highlight" title="Complete Example (JSON-LD)">
 {
   "id": "http://example.org/anno32",
-  "@type": "Annotation",
+  "type": "Annotation",
   "motivation": "commenting",
   "creator": {
     "id": "http://example.org/user1",
-    "@type": "Person",
+    "type": "Person",
     "name": "A. Person",
     "nick": "user1"
   },
   "created": "2015-10-13T13:00:00Z",
   "generator": {
     "id": "http://example.org/client1",
-    "@type": "SoftwareAgent",
+    "type": "SoftwareAgent",
     "name": "Code v2.1",
     "homepage": "http://example.org/homepage1"
   },
   "generated": "2015-10-14T15:13:28Z",
   "stylesheet": {
     "id": "http://example.org/stylesheet1",
-    "@type": "CssStylesheet"
+    "type": "CssStylesheet"
   },
 
   "body": [
     {
-      "@type": "TextualBody",
+      "type": "TextualBody",
       "role": "tagging",
       "text": "love"
     },
     {
-      "@type": "Choice",
+      "type": "Choice",
       "members": [
         {
-          "@type": "TextualBody",
+          "type": "TextualBody",
           "role": "describing",
           "text": "I really love this particular bit of text in this XML. No really.",
           "format": "text/plain",
@@ -2566,16 +2567,16 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
           "creator": "http://example.org/user1"
         },
         {
-          "@type": "SpecificResource", 
+          "type": "SpecificResource", 
           "role": "describing",
           "source": {
             "id": "http://example.org/comment1",
-            "@type": "Audio",
+            "type": "Audio",
             "format": "audio/mpeg",
             "language": "de",
             "creator": {
               "id": "http://example.org/user2",
-              "@type": "Person"
+              "type": "Person"
             }
           }
         }
@@ -2583,28 +2584,28 @@ The RECOMMENDED serialization format is [[JSON-LD]]. The JSON-LD context present
     }
   ],
   "target": {
-    "@type": "SpecificResource",
+    "type": "SpecificResource",
     "styleClass": "mystyle",
     "source": "http://example.com/document1",
     "state": [
       {
-        "@type": "HttpRequestState",
+        "type": "HttpRequestState",
         "value": "Accept: application/xml"
       },
       {
-        "@type": "TimeState",
+        "type": "TimeState",
         "sourceDate": "2015-09-25T12:00:00Z"
       }
     ],
     "selector": {
-      "@type": "List",
+      "type": "List",
       "members": [
         {
-          "@type": "FragmentSelector",
+          "type": "FragmentSelector",
           "value": "xpointer(/doc/body/section[2]/para[1])"
         },
         {
-          "@type": "TextPositionSelector",
+          "type": "TextPositionSelector",
           "start": 6,
           "end": 27
         }

--- a/model/wd/index.html
+++ b/model/wd/index.html
@@ -651,10 +651,10 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Annotation
 <br>An Annotation <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
   <br>An Annotation <em title="MUST" class="rfc2119">MUST</em> have at least the <code>Annotation</code> class, and <em title="MAY" class="rfc2119">MAY</em> have other classes.</td></tr>
 <tr><td>Annotation</td><td>Class</td><td>oa:Annotation</td><td>The class for Web Annotations
-<br>The <code>Annotation</code> class <em title="MUST" class="rfc2119">MUST</em> be associated with an Annotation using <code>@type</code>.</td></tr>
+<br>The <code>Annotation</code> class <em title="MUST" class="rfc2119">MUST</em> be associated with an Annotation using <code>type</code>.</td></tr>
 <tr><td>body</td><td>Relationship<br>Property</td><td>oa:hasBody</td><td>The relationship between an Annotation and its Body
 <br>There <em title="SHOULD" class="rfc2119">SHOULD</em> be 1 or more <code>body</code> relationships or properties associated with an Annotation but there <em title="MAY" class="rfc2119">MAY</em> be 0.
 <div class="note"><div id="h-note1" role="heading" aria-level="4" class="note-title"><span>Note</span></div><div class="">When the <code>body</code> is a relationship (it is a URI) it <em title="MUST" class="rfc2119">MUST</em> be given as the value of an <code>id</code> property of an object in the JSON-LD serialization.</div></div>
@@ -675,7 +675,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 1</span>: Basic Annotation Model (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/post1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/page1"</span><span class="pln"> 
 </span><span class="pun">}</span></pre></div>
@@ -733,7 +733,7 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 3</span>: Creation Information (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno2"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-01-28T12:00:00Z"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
@@ -776,7 +776,7 @@ More information about the agents involved in the creation of an Annotation is n
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the agent
 <br>An Agent <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br>An Agent <em title="SHOULD" class="rfc2119">SHOULD</em> have at least 1 class, from those below.</td></tr>
 
 <tr><td>Person</td><td>Class</td><td>foaf:Person</td><td>The class for a human agent, typically used as the class of the <code>creator</code> of the Annotation</td></tr>
@@ -804,16 +804,16 @@ More information about the agents involved in the creation of an Annotation is n
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 5</span>: Creation Agents (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno3"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"My Pseudonym"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"pseudo"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SoftwareAgent"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SoftwareAgent"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Code v2.1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"homepage"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1/homepage1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
@@ -897,7 +897,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 7</span>: Motivations (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno4"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/resource1"</span><span class="pln">
@@ -957,7 +957,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 9</span>: External Resources (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno5"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/analysis1.mp3"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"audio/mpeg"</span><span class="pun">,</span><span class="pln">
@@ -1019,10 +1019,10 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 11</span>: Creation Information (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno6"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/agent1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"A. Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"agent1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
@@ -1030,7 +1030,7 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/walkthrough1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
       </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"B. Person"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"agent2"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
@@ -1039,7 +1039,7 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/game1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
       </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/company1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Organization"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Organization"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Game Company"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
@@ -1088,7 +1088,7 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
 
 <table class="model">
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:class</td><td>The type of the Body resource.
+<tr><td>type</td><td>Relationship</td><td>rdf:class</td><td>The type of the Body resource.
   <br>The Body <em title="MAY" class="rfc2119">MAY</em> have a type, and if so, it <em title="SHOULD" class="rfc2119">SHOULD</em> be drawn from the list below.</td></tr>
 <tr><td>Dataset</td><td>Class</td><td>dctypes:Dataset</td><td>The class for a resource which encodes data in a defined structure</td></tr>
 <tr><td>Image</td><td>Class</td><td>dctypes:StillImage</td><td>The class for image resources, primarily intended to be seen</td></tr>
@@ -1108,14 +1108,14 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 13</span>: Typing of Body and Target (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno7"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="str">"http://example.org/video1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"Video"</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="str">"Video"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/site1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Text"</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Text"</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
 </div>
@@ -1182,7 +1182,7 @@ For more information regarding the use of Fragment URIs, please see the Best Pra
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 15</span>: Fragment URIs (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno8"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
@@ -1224,7 +1224,7 @@ The fundamental features of a textual body are:
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the textual body
 <br>The Body <em title="MAY" class="rfc2119">MAY</em> have exactly 1 http/https URI that identifies it.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br>The Body <em title="MAY" class="rfc2119">MAY</em> have the <code>TextualBody</code> class, and <em title="MAY" class="rfc2119">MAY</em> have other classes.</td></tr>
 <tr><td>TextualBody</td><td>Class</td><td>oa:TextualBody</td><td>A class assigned to the Body for embedding textual resources within the Annotation.</td></tr>
 <tr><td>text</td><td>Property</td><td>oa:text</td><td>The character sequence of the content.<br>
@@ -1248,9 +1248,9 @@ There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>text</code> 
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 17</span>: Textual Body (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno9"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"text"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"&lt;p&gt;Comment text&lt;/p&gt;"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"format"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"text/html"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"language"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"en"</span><span class="pln">
@@ -1305,7 +1305,7 @@ There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>text</code> 
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 19</span>: Tagging (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno10"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"bookmarking"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"text"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"readme"</span><span class="pun">,</span><span class="pln">
@@ -1380,7 +1380,7 @@ An alternative that would allow clients to avoid type checking and make the mode
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 21</span>: String Body (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
 	</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno11"</span><span class="pun">,</span><span class="pln">
-	</span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
+	</span><span class="str">"type"</span><span class="pun">:</span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
 	</span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Comment text"</span><span class="pun">,</span><span class="pln">
 	</span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/target1"</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
@@ -1438,7 +1438,7 @@ The diagrams and examples in this section only depict one of these, however the 
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
 <tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
 <br>A Specific Resource <em title="MAY" class="rfc2119">MAY</em> have exactly 1 http/https URI that identifies it, or <em title="MAY" class="rfc2119">MAY</em> have no identity.</td></tr>
-<tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
+<tr><td>type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
   <br>The Specific Resource <em title="MAY" class="rfc2119">MAY</em> have the <code>SpecificResource</code>.</td></tr>
 <tr><td>SpecificResource</td><td>Class</td><td>oa:SpecificResource</td><td>The class for Specific Resources
 <br>The <code>SpecificResource</code> class <em title="SHOULD" class="rfc2119">SHOULD</em> be associated with a Specific Resource to be clear as to its role as a more specific region or state of another resource.</td></tr>
@@ -1460,11 +1460,11 @@ The diagrams and examples in this section only depict one of these, however the 
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 23</span>: Specific Resources (JSON)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno12"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/region1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
@@ -1513,14 +1513,14 @@ The diagrams and examples in this section only depict one of these, however the 
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 25</span>: Resource with Role (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno13"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"tagging"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/city1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/photo1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Image"</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Image"</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
 </div>
@@ -1570,7 +1570,7 @@ The diagrams and examples in this section only depict one of these, however the 
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 27</span>: Selectors (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno14"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/paraselector1"</span><span class="pln">
@@ -1651,13 +1651,13 @@ A Fragment URI may be reconstructed by concatenating the <code>source</code>, a 
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 29</span>: Fragment Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno15"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/video1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"FragmentSelector"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"FragmentSelector"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"conformsTo"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/TR/media-frags/"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"t=30,60"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
@@ -1731,12 +1731,12 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 31</span>: Text Quote Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno16"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextQuoteSelector"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextQuoteSelector"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"exact"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"anotation"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"prefix"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"this is an "</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"suffix"</span><span class="pun">:</span><span class="pln"> </span><span class="str">" that has some"</span><span class="pln">
@@ -1806,12 +1806,12 @@ The use of this Selector does not require text to be copied from the Source docu
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 33</span>: Text Position Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno17"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/review1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/ebook1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextPositionSelector"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextPositionSelector"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"start"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">412</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"end"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">795</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
@@ -1871,12 +1871,12 @@ Similar to the Text Position Selector, the Data Position Selector uses the same 
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 35</span>: Data Position Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno18"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/diskimg1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:DataPositionSelector"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:DataPositionSelector"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"start"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">4096</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"end"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">4104</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
@@ -1942,13 +1942,13 @@ There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>text</code> pr
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 37</span>: SVG Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno19"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/road1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/map1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
       </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/svg1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SvgSelector"</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SvgSelector"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
@@ -1980,12 +1980,12 @@ There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>text</code> pr
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 39</span>: SVG Selector, embedded (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno20"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/road1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/map1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="str">"SvgSelector"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"EmbeddedContent"</span><span class="pun">],</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="str">"SvgSelector"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"EmbeddedContent"</span><span class="pun">],</span><span class="pln">
       </span><span class="str">"text"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"&lt;svg:svg&gt; ... &lt;/svg:svg&gt;"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"image/svg+xml"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
@@ -2044,7 +2044,7 @@ There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>text</code> pr
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 41</span>: State (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno21"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
@@ -2103,12 +2103,12 @@ representation, appropriate for the Annotation.
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 43</span>: Time State (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno22"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TimeState"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TimeState"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"cached"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://archive.example.org/copy1"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"sourceDate"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-07-20T13:30:00Z"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
@@ -2166,12 +2166,12 @@ of the headers to be replayed when obtaining the representation. </p>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 45</span>: HTTP Request State (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno23"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/resource1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"HttpRequestState"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"HttpRequestState"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Accept: application/pdf"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
@@ -2232,10 +2232,10 @@ There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</co
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 47</span>: CSS Style (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno24"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/style1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssStylesheet"</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssStylesheet"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -2273,9 +2273,9 @@ There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</co
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 49</span>: CSS Style, embedded (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno25"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="str">"CssStylesheet"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"EmbeddedContent"</span><span class="pun">],</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="str">"CssStylesheet"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"EmbeddedContent"</span><span class="pun">],</span><span class="pln">
     </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">".red { color: red }"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"text/css"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
@@ -2333,7 +2333,7 @@ There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</co
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 51</span>: Scope (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno26"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pun">,</span><span class="pln">
@@ -2383,7 +2383,7 @@ There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</co
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 53</span>: Annotations without a Body (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno27"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/ebook1"</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
 </div>
@@ -2423,7 +2423,7 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 55</span>: Multiple Bodies or Targets (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno28"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
     </span><span class="pun">{</span><span class="pln"> 
       </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
@@ -2499,9 +2499,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 57</span>: Choice (JSON-LD)</div><pre class="example hightlight">{
   "id": "http://example.org/anno29",
-  "@type": "Annotation",
+  "type": "Annotation",
   "body": {
-    "@type": "Choice",
+    "type": "Choice",
     "members": [
       { 
         "id": "http://example.org/note1",
@@ -2562,10 +2562,10 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 59</span>: Composite (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno30"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comparison1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Composite"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Composite"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"item"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
       </span><span class="str">"http://example.org/comic1"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"http://example.org/comic2"</span><span class="pln">
@@ -2615,12 +2615,12 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 61</span>: List (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno31"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"List"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"List"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"members"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
         </span><span class="str">"http://example.org/paraselector1"</span><span class="pun">,</span><span class="pln">
         </span><span class="str">"http://example.org/offsetselector1"</span><span class="pln">
@@ -2697,6 +2697,7 @@ The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization forma
     </span><span class="str">"as"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"http://www.w3.org/ns/activitystreams#"</span><span class="pun">,</span><span class="pln">
 
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"@type"</span><span class="pun">,</span><span class="pln">
 
     </span><span class="str">"Annotation"</span><span class="pun">:</span><span class="pln">           </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"Dataset"</span><span class="pun">:</span><span class="pln">              </span><span class="str">"dctypes:Dataset"</span><span class="pun">,</span><span class="pln">
@@ -2805,38 +2806,38 @@ The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization forma
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 63</span>: Complete Example (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno32"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"commenting"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"A. Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"user1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-10-13T13:00:00Z"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SoftwareAgent"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SoftwareAgent"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Code v2.1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"homepage"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/homepage1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"generated"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-10-14T15:13:28Z"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/stylesheet1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssStylesheet"</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssStylesheet"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
 
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
     </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"tagging"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"text"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"love"</span><span class="pln">
     </span><span class="pun">},</span><span class="pln">
     </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Choice"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Choice"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"members"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
         </span><span class="pun">{</span><span class="pln">
-          </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
+          </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
           </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
           </span><span class="str">"text"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I really love this particular bit of text in this XML. No really."</span><span class="pun">,</span><span class="pln">
           </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"text/plain"</span><span class="pun">,</span><span class="pln">
@@ -2844,16 +2845,16 @@ The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization forma
           </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pln">
         </span><span class="pun">},</span><span class="pln">
         </span><span class="pun">{</span><span class="pln">
-          </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln"> 
+          </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln"> 
           </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
           </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
             </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
-            </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Audio"</span><span class="pun">,</span><span class="pln">
+            </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Audio"</span><span class="pun">,</span><span class="pln">
             </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"audio/mpeg"</span><span class="pun">,</span><span class="pln">
             </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"de"</span><span class="pun">,</span><span class="pln">
             </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
               </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user2"</span><span class="pun">,</span><span class="pln">
-              </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pln">
+              </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pln">
             </span><span class="pun">}</span><span class="pln">
           </span><span class="pun">}</span><span class="pln">
         </span><span class="pun">}</span><span class="pln">
@@ -2861,28 +2862,28 @@ The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization forma
     </span><span class="pun">}</span><span class="pln">
   </span><span class="pun">],</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"styleClass"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"mystyle"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/document1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
       </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"HttpRequestState"</span><span class="pun">,</span><span class="pln">
+        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"HttpRequestState"</span><span class="pun">,</span><span class="pln">
         </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Accept: application/xml"</span><span class="pln">
       </span><span class="pun">},</span><span class="pln">
       </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TimeState"</span><span class="pun">,</span><span class="pln">
+        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TimeState"</span><span class="pun">,</span><span class="pln">
         </span><span class="str">"sourceDate"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-09-25T12:00:00Z"</span><span class="pln">
       </span><span class="pun">}</span><span class="pln">
     </span><span class="pun">],</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"List"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"List"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"members"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
         </span><span class="pun">{</span><span class="pln">
-          </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"FragmentSelector"</span><span class="pun">,</span><span class="pln">
+          </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"FragmentSelector"</span><span class="pun">,</span><span class="pln">
           </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xpointer(/doc/body/section[2]/para[1])"</span><span class="pln">
         </span><span class="pun">},</span><span class="pln">
         </span><span class="pun">{</span><span class="pln">
-          </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextPositionSelector"</span><span class="pun">,</span><span class="pln">
+          </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextPositionSelector"</span><span class="pun">,</span><span class="pln">
           </span><span class="str">"start"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">6</span><span class="pun">,</span><span class="pln">
           </span><span class="str">"end"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">27</span><span class="pln">
         </span><span class="pun">}</span><span class="pln">

--- a/model/wd/index.html
+++ b/model/wd/index.html
@@ -649,7 +649,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 
 <table class="model">
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the Annotation
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Annotation
 <br>An Annotation <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The relationship between the Annotation and its class.
   <br>An Annotation <em title="MUST" class="rfc2119">MUST</em> have at least the <code>Annotation</code> class, and <em title="MAY" class="rfc2119">MAY</em> have other classes.</td></tr>
@@ -657,7 +657,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <br>The <code>Annotation</code> class <em title="MUST" class="rfc2119">MUST</em> be associated with an Annotation using <code>@type</code>.</td></tr>
 <tr><td>body</td><td>Relationship<br>Property</td><td>oa:hasBody</td><td>The relationship between an Annotation and its Body
 <br>There <em title="SHOULD" class="rfc2119">SHOULD</em> be 1 or more <code>body</code> relationships or properties associated with an Annotation but there <em title="MAY" class="rfc2119">MAY</em> be 0.
-<div class="note"><div id="h-note1" role="heading" aria-level="4" class="note-title"><span>Note</span></div><div class="">When the <code>body</code> is a relationship (it is a URI) it <em title="MUST" class="rfc2119">MUST</em> be given as the value of an <code>@id</code> property of an object in the JSON-LD serialization.</div></div>
+<div class="note"><div id="h-note1" role="heading" aria-level="4" class="note-title"><span>Note</span></div><div class="">When the <code>body</code> is a relationship (it is a URI) it <em title="MUST" class="rfc2119">MUST</em> be given as the value of an <code>id</code> property of an object in the JSON-LD serialization.</div></div>
 </td></tr>
 <tr><td>target</td><td>Relationship</td><td>oa:hasTarget</td><td>The relationship between an Annotation and its Target
 <br>There <em title="MUST" class="rfc2119">MUST</em> be 1 or more <code>target</code> relationships associated with an Annotation.
@@ -674,9 +674,9 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 1</span>: Basic Annotation Model (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno1"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno1"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/post1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/post1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/page1"</span><span class="pln"> 
 </span><span class="pun">}</span></pre></div>
 </div>
@@ -732,13 +732,13 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 3</span>: Creation Information (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno2"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno2"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-01-28T12:00:00Z"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"generated"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-02-04T12:00:00Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/review1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/review1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/restaurant1"</span><span class="pln">
 </span><span class="pun">}</span></pre></div>  
 </div>
@@ -774,7 +774,7 @@ More information about the agents involved in the creation of an Annotation is n
 
 <table class="model">
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the agent
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the agent
 <br>An Agent <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br>An Agent <em title="SHOULD" class="rfc2119">SHOULD</em> have at least 1 class, from those below.</td></tr>
@@ -803,21 +803,21 @@ More information about the agents involved in the creation of an Annotation is n
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 5</span>: Creation Agents (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno3"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno3"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"My Pseudonym"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"pseudo"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SoftwareAgent"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Code v2.1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"homepage"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1/homepage1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/review1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/review1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/restaurant1"</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
 </div>
@@ -896,10 +896,10 @@ For more information about how Motivations can be inter-related and new Motivati
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 7</span>: Motivations (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno4"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno4"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/resource1"</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
 </div>
@@ -936,8 +936,8 @@ For more information about how Motivations can be inter-related and new Motivati
 <h4 id="model-4">Model</h4>
 
 <table class="model">
-  <tbody><tr><td>@id</td><td>Property</td><td> - </td><td>The URI that identifies the Body or Target resource.
-<br>External Bodies or Targets <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>@id</code> with the value of the resource's URI.
+  <tbody><tr><td>id</td><td>Property</td><td> - </td><td>The URI that identifies the Body or Target resource.
+<br>External Bodies or Targets <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>id</code> with the value of the resource's URI.
   </td></tr>
   <tr><td>language</td><td>Property</td><td>dc:language</td><td>The language of the textual body's content
   <br>The Body or Target <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 language associated with it, but <em title="MAY" class="rfc2119">MAY</em> have 0 or more.  The value of the property <em title="SHOULD" class="rfc2119">SHOULD</em> be a language code following the [<cite><a href="#bib-rfc5646" class="bibref">rfc5646</a></cite>] specifiction.</td></tr>
@@ -956,15 +956,15 @@ For more information about how Motivations can be inter-related and new Motivati
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 9</span>: External Resources (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno5"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno5"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/analysis1.mp3"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/analysis1.mp3"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"audio/mpeg"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"fr"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.gov/patent1.pdf"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.gov/patent1.pdf"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"application/pdf"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"en"</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
@@ -1018,27 +1018,27 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 11</span>: Creation Information (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno6"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno6"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/agent1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/agent1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"A. Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"agent1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/walkthrough1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/walkthrough1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"B. Person"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"agent2"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/game1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/game1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/company1"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/company1"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Organization"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Game Company"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
@@ -1107,14 +1107,14 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 13</span>: Typing of Body and Target (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno7"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno7"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="str">"http://example.org/video1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="str">"http://example.org/video1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"Video"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/site1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/site1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Text"</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
@@ -1148,8 +1148,8 @@ The datetime <em title="MUST" class="rfc2119">MUST</em> be expressed in the <a h
 
 <table class="model">
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
-  <tr><td>@id</td><td>Property</td><td> - </td><td>The Fragment URI that identifies the segment of the Body or Target resource.
-<br>External Bodies or Targets <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>@id</code> with the value of the resource's URI, and this <em title="MAY" class="rfc2119">MAY</em> be a Fragment URI.
+  <tr><td>id</td><td>Property</td><td> - </td><td>The Fragment URI that identifies the segment of the Body or Target resource.
+<br>External Bodies or Targets <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>id</code> with the value of the resource's URI, and this <em title="MAY" class="rfc2119">MAY</em> be a Fragment URI.
   </td></tr>
 </tbody></table>
 
@@ -1181,13 +1181,13 @@ For more information regarding the use of Fragment URIs, please see the Best Pra
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 15</span>: Fragment URIs (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno8"</span><span class="pun">,</span><span class="pln">  
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno8"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/image1#xywh=100,100,300,300"</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/image1#xywh=100,100,300,300"</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
 </div>
@@ -1222,7 +1222,7 @@ The fundamental features of a textual body are:
 
 <table class="model">
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>  
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the textual body
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the textual body
 <br>The Body <em title="MAY" class="rfc2119">MAY</em> have exactly 1 http/https URI that identifies it.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Body
   <br>The Body <em title="MAY" class="rfc2119">MAY</em> have the <code>TextualBody</code> class, and <em title="MAY" class="rfc2119">MAY</em> have other classes.</td></tr>
@@ -1247,7 +1247,7 @@ There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>text</code> 
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 17</span>: Textual Body (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno9"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno9"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
@@ -1304,7 +1304,7 @@ There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>text</code> 
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 19</span>: Tagging (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno10"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno10"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"bookmarking"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -1356,7 +1356,7 @@ There are several restrictions on when this form may be used and how it is to be
 </ul>
 <p></p>
 
-<div class="note"><div id="h-note3" role="heading" aria-level="6" class="note-title"><span>Note</span></div><p class="">In order for the <code>body</code> value to be a URI, it <em title="MUST" class="rfc2119">MUST</em> be in the <code>{"@id": "URI"}</code> form, otherwise it will be considered a string literal.  However, as <code>target</code> <em title="MUST NOT" class="rfc2119">MUST NOT</em> be a string literal, it <em title="MAY" class="rfc2119">MAY</em> be given as either a string or in the JSON object form.</p></div>
+<div class="note"><div id="h-note3" role="heading" aria-level="6" class="note-title"><span>Note</span></div><p class="">In order for the <code>body</code> value to be a URI, it <em title="MUST" class="rfc2119">MUST</em> be in the <code>{"id": "URI"}</code> form, otherwise it will be considered a string literal.  However, as <code>target</code> <em title="MUST NOT" class="rfc2119">MUST NOT</em> be a string literal, it <em title="MAY" class="rfc2119">MAY</em> be given as either a string or in the JSON object form.</p></div>
 
 <div id="issue-1" class="issue"><div id="h-issue1" role="heading" aria-level="6" class="issue-title"><span>Issue 1</span></div><div class="">
 An alternative that would allow clients to avoid type checking and make the model more coherent under consideration is to use a separate property, <code>bodyText</code>, to record the text of the body.
@@ -1379,7 +1379,7 @@ An alternative that would allow clients to avoid type checking and make the mode
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 21</span>: String Body (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-	</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno11"</span><span class="pun">,</span><span class="pln">
+	</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno11"</span><span class="pun">,</span><span class="pln">
 	</span><span class="str">"@type"</span><span class="pun">:</span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
 	</span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Comment text"</span><span class="pun">,</span><span class="pln">
 	</span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/target1"</span><span class="pln">
@@ -1436,7 +1436,7 @@ The diagrams and examples in this section only depict one of these, however the 
 
 <table class="model">
 <tbody><tr><th>Term</th><th>Type</th><th>URI</th><th>Description</th></tr>
-<tr><td>@id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
+<tr><td>id</td><td>Property</td><td> - </td><td>The identity of the Specific Resource
 <br>A Specific Resource <em title="MAY" class="rfc2119">MAY</em> have exactly 1 http/https URI that identifies it, or <em title="MAY" class="rfc2119">MAY</em> have no identity.</td></tr>
 <tr><td>@type</td><td>Relationship</td><td>rdf:type</td><td>The class of the Specific Resource
   <br>The Specific Resource <em title="MAY" class="rfc2119">MAY</em> have the <code>SpecificResource</code>.</td></tr>
@@ -1459,11 +1459,11 @@ The diagrams and examples in this section only depict one of these, however the 
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 23</span>: Specific Resources (JSON)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno12"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno12"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/region1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/region1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
@@ -1512,14 +1512,14 @@ The diagrams and examples in this section only depict one of these, however the 
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 25</span>: Resource with Role (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno13"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno13"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"tagging"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/city1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/photo1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/photo1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Image"</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
@@ -1569,7 +1569,7 @@ The diagrams and examples in this section only depict one of these, however the 
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 27</span>: Selectors (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno14"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno14"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
@@ -1650,9 +1650,9 @@ A Fragment URI may be reconstructed by concatenating the <code>source</code>, a 
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 29</span>: Fragment Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno15"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno15"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/video1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
@@ -1730,9 +1730,9 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 31</span>: Text Quote Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno16"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno16"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -1805,9 +1805,9 @@ The use of this Selector does not require text to be copied from the Source docu
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 33</span>: Text Position Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno17"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno17"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/review1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/review1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/ebook1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -1870,9 +1870,9 @@ Similar to the Text Position Selector, the Data Position Selector uses the same 
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 35</span>: Data Position Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno18"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno18"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/diskimg1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -1941,13 +1941,13 @@ There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>text</code> pr
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 37</span>: SVG Selector (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno19"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno19"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/road1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/road1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/map1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/svg1"</span><span class="pun">,</span><span class="pln">
+      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/svg1"</span><span class="pun">,</span><span class="pln">
       </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SvgSelector"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
@@ -1979,9 +1979,9 @@ There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>text</code> pr
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 39</span>: SVG Selector, embedded (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno20"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno20"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/road1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/road1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/map1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -2043,13 +2043,13 @@ There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>text</code> pr
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 41</span>: State (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno21"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno21"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/state1"</span><span class="pln">
+      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/state1"</span><span class="pln">
     </span><span class="pun">}</span><span class="pln">
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
@@ -2102,9 +2102,9 @@ representation, appropriate for the Annotation.
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 43</span>: Time State (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno22"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno22"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -2165,9 +2165,9 @@ of the headers to be replayed when obtaining the representation. </p>
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 45</span>: HTTP Request State (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno23"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno23"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/resource1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -2231,13 +2231,13 @@ There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</co
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 47</span>: CSS Style (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno24"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno24"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/style1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/style1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssStylesheet"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/document1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"styleClass"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"red"</span><span class="pln">
@@ -2272,14 +2272,14 @@ There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</co
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 49</span>: CSS Style, embedded (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno25"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno25"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="str">"CssStylesheet"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"EmbeddedContent"</span><span class="pun">],</span><span class="pln">
     </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">".red { color: red }"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"text/css"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/body1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/body1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/target1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"styleClass"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"red"</span><span class="pln">
@@ -2332,9 +2332,9 @@ There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</co
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 51</span>: Scope (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno26"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno26"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"scope"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pln">
@@ -2382,7 +2382,7 @@ There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</co
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 53</span>: Annotations without a Body (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno27"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno27"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/ebook1"</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
@@ -2422,7 +2422,7 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 55</span>: Multiple Bodies or Targets (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno28"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno28"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
     </span><span class="pun">{</span><span class="pln"> 
@@ -2498,17 +2498,17 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 57</span>: Choice (JSON-LD)</div><pre class="example hightlight">{
-  "@id": "http://example.org/anno29",
+  "id": "http://example.org/anno29",
   "@type": "Annotation",
   "body": {
     "@type": "Choice",
     "members": [
       { 
-        "@id": "http://example.org/note1",
+        "id": "http://example.org/note1",
         "language": "en"
       },
       {
-        "@id": "http://example.org/note2",
+        "id": "http://example.org/note2",
         "language": "fr"
       }
     ]
@@ -2561,9 +2561,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 59</span>: Composite (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno30"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno30"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comparison1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comparison1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Composite"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"item"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
@@ -2614,9 +2614,9 @@ It is also possible for an Annotation to have multiple Bodies and/or Targets.  E
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 61</span>: List (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno31"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno31"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
+  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">},</span><span class="pln">
   </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
@@ -2695,6 +2695,8 @@ The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization forma
     </span><span class="str">"iana"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"http://www.iana.org/assignments/relation/"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"owl"</span><span class="pun">:</span><span class="pln">     </span><span class="str">"http://www.w3.org/2002/07/owl#"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"as"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"http://www.w3.org/ns/activitystreams#"</span><span class="pun">,</span><span class="pln">
+
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln">
 
     </span><span class="str">"Annotation"</span><span class="pun">:</span><span class="pln">           </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"Dataset"</span><span class="pun">:</span><span class="pln">              </span><span class="str">"dctypes:Dataset"</span><span class="pun">,</span><span class="pln">
@@ -2802,25 +2804,25 @@ The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization forma
 </ul>
 <div style="display: block;" class="tab_jsonld">
 <div class="example"><div class="example-title"><span>Example 63</span>: Complete Example (JSON-LD)</div><pre style="" class="example highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno32"</span><span class="pun">,</span><span class="pln">
+  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno32"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"commenting"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"A. Person"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"user1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-10-13T13:00:00Z"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SoftwareAgent"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Code v2.1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"homepage"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/homepage1"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
   </span><span class="str">"generated"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-10-14T15:13:28Z"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/stylesheet1"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/stylesheet1"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssStylesheet"</span><span class="pln">
   </span><span class="pun">},</span><span class="pln">
 
@@ -2845,12 +2847,12 @@ The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization forma
           </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln"> 
           </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
           </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-            </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
+            </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
             </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Audio"</span><span class="pun">,</span><span class="pln">
             </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"audio/mpeg"</span><span class="pun">,</span><span class="pln">
             </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"de"</span><span class="pun">,</span><span class="pln">
             </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-              </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user2"</span><span class="pun">,</span><span class="pln">
+              </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user2"</span><span class="pun">,</span><span class="pln">
               </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pln">
             </span><span class="pun">}</span><span class="pln">
           </span><span class="pun">}</span><span class="pln">


### PR DESCRIPTION
@msporny told our annotation breakout session at TPAC that the `@` stuff is _soley_ to be used to avoid conflicts. If you're creating a new JSON document (as we are), then we don't need them. :tada: 
