### PR TITLE
DCMI Metadata Terms examples

### DIFF
--- a/vocab/wd/index-respec.html
+++ b/vocab/wd/index-respec.html
@@ -1406,6 +1406,12 @@ bodyText | cachedSource | end | exact | hasBody | hasRole | hasSelector | hasSou
   </div>
   <div>
     <pre class="example highlight" title="dctypes:MovingImage">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody [ oa:text "tag" ] ;
+    oa:hasTarget &lt;http://example.com/video1&gt; ;
+    oa:motivatedBy oa:tagging .
+
+&lt;http://example.org/video1&gt; a dctypes:MovingImage .
     </pre>
   </div>
 </section>
@@ -1427,6 +1433,12 @@ bodyText | cachedSource | end | exact | hasBody | hasRole | hasSelector | hasSou
   </div>
   <div>
     <pre class="example highlight" title="dctypes:StillImage">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody [ oa:text "tag" ] ;
+    oa:hasTarget &lt;http://example.com/image1&gt; ;
+    oa:motivatedBy oa:tagging .
+
+&lt;http://example.org/image1&gt; a dctypes:StillImage .
     </pre>
   </div>
 </section>
@@ -1448,6 +1460,12 @@ bodyText | cachedSource | end | exact | hasBody | hasRole | hasSelector | hasSou
   </div>
   <div>
     <pre class="example highlight" title="dctypes:Sound">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody [ oa:text "tag" ] ;
+    oa:hasTarget &lt;http://example.com/audio1&gt; ;
+    oa:motivatedBy oa:tagging .
+
+&lt;http://example.org/audio1&gt; a dctypes:Sound .
     </pre>
   </div>
 </section>
@@ -1469,6 +1487,12 @@ bodyText | cachedSource | end | exact | hasBody | hasRole | hasSelector | hasSou
   </div>
   <div>
     <pre class="example highlight" title="dctypes:Text">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody [ oa:text "tag" ] ;
+    oa:hasTarget &lt;http://example.com/document1&gt; ;
+    oa:motivatedBy oa:tagging .
+
+&lt;http://example.org/document1&gt; a dctypes:Text .
     </pre>
   </div>
 </section>


### PR DESCRIPTION
Added examples for DCMI Metadata Terms: StillImage, MovingImage, Sound and Text.
