### PR TITLE
Proposed improvements on the terminology section of the model

### DIFF
--- a/model/wd2/index-respec.html
+++ b/model/wd2/index-respec.html
@@ -161,8 +161,8 @@ All efforts have been made to keep the implementation costs for both producers
 and consumers to a minimum.  A single method of fulfilling a use case
 is strongly preferred over multiple methods, unless there are existing
 standards that need to be accommodated or there is a significant cost
-associated with using only a single method.  While the Data Model is built using Linked Data 
-fundamentals, the design is intended to allow rich and performant non-graph-based implementations.  
+associated with using only a single method.  While the Data Model is built using Linked Data
+fundamentals, the design is intended to allow rich and performant non-graph-based implementations.
 As such, inferencing and other graph-based queries are explicitly not a priority for optimization in the
 design of the model.
 
@@ -176,7 +176,7 @@ design of the model.
 The examples throughout the document are serialized as [[JSON-LD]] using the Context given in Appendix A of the Annotation Vocabulary [[annotation-vocab]], which is the preferred serialization format.
 </p>
 
-<p>When the only information that is recorded in the annotation is the URI of a resource, then that URI is used as the value of the relationship, as in <a href="#annotations">Example 1</a>.  When there is more information about the resource, the URI is the value of the <code>id</code> property of the object which is the value of the relationship, as in <a href="#external-web-resources">Example 2</a>.</p>  
+<p>When the only information that is recorded in the annotation is the URI of a resource, then that URI is used as the value of the relationship, as in <a href="#annotations">Example 1</a>.  When there is more information about the resource, the URI is the value of the <code>id</code> property of the object which is the value of the relationship, as in <a href="#external-web-resources">Example 2</a>.</p>
 
 
 </section>
@@ -189,26 +189,32 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 <dl>
 
-  <dt>Resource</dt>
-  <dd>An item of interest that may be identified by a URI (a Web Resource), or may not have an identifier (a Blank Node).</dd>
+  <dt><dfn data-lt="Resource|Resources">Resource</dfn></dt>
+  <dd>An item of interest that may be identified by a URI (although not necessarily).</dd>
 
-  <dt>Web Resource</dt>
-  <dd>An item of interest that is identified by a URI, as described in the Web Architecture [[webarch]].  Web Resources may be dereferencable from their URI.</dd>
+  <dt><dfn data-lt="Web Resource|Web Resources">Web Resource</dfn></dt>
+  <dd>An item of interest, i.e., a <a>Resource</a> that is identified by a URI, as described in the Web Architecture [[webarch]].  Web Resources may be dereferencable from their URI.</dd>
 
-  <dt>External Web Resource</dt>
-  <dd>A Web Resource which is not part of the representation of the Annotation, such as a web page, image or video. External Web Resources are dereferencable from their URI.  Conversely a Specific Resource is not an External Web Resource, as its state is entirely captured within the Annotation's representation.</dd>
+  <dt><dfn data-lt="External Web Resource|External Web Resources">External Web Resource</dfn></dt>
+  <dd>A <a>Web Resource</a> which is not part of the representation of the Annotation, such as a web page, image or video. External Web Resources are dereferencable from their URI.
 
-  <dt>Property</dt>
-  <dd>A feature of a Web Resource, that often has a particular data type.  In the model sections, the term "property" is used to refer to only those features which are NOT Relationships and instead have a literal value such as a string, integer or date.  The valid values for a Property are thus any data type other than object, or an array containing members of that data type if more than one is allowed.</dd>
+  <dt><dfn data-lt="Specific Resource|Specific Resources">Specific Resource</dfn></dt>
+  <dd>As opposed to a <a>External Web Resource</a>, the state of a Specific Resource is entirely captured within the Annotation's representation.</dd>
 
-  <dt>Relationship</dt>
-  <dd>In the model sections, the term "relationship" is used to distinguish those features that refer to other Web Resources, either by reference to the resource's URI or by including a description of the resource in the Annotation's representation. The valid values for a Relationship are: a quoted string containing a URI, an object that has the "id" property, or an array containing either of these if more than one is allowed.</dd>
+  <dt><dfn data-lt="Property|Properties">Property</dfn></dt>
+  <dd>A feature of a <a>Web Resource</a>, that often has a particular data <a>type</a>. In the model sections, the term "property" is used to refer to only those features which are <em>not</em> <a>Relationships</a> and instead have a literal value such as a string, integer or date.  The valid values for a Property are thus any data type other than object, or an array containing members of that data type if more than one is allowed.</dd>
 
-  <dt>Class</dt>
-  <dd>A type that can be associated with a Resource. Classes are Web Resources, as they are identified by a URI.</dd>
+  <dt><dfn data-lt="Relationship|Relationships">Relationship</dfn></dt>
+  <dd>In the model sections, the term "relationship" is used to distinguish those features that refer to other <a>Web Resources</a>, either by reference to the resource's URI or by including a description of the resource in the Annotation's representation. The valid values for a Relationship are: a quoted string containing a URI, an object that has an "id" property, or an array containing either of these if more than one is allowed.</dd>
 
-  <dt>Instance</dt>
-  <dd>An instance of a particular Class. Instances are Resources, as they may or may not be identified by a URI.</dd>
+  <dt><dfn data-lt="Class|Classes">Class</dfn></dt>
+  <dd><a>Resources</a> may be divided, conceptually, into groups called "classes"; members of a class are known as <a>Instances</a> of the class. Resources are associated with a particular class through <a>typing</a>. Classes are identified by URI-s, i.e., they are also <a>Web Resources</a> themselves.</dd>
+
+  <dt><dfn data-lt="type|types|typing">Type</dfn></dt>
+  <dd>A special <a>Relationship</a> that associates an <a>Instance</a> of a class to the <a>Class</a> it belongs to.</dd>
+
+  <dt><dfn data-lt="Instance|Instances">Instance</dfn></dt>
+  <dd>An element of a group of <a>Resources</a> represented by a particular <a>Class</a>. Instances are identified by URI-s, i.e., they are also <a>Web Resources</a> themselves.</dd>
 
 </dl>
 
@@ -311,7 +317,7 @@ An Annotation is a web resource. Typically, an Annotation has a single Body, whi
 <section>
   <h2>Bodies and Targets</h2>
 
-The Web is distributed, with different systems working together to provide access to content.  Annotations can be used to link those resources together, being referenced as the Body and Target.  The Target resource is always an External Web Resource, but the Body may also be embedded within the Annotation.  External Web Resources may be separately dereferenced to retrieve a representation of their state, whereas the embedded Body does not need to be dereferenced as the representation is included within the Annotation's representation. 
+The Web is distributed, with different systems working together to provide access to content.  Annotations can be used to link those resources together, being referenced as the Body and Target.  The Target resource is always an External Web Resource, but the Body may also be embedded within the Annotation.  External Web Resources may be separately dereferenced to retrieve a representation of their state, whereas the embedded Body does not need to be dereferenced as the representation is included within the Annotation's representation.
 
 <section>
 <h3>External Web Resources</h3>
@@ -323,7 +329,7 @@ The Web is distributed, with different systems working together to provide acces
 <h4>Model</h4>
 
 <table class="model">
-<tr><th>Term</th><th>Type</th><th>Description</th></tr> 
+<tr><th>Term</th><th>Type</th><th>Description</th></tr>
   <tr><td>id</td><td>Property</td><td>The URI that identifies the Body or Target resource.
 <br/>Bodies or Targets which are External Web Resources MUST have exactly 1 <code>id</code> with the value of the resource's URI.
   </td></tr>
@@ -448,7 +454,7 @@ For more information regarding the use of URIs with fragment components, please 
   }
 }
 </pre>
-</section>  
+</section>
 
 <section>
   <h3>Embedded Textual Body</h3>
@@ -475,7 +481,7 @@ There MUST be exactly 1 <code>text</code> property associated with the TextualBo
 
 <p>Systems SHOULD assume that Textual Bodies have the <code>Text</code> class, described in <a href="#classes">Classes</a> above, even if it is not explicitly included in the <code>type</code> property. </p>
 
-<p>The properties of External Web Resources, such as <code>language</code> and <code>format</code> also apply to embedded Textual Body resources.</p> 
+<p>The properties of External Web Resources, such as <code>language</code> and <code>format</code> also apply to embedded Textual Body resources.</p>
 
 <h4>Example</h4>
 
@@ -510,7 +516,7 @@ The simplest type of Body is a plain text string, without additional information
 <tr><th>Term</th><th>Type</th><th>Description</th></tr>
 <tr><td>bodyText</td><td>Property</td><td>The string value of the body of the Annotation.
 <br/>There MAY be exactly 1 <code>bodyText</code> for an Annotation, and the value MUST conform to the requirements below.  If the <code>bodyText</code> property is present, then the <code>body</code> relationship MUST NOT also be present.</td></tr>
-</table> 
+</table>
 
 <p>
 There are several restrictions on when this form may be used and how it is to be interpreted.
@@ -796,7 +802,7 @@ Each agent MAY have 1 or more values in the <code>email_sha1</code> property.</t
 <p>Further properties that describe the audience are used from <a href="http://schema.org/Audience">schema.org's Audience</a> classes.  The properties and class names MUST be prefixed in the JSON with <code>schema:</code> to ensure that they are uniquely distinguished from any other properties or classes.</p>
 
 <p>
-The use of <code>audience</code> does not imply nor enable any access restriction to prevent the annotation from being seen.  Systems SHOULD use the information for filtering the display of Annotations based on their knowledge of the user, and not assume that the Annotation or other resources will require authentication and authorization. 
+The use of <code>audience</code> does not imply nor enable any access restriction to prevent the annotation from being seen.  Systems SHOULD use the information for filtering the display of Annotations based on their knowledge of the user, and not assume that the Annotation or other resources will require authentication and authorization.
 </p>
 
 <h4>Example</h4>
@@ -877,7 +883,7 @@ For more information about how Motivations can be inter-related and new Motivati
   "target": "http://example.com/page1"
 }
 </pre>
-</section>  
+</section>
 
 <section>
 <h3>Rights Information</h3>
@@ -1122,7 +1128,7 @@ The URI that uses the fragment may be reconstructed by concatenating the <code>s
       "value": "t=30,60"
     }
   },
-  "target": "http://example.org/image1"  
+  "target": "http://example.org/image1"
 }
 </pre>
 </section>


### PR DESCRIPTION
I have tried to improve the wording of the Terminology section, surfacing each terms to the top and also making the description of classes (hopefully) a bit clearer (took over some terminology from the RDF Schema specification).

I have also used the respec tools to have definitions and an (easy) way to refer to the definition. It may be useful to put such references into the text (a bit tedious but should be doable with a good text editor...)
