### PR TITLE
Vocab namespaces section

### DIFF
--- a/vocab/wd/index-linktemplate.html
+++ b/vocab/wd/index-linktemplate.html
@@ -111,10 +111,10 @@
                 }
           ],
           previousMaturity:     "WD",
-          previousPublishDate:  "2015-10-15",
-          previousURI:          "http://www.w3.org/TR/2015/WD-annotation-model-20151015/",
+          previousPublishDate:  "2013-02-08",
+          previousURI:          "http://www.openannotation.org/spec/core/20130208/index.html",
           publishDate:          "2016-03-31",
-          edDraftURI:           "http://w3c.github.io/web-annotation/",
+          edDraftURI:           "http://w3c.github.io/web-annotation/vocab/wd/",
           wg:                   "Web Annotation Working Group",
           wgURI:                "http://www.w3.org/annotation/",
           wgPublicList:         "public-annotation",
@@ -197,7 +197,7 @@ The use of the W3CDTF format, instead of the more restrictive but more common xs
 <h2>Introduction</h2>
 
 <p>
-The specification is divided into two major sections: the terms defined in the Web Annotation ontology, and terms from other ontologies used in the model.
+The specification is divided into two major sections: the terms defined in the Web Annotation vocabulary, and terms from other ontologies used in the model.
 </p>
 
 <p>
@@ -221,6 +221,36 @@ Each class lists the recommendations from the model for the REQUIRED, RECOMMENDE
 <tr><td>skos</td><td>http://www.w3.org/2004/02/skos/core#</td><td>[[!skos-reference]]</td></tr>
 <tr><td>xsd</td><td>http://www.w3.org/2001/XMLSchema#</td><td>[[!xmlschema-2]]</td></tr>
 </table>
+
+<p>
+This document defines terms in the Web Annotation namespace:
+</p>
+
+<pre>http://www.w3.org/ns/oa#</pre>
+
+<p>
+While the vocabulary may be retrieved from
+the <code>https://</code> variant of the namespace,
+for compatibility with the precursor
+<a href="http://www.openannotation.org/spec/core/">Open Annotation Data Model</a>,
+the namespace uses <code>http://</code> in its URI.
+</p>
+
+<p>
+This vocabulary is also available
+(<span class="issue">TODO: <a href="https://github.com/w3c/web-annotation/issues/66">issue #66</a></span>)
+as an RDFS [[!rdf-schema]] and OWL [[!owl2-overview]] ontology:
+
+</p>
+
+<ul>
+  <li><a href="oa.ttl">oa.ttl</a> (Turtle format)</li>
+  <li><a href="oa.jsonld">oa.jsonld</a> (JSON-LD format)</li>
+  <li><a href="oa.rdf">oa.rdf</a> (RDF/XML format)</li>
+</ul>
+
+The above ontology files are licensed under the
+<a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">W3C Software and Document license</a>.
 
 </section>
 

--- a/vocab/wd/index-respec.html
+++ b/vocab/wd/index-respec.html
@@ -111,10 +111,10 @@
                 }
           ],
           previousMaturity:     "WD",
-          previousPublishDate:  "2015-10-15",
-          previousURI:          "http://www.w3.org/TR/2015/WD-annotation-model-20151015/",
+          previousPublishDate:  "2013-02-08",
+          previousURI:          "http://www.openannotation.org/spec/core/20130208/index.html",
           publishDate:          "2016-03-31",
-          edDraftURI:           "http://w3c.github.io/web-annotation/",
+          edDraftURI:           "http://w3c.github.io/web-annotation/vocab/wd/",
           wg:                   "Web Annotation Working Group",
           wgURI:                "http://www.w3.org/annotation/",
           wgPublicList:         "public-annotation",
@@ -197,7 +197,7 @@ The use of the W3CDTF format, instead of the more restrictive but more common xs
 <h2>Introduction</h2>
 
 <p>
-The specification is divided into two major sections: the terms defined in the Web Annotation ontology, and terms from other ontologies used in the model.
+The specification is divided into two major sections: the terms defined in the Web Annotation vocabulary, and terms from other ontologies used in the model.
 </p>
 
 <p>
@@ -221,6 +221,36 @@ Each class lists the recommendations from the model for the REQUIRED, RECOMMENDE
 <tr><td>skos</td><td>http://www.w3.org/2004/02/skos/core#</td><td>[[!skos-reference]]</td></tr>
 <tr><td>xsd</td><td>http://www.w3.org/2001/XMLSchema#</td><td>[[!xmlschema-2]]</td></tr>
 </table>
+
+<p>
+This document defines terms in the Web Annotation namespace:
+</p>
+
+<pre>http://www.w3.org/ns/oa#</pre>
+
+<p>
+While the vocabulary may be retrieved from
+the <code>https://</code> variant of the namespace,
+for compatibility with the precursor
+<a href="http://www.openannotation.org/spec/core/">Open Annotation Data Model</a>,
+the namespace uses <code>http://</code> in its URI.
+</p>
+
+<p>
+This vocabulary is also available
+(<span class="issue">TODO: <a href="https://github.com/w3c/web-annotation/issues/66">issue #66</a></span>)
+as an RDFS [[!rdf-schema]] and OWL [[!owl2-overview]] ontology:
+
+</p>
+
+<ul>
+  <li><a href="oa.ttl">oa.ttl</a> (Turtle format)</li>
+  <li><a href="oa.jsonld">oa.jsonld</a> (JSON-LD format)</li>
+  <li><a href="oa.rdf">oa.rdf</a> (RDF/XML format)</li>
+</ul>
+
+The above ontology files are licensed under the
+<a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">W3C Software and Document license</a>.
 
 </section>
 

--- a/vocab/wd/index-respec.html
+++ b/vocab/wd/index-respec.html
@@ -7,7 +7,7 @@
 
 .model {
  empty-cells: show;
- border-collapse: collapse; 
+ border-collapse: collapse;
  margin-bottom: .5ex;
  border: 1px solid black;
  width: 100%;
@@ -89,7 +89,7 @@
       <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
       <script class='remove'>
       var respecConfig = {
-          specStatus: "WD", 
+          specStatus: "WD",
           shortName:  "annotation-vocab",
           editors: [
                 {   name:       "Robert Sanderson",
@@ -101,7 +101,7 @@
                     url:        "http://www.paolociccarese.info",
                     company:    "Massachusetts General Hospital",
                     companyUrl: "",
-                    mailto:     "paolo.ciccarese@gmail.com " 
+                    mailto:     "paolo.ciccarese@gmail.com "
                 },
                 {   name:       "Benjamin Young",
                     url:        "http://bigbluehat.com/",
@@ -113,7 +113,7 @@
           previousMaturity:     "WD",
           previousPublishDate:  "2015-10-15",
           previousURI:          "http://www.w3.org/TR/2015/WD-annotation-model-20151015/",
-          publishDate:          "2016-03-31", 
+          publishDate:          "2016-03-31",
           edDraftURI:           "http://w3c.github.io/web-annotation/",
           wg:                   "Web Annotation Working Group",
           wgURI:                "http://www.w3.org/annotation/",
@@ -134,9 +134,24 @@
                 rawDate: "2004-02-16"
 
             },
-            "web-annotation": {
-              title: "Web Annotation",
-              href: "http://www.w3.org/TR/annotation-model/",
+            "annotation-model": {
+              "authors": [
+                    "Robert Sanderson",
+                    "Paolo Ciccarese",
+                    "Benjamin Young"
+              ],
+              title: "Web Annotation Data Model",
+              href: "http://www.w3.org/TR/2016/WD-annotation-model-20160331/",
+              publisher: "W3C",
+              rawDate: "2016-03-31",
+              status: "WD"
+            },
+            "annotation-protocol": {
+              "authors": [
+                "Robert Sanderson"
+              ],
+              title: "Web Annotation Protocol",
+              href: "http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/",
               publisher: "W3C",
               rawDate: "2016-03-31",
               status: "WD"
@@ -151,25 +166,25 @@
                         }]
                 }
           ]
-      };  
-      </script> 
+      };
+      </script>
     </head>
     <body>
 
 
 <section id="abstract">
 
-<p>The Web Annotation Vocabulary specifies the set of RDF classes, predicates and named entities that are used by the Web Annotation Data Model [[!!annotation-model]].  It also lists recommended terms from other ontologies that are used in the model, and provides the JSON-LD Context and profile definitions needed to use the Web Annotation JSON serialization in a Linked Data context.</p>  
+<p>The Web Annotation Vocabulary specifies the set of RDF classes, predicates and named entities that are used by the Web Annotation Data Model [[!annotation-model]].  It also lists recommended terms from other ontologies that are used in the model, and provides the JSON-LD Context and profile definitions needed to use the Web Annotation JSON serialization in a Linked Data context.</p>
 
 </section>
 
-<section id="sotd"> 
+<section id="sotd">
 <p>
   <b>This is a work in progress. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future. If you feel something should be covered, please <a href="mailto:public-annotation@w3.org">tell us!</a></b>
 </p>
 
 <div class="note">
-  The content of this document, along with the Web Annotation [[!web-annotation]] specification, is the result of the split of the <a href="https://www.w3.org/TR/2015/WD-annotation-model-20151015/">Web Annotation Data Model</a> specification document.
+  The content of this document, along with the latest release of the Web Annotation Data Model [[!annotation-model]] specification, is the result of the split of the <a href="https://www.w3.org/TR/2015/WD-annotation-model-20151015/">previous release</a> of the  Web Annotation Data Model Working Draft into two documents.
 </div>
 
 <p class="issue">
@@ -182,7 +197,7 @@ The use of the W3CDTF format, instead of the more restrictive but more common xs
 <h2>Introduction</h2>
 
 <p>
-The specification is divided into two major sections: the terms defined in the Web Annotation ontology, and terms from other ontologies used in the model.  
+The specification is divided into two major sections: the terms defined in the Web Annotation ontology, and terms from other ontologies used in the model.
 </p>
 
 <p>
@@ -261,7 +276,7 @@ The namespace used for the Web Annotation Ontology is:
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#Annotation</li>
       <li><strong>Required Predicates:</strong> <a href="#hastarget">oa:hasTarget</a>, <a href="#rdf-type">rdf:type</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#hasbody">oa:hasBody</a>, <a href="#motivatedby">oa:motivatedBy</a>, <a href="#dcterms-creator">dcterms:creator</a>, <a href="#dcterms-created">dcterms:created</a></li> 
+      <li><strong>Recommended Predicates:</strong> <a href="#hasbody">oa:hasBody</a>, <a href="#motivatedby">oa:motivatedBy</a>, <a href="#dcterms-creator">dcterms:creator</a>, <a href="#dcterms-created">dcterms:created</a></li>
       <li><strong>Other Predicates:</strong> <a href="#bodytext">oa:bodyText</a>, <a href="#styledby">oa:styledBy</a>, <a href="#dcterms-issued">dcterms:issued</a>, <a href="#as-generator">as:generator</a> </li>
     </ul>
   </div>
@@ -351,7 +366,7 @@ The namespace used for the Web Annotation Ontology is:
         oa:hasSource &lt;http://example.org/page1&gt; ;
         oa:hasSelector [
             a oa:CssSelector ;
-            rdf:value "#elemid > .elemclass + p" ] ] . 
+            rdf:value "#elemid > .elemclass + p" ] ] .
     </pre>
   </div>
 </section>
@@ -447,7 +462,7 @@ The namespace used for the Web Annotation Ontology is:
         oa:hasSource &lt;http://example.org/target1&gt; ;
         oa:hasState [
             a oa:HttpRequestState ;
-            rdf:value "Accept: text/plain" ] ] .
+            rdf:value "Accept: application/pdf" ] ] .
     </pre>
   </div>
 </section>
@@ -514,7 +529,7 @@ The namespace used for the Web Annotation Ontology is:
     <pre class="example highlight" title="oa:ResourceSelection">
 &lt;http://example.org/cell1&gt; a oa:ResourceSelection ;
     oa:hasSource &lt;http://example.org/image1&gt; ;
-    oa:hasSelector [ 
+    oa:hasSelector [
       a oa:XPathSelector ;
       rdfs:value "//table[1]/tr[1]/td[4]" ] .
     </pre>
@@ -566,7 +581,7 @@ The namespace used for the Web Annotation Ontology is:
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#State</li>
-      <li><strong>Super Class Of:</strong> <a href="#httprequeststate">oa:HttpRequestState</a>, <a href="#timestate">oa:TimeState</a></li>      
+      <li><strong>Super Class Of:</strong> <a href="#httprequeststate">oa:HttpRequestState</a>, <a href="#timestate">oa:TimeState</a></li>
       <li><strong>Range Of:</strong> <a href="#hasstate">oa:hasState</a></li>
     </ul>
   </div>
@@ -581,7 +596,7 @@ The namespace used for the Web Annotation Ontology is:
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#Style</li>
-      <li><strong>Super Class Of:</strong> <a href="#cssstyle">oa:CssStyle</a></li>      
+      <li><strong>Super Class Of:</strong> <a href="#cssstyle">oa:CssStyle</a></li>
       <li><strong>Range Of:</strong> <a href="#styledby">oa:styledBy</a></li>
     </ul>
   </div>
@@ -634,7 +649,7 @@ The namespace used for the Web Annotation Ontology is:
         oa:hasSelector [
             a oa:TextPositionSelector ;
             oa:start 412 ;
-            oa:end 795 ] ] .      
+            oa:end 795 ] ] .
     </pre>
   </div>
 </section>
@@ -660,7 +675,7 @@ The namespace used for the Web Annotation Ontology is:
             a oa:TextQuoteSelector ;
             oa:exact "anotation" ;
             oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .      
+            oa:suffix " that has some" ] ] .
     </pre>
   </div>
 </section>
@@ -711,7 +726,7 @@ The namespace used for the Web Annotation Ontology is:
         oa:hasState [
             a oa:TimeState ;
             oa:cachedSource &lt;http://example.org/copy1&gt; ;
-            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .      
+            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .
     </pre>
   </div>
 </section>
@@ -734,7 +749,7 @@ The namespace used for the Web Annotation Ontology is:
         oa:hasSource &lt;http://example.org/page1&gt; ;
         oa:hasSelector [
           a oa:XPathSelector ;
-          rdfs:value "//div[@id='elem1']" ] ] .      
+          rdfs:value "/html/body/p[2]/table/tr[2]/td[3]/span" ] ] .
     </pre>
   </div>
 </section>
@@ -752,11 +767,11 @@ The namespace used for the Web Annotation Ontology is:
 
 <section class="term">
   <h4>annotationService</h4>
-  <p>The object of the relationship is the end point of a service that conforms to the [[!annotation-protocol]], and it may be associated with any resource.  The expectation of asserting the relationship is that the object is the preferred service for maintaining annotations about the subject resource, according to the publisher of the relationship. 
+  <p>The object of the relationship is the end point of a service that conforms to the [[!annotation-protocol]], and it may be associated with any resource.  The expectation of asserting the relationship is that the object is the preferred service for maintaining annotations about the subject resource, according to the publisher of the relationship.
   </p>
   <p>
   This relationship is intended to be used both within Linked Data descriptions and as the <code>rel</code> type of a Link, via HTTP Link Headers [[!rfc5988]] for binary resources and in HTML &lt;link&gt; elements.  For more information about these, please see the Annotation Protocol specification [[!annotation-protocol]].
-  </p>    
+  </p>
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#annotationService</li>
@@ -873,7 +888,7 @@ The namespace used for the Web Annotation Ontology is:
             a oa:TextQuoteSelector ;
             oa:exact "anotation" ;
             oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .      
+            oa:suffix " that has some" ] ] .
     </pre>
   </div>
 </section>
@@ -892,7 +907,7 @@ The namespace used for the Web Annotation Ontology is:
     <pre class="example highlight" title="oa:hasBody">
 &lt;http://example.org/anno23&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/post1&gt; ;
-    oa:hasTarget &lt;http://example.com/page1&gt; .      
+    oa:hasTarget &lt;http://example.com/page1&gt; .
     </pre>
   </div>
 </section>
@@ -953,7 +968,7 @@ The namespace used for the Web Annotation Ontology is:
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasScope</li>
       <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
-      <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#context">as:context</a></li>      
+      <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#context">as:context</a></li>
     </ul>
   </div>
   <div>
@@ -1400,7 +1415,7 @@ The namespace used for the Web Annotation Ontology is:
     <pre class="example highlight" title="oa:bookmarking">
 &lt;http://example.org/anno45&gt; a oa:Annotation ;
     oa:hasTarget &lt;http://example.com/page1&gt; ;
-    oa:motivatedBy oa:bookmarking .      
+    oa:motivatedBy oa:bookmarking .
     </pre>
   </div>
 </section>
@@ -1507,7 +1522,7 @@ The namespace used for the Web Annotation Ontology is:
 &lt;http://example.org/anno51&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.com/identities/object1&gt; ;
     oa:hasTarget &lt;http://example.com/image-of-object1&gt; ;
-    oa:motivatedBy oa:identifying .      
+    oa:motivatedBy oa:identifying .
     </pre>
   </div>
 </section>
@@ -1673,7 +1688,7 @@ The namespace used for the Web Annotation Ontology is:
   rdfs:label "Example Collection" ;
   as:totalItems 42023 ;
   as:first &lt;http://example.org/collection1/page1&gt; ;
-  as:last &lt;http://example.org/collection1/page42&gt; .      
+  as:last &lt;http://example.org/collection1/page42&gt; .
     </pre>
   </div>
 </section>
@@ -1720,7 +1735,7 @@ The namespace used for the Web Annotation Ontology is:
     oa:hasTarget &lt;http://example.com/dataset1&gt; .
 
 &lt;http://example.com/dataset1&gt; a dctypes:Dataset ;
-  dc:format "text/csv" .    
+  dc:format "text/csv" .
     </pre>
   </div>
 </section>
@@ -1902,7 +1917,7 @@ The namespace used for the Web Annotation Ontology is:
   rdfs:label "Example Collection" ;
   as:totalItems 42023 ;
   as:first &lt;http://example.org/collection1/page1&gt; ;
-  as:last &lt;http://example.org/collection1/page42&gt; . 
+  as:last &lt;http://example.org/collection1/page42&gt; .
     </pre>
   </div>
 </section>
@@ -1969,7 +1984,7 @@ The namespace used for the Web Annotation Ontology is:
   rdfs:label "Example Collection" ;
   as:totalItems 42023 ;
   as:first &lt;http://example.org/collection1/page1&gt; ;
-  as:last &lt;http://example.org/collection1/page42&gt; . 
+  as:last &lt;http://example.org/collection1/page42&gt; .
     </pre>
   </div>
 </section>
@@ -2088,7 +2103,7 @@ The namespace used for the Web Annotation Ontology is:
   rdfs:label "Example Collection" ;
   as:totalItems 42023 ;
   as:first &lt;http://example.org/collection1/page1&gt; ;
-  as:last &lt;http://example.org/collection1/page42&gt; . 
+  as:last &lt;http://example.org/collection1/page42&gt; .
     </pre>
   </div>
 </section>
@@ -2424,7 +2439,7 @@ The namespace used for the Web Annotation Ontology is:
 
 <p>This vocabulary may be extended in the regular way, by creating new or importing existing predicates and classes from other RDF based ontologies. Extensions may be made to any resource, including adding new objects as well as properties. If there is a property in one of the ontologies that are already included in the context, then it is RECOMMENDED to use a CURIE, the namespace and property name separated by a <code>:</code> character, as the JSON-LD key rather than creating a new context.</p>
 
-<p>For example, it is easier to add <code>skos:prefLabel</code> to the Annotation rather than requiring clients to download a new context document to discover the mapping.</p>  
+<p>For example, it is easier to add <code>skos:prefLabel</code> to the Annotation rather than requiring clients to download a new context document to discover the mapping.</p>
 
   <pre class="highlight example" title="Extension Example 1">
 {
@@ -2445,7 +2460,7 @@ The namespace used for the Web Annotation Ontology is:
 
 
 <p>In order to ensure a lack of collision between key names, a JSON-LD context document SHOULD be made available when the term is not from an ontology that is already in the Web Annotation context. Extension contexts MUST NOT redefine existing JSON-LD keys from the Web Annotation context.  Implementations MUST ignore unfamiliar properties when processing the data, but servers SHOULD preserve them if they are part of a valid and included context.</p>
-  
+
 <p>For example, adding height and width for images from the EXIF vocabulary [[exif]] could be done by defining a JSON-LD context, and including the <code>height</code> and <code>width</code> properties and linking to the newly defined context in the Annotation's serialization.</p>
 
   <pre class="highlight example" title="Extension Example 2">
@@ -2608,7 +2623,7 @@ The RECOMMENDED serialization format is [[!JSON-LD]]. The JSON-LD context presen
 <section class="appendix">
   <h3>JSON-LD Frames</h3>
 
-<p>There is an unofficial, yet well implemented, JSON-LD specification [[json-ld-framing]] that describes a deterministic layout for serializing an RDF graph into a particular JSON-LD document layout.  Applying the following frames to the graph of information will generate JSON as close as possible to the serialization recommended by the Web Annotation Data Model.</p> 
+<p>There is an unofficial, yet well implemented, JSON-LD specification [[json-ld-framing]] that describes a deterministic layout for serializing an RDF graph into a particular JSON-LD document layout.  Applying the following frames to the graph of information will generate JSON as close as possible to the serialization recommended by the Web Annotation Data Model.</p>
 
 <section>
   <h3>Annotation Frame</h3>
@@ -2631,7 +2646,7 @@ A Frame for serializing a single Annotation.</p>
   "audience": {"@embed": true}
 }
 
-</pre>  
+</pre>
 </section>
 
 <section>
@@ -2650,7 +2665,7 @@ A Frame for serializing a single Annotation.</p>
     "last": [{"@embed": "False"}]
 }
 
-</pre> 
+</pre>
 
 <div class="note">If it is instead desirable to embed the first page of the Collection, change the <code>false</code> for <code>first</code> to <code>true</code>.</div>
 
@@ -2670,7 +2685,7 @@ A Frame for serializing a single Annotation.</p>
   "partOf": {"@embed": false},
   "items": {"@embed": true}
 }
-</pre> 
+</pre>
 
 </section>
 </section>
@@ -2680,8 +2695,8 @@ A Frame for serializing a single Annotation.</p>
 
 <p>Although the list of Motivations in the specification is derived from an extensive survey of the annotation landscape, there are many situations where more precise definitions are required or desirable. In these cases it is RECOMMENDED to create a new Motivation resource and relate it to one or more that already exist.</p>
 
-<p>New Motivations MUST be instances of <code>oa:Motivation</code>, which is a subClass of <code>skos:Concept</code>.  
-The <code>skos:broader</code> relationship SHOULD be asserted between the new Motivation and at least one existing Motivation, if there are any that are broader in scope.  Other relationships, such as <code>skos:relatedMatch</code>, <code>skos:exactMatch</code> and <code>skos:closeMatch</code>, SHOULD also be asserted to concepts created by other communities. 
+<p>New Motivations MUST be instances of <code>oa:Motivation</code>, which is a subClass of <code>skos:Concept</code>.
+The <code>skos:broader</code> relationship SHOULD be asserted between the new Motivation and at least one existing Motivation, if there are any that are broader in scope.  Other relationships, such as <code>skos:relatedMatch</code>, <code>skos:exactMatch</code> and <code>skos:closeMatch</code>, SHOULD also be asserted to concepts created by other communities.
 </p>
 
 <h4>Model</h4>
@@ -2700,7 +2715,7 @@ The <code>skos:broader</code> relationship SHOULD be asserted between the new Mo
 <p>The following people have been instrumental in providing thoughts, feedback, reviews, content, criticism and input in the creation of this specification:
 
 <div style="margin-left: 3em">
-Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven Capadisli, Paolo Ciccarese, Tim Cole, Ray Denenberg, TB Dinesh, Sergiu Gordea, Benjamin Goering, Amy Guy, Ivan Herman, Frederick Hirsch, Antoine Isaac, Jacob Jett, Takeshi Kanai, Gregg Kellogg, Andreas Kuckartz, Randall Leeds, Hugo Manguinhas, Ben De Meester, Luc Moreau, Addison Phillips, Davis Salisbury, Robert Sanderson, Felix Sasaki, Doug Schepers, Tzviya Siegman, Stian Soiland-Reyes, Manu Sporney, Nick Stenning, Jon Stroop, Lutz Suhrbier, Kyrce Swenson, Raphael Troncy, Simeon Warner, Erik Wilde, Dan Whaley, Benjamin Young 
+Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven Capadisli, Paolo Ciccarese, Tim Cole, Ray Denenberg, TB Dinesh, Sergiu Gordea, Benjamin Goering, Amy Guy, Ivan Herman, Frederick Hirsch, Antoine Isaac, Jacob Jett, Takeshi Kanai, Gregg Kellogg, Andreas Kuckartz, Randall Leeds, Hugo Manguinhas, Ben De Meester, Luc Moreau, Addison Phillips, Davis Salisbury, Robert Sanderson, Felix Sasaki, Doug Schepers, Tzviya Siegman, Stian Soiland-Reyes, Manu Sporney, Nick Stenning, Jon Stroop, Lutz Suhrbier, Kyrce Swenson, Raphael Troncy, Simeon Warner, Erik Wilde, Dan Whaley, Benjamin Young
 </div>
 </p>
 

--- a/vocab/wd/index.html
+++ b/vocab/wd/index.html
@@ -333,10 +333,10 @@ code.prettyprint {
     }
   ],
   "previousMaturity": "WD",
-  "previousPublishDate": "2015-10-15",
-  "previousURI": "http://www.w3.org/TR/2015/WD-annotation-model-20151015/",
+  "previousPublishDate": "2013-02-08",
+  "previousURI": "http://www.openannotation.org/spec/core/20130208/index.html",
   "publishDate": "2016-03-31",
-  "edDraftURI": "http://w3c.github.io/web-annotation/",
+  "edDraftURI": "http://w3c.github.io/web-annotation/vocab/wd/",
   "wg": "Web Annotation Working Group",
   "wgURI": "http://www.w3.org/annotation/",
   "wgPublicList": "public-annotation",
@@ -402,9 +402,9 @@ code.prettyprint {
       <dt>Latest published version:</dt>
       <dd><a href="http://www.w3.org/TR/annotation-vocab/">http://www.w3.org/TR/annotation-vocab/</a></dd>
       <dt>Latest editor's draft:</dt>
-      <dd><a href="http://w3c.github.io/web-annotation/">http://w3c.github.io/web-annotation/</a></dd>
+      <dd><a href="http://w3c.github.io/web-annotation/vocab/wd/">http://w3c.github.io/web-annotation/vocab/wd/</a></dd>
       <dt>Previous version:</dt>
-      <dd><a rel="dcterms:replaces" href="http://www.w3.org/TR/2015/WD-annotation-vocab-20151015/">http://www.w3.org/TR/2015/WD-annotation-vocab-20151015/</a></dd>
+      <dd><a rel="dcterms:replaces" href="http://www.w3.org/TR/2013/WD-annotation-vocab-20130208/">http://www.w3.org/TR/2013/WD-annotation-vocab-20130208/</a></dd>
     <dt>Editors:</dt>
     <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Robert Sanderson"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.stanford.edu/~azaroth/">Robert Sanderson</a>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
 <span property="rdf:rest" resource="_:editor1"></span>
@@ -506,7 +506,7 @@ The use of the W3CDTF format, instead of the more restrictive but more common xs
 <!--OddPage--><h2 resource="#h-introduction" id="h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2><p><em>This section is non-normative.</em></p>
 
 <p>
-The specification is divided into two major sections: the terms defined in the Web Annotation ontology, and terms from other ontologies used in the model.
+The specification is divided into two major sections: the terms defined in the Web Annotation vocabulary, and terms from other ontologies used in the model.
 </p>
 
 <p>
@@ -530,6 +530,36 @@ Each class lists the recommendations from the model for the <em title="REQUIRED"
 <tr><td>skos</td><td>http://www.w3.org/2004/02/skos/core#</td><td>[<cite><a href="#bib-skos-reference" class="bibref">skos-reference</a></cite>]</td></tr>
 <tr><td>xsd</td><td>http://www.w3.org/2001/XMLSchema#</td><td>[<cite><a href="#bib-xmlschema-2" class="bibref">xmlschema-2</a></cite>]</td></tr>
 </tbody></table>
+
+<p>
+This document defines terms in the Web Annotation namespace:
+</p>
+
+<pre>http://www.w3.org/ns/oa#</pre>
+
+<p>
+While the vocabulary may be retrieved from
+the <code>https://</code> variant of the namespace,
+for compatibility with the precursor
+<a href="http://www.openannotation.org/spec/core/">Open Annotation Data Model</a>,
+the namespace uses <code>http://</code> in its URI.
+</p>
+
+<p>
+This vocabulary is also available
+(<span class="issue">TODO: <a href="https://github.com/w3c/web-annotation/issues/66">issue #66</a></span>)
+as an RDFS [<cite><a href="#bib-rdf-schema" class="bibref">rdf-schema</a></cite>] and OWL [<cite><a href="#bib-owl2-overview" class="bibref">owl2-overview</a></cite>] ontology:
+
+</p>
+
+<ul>
+  <li><a href="oa.ttl">oa.ttl</a> (Turtle format)</li>
+  <li><a href="oa.jsonld">oa.jsonld</a> (JSON-LD format)</li>
+  <li><a href="oa.rdf">oa.rdf</a> (RDF/XML format)</li>
+</ul>
+
+The above ontology files are licensed under the
+<a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"><abbr title="World Wide Web Consortium">W3C</abbr> Software and Document license</a>.
 
 </section>
 
@@ -2855,6 +2885,7 @@ Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven
 </dd><dt id="bib-activitystreams-vocabulary">[activitystreams-vocabulary]</dt><dd>James Snell; Evan Prodromou. W3C. <a property="dc:requires" href="http://www.w3.org/TR/activitystreams-vocabulary/"><cite>Activity Vocabulary</cite></a>. 15 December 2015. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/activitystreams-vocabulary/">http://www.w3.org/TR/activitystreams-vocabulary/</a>
 </dd><dt id="bib-annotation-model">[annotation-model]</dt><dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/"><cite>Web Annotation Data Model</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
 </dd><dt id="bib-annotation-protocol">[annotation-protocol]</dt><dd>Robert Sanderson. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/"><cite>Web Annotation Protocol</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a>
+</dd><dt id="bib-owl2-overview">[owl2-overview]</dt><dd>W3C OWL Working Group. W3C. <a property="dc:requires" href="http://www.w3.org/TR/owl2-overview/"><cite>OWL 2 Web Ontology Language Document Overview (Second Edition)</cite></a>. 11 December 2012. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/owl2-overview/">http://www.w3.org/TR/owl2-overview/</a>
 </dd><dt id="bib-rdf-schema">[rdf-schema]</dt><dd>Dan Brickley; Ramanathan Guha. W3C. <a property="dc:requires" href="http://www.w3.org/TR/rdf-schema/"><cite>RDF Schema 1.1</cite></a>. 25 February 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/rdf-schema/">http://www.w3.org/TR/rdf-schema/</a>
 </dd><dt id="bib-rfc5988">[rfc5988]</dt><dd>M. Nottingham. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988">https://tools.ietf.org/html/rfc5988</a>
 </dd><dt id="bib-skos-reference">[skos-reference]</dt><dd>Alistair Miles; Sean Bechhofer. W3C. <a property="dc:requires" href="http://www.w3.org/TR/skos-reference"><cite>SKOS Simple Knowledge Organization System Reference</cite></a>. 18 August 2009. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/skos-reference">http://www.w3.org/TR/skos-reference</a>

--- a/vocab/wd/index.html
+++ b/vocab/wd/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr" typeof="bibo:Document w3p:WD" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
-<head><meta lang="" property="dc:language" content="en">
+<head><meta property="dc:language" content="en" lang="">
     <title>Web Annotation Vocabulary</title>
     <meta charset="utf-8">
     <style>
@@ -86,15 +86,15 @@
 }
 
       </style>
-
-
+      
+      
     <style>/*****************************************************************
  * ReSpec 3 CSS
  * Robin Berjon - http://berjon.com/
  *****************************************************************/
 
 /* --- INLINES --- */
-em.rfc2119 {
+em.rfc2119 { 
     text-transform:     lowercase;
     font-variant:       small-caps;
     font-style:         normal;
@@ -203,7 +203,7 @@ table.simple {
         display: none;
     }
 }
-</style><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><style>/* --- EXAMPLES --- */
+</style><meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"><style>/* --- EXAMPLES --- */
 div.example-title {
     min-width: 7.5em;
     color: #b9ab2d;
@@ -306,7 +306,7 @@ code.prettyprint {
 
 /* this from google-code-prettify */
 .pln{color:#000}@media screen{.str{color:#080}.kwd{color:#008}.com{color:#800}.typ{color:#606}.lit{color:#066}.pun,.opn,.clo{color:#660}.tag{color:#008}.atn{color:#606}.atv{color:#080}.dec,.var{color:#606}.fun{color:red}}@media print,projection{.str{color:#060}.kwd{color:#006;font-weight:bold}.com{color:#600;font-style:italic}.typ{color:#404;font-weight:bold}.lit{color:#044}.pun,.opn,.clo{color:#440}.tag{color:#006;font-weight:bold}.atn{color:#404}.atv{color:#060}}ol.linenums{margin-top:0;margin-bottom:0}li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8{list-style-type:none}li.L1,li.L3,li.L5,li.L7,li.L9{background:#eee}
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
+</style><link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script type="application/json" id="initialUserConfig">{
   "specStatus": "WD",
   "shortName": "annotation-vocab",
   "editors": [
@@ -355,9 +355,24 @@ code.prettyprint {
       "publisher": "W3C",
       "rawDate": "2004-02-16"
     },
-    "web-annotation": {
-      "title": "Web Annotation",
-      "href": "http://www.w3.org/TR/annotation-model/",
+    "annotation-model": {
+      "authors": [
+        "Robert Sanderson",
+        "Paolo Ciccarese",
+        "Benjamin Young"
+      ],
+      "title": "Web Annotation Data Model",
+      "href": "http://www.w3.org/TR/2016/WD-annotation-model-20160331/",
+      "publisher": "W3C",
+      "rawDate": "2016-03-31",
+      "status": "WD"
+    },
+    "annotation-protocol": {
+      "authors": [
+        "Robert Sanderson"
+      ],
+      "title": "Web Annotation Protocol",
+      "href": "http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/",
       "publisher": "W3C",
       "rawDate": "2016-03-31",
       "status": "WD"
@@ -375,9 +390,9 @@ code.prettyprint {
     }
   ]
 }</script></head>
-    <body class="h-entry toc-sidebar" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
+    <body id="respecDocument" role="document" class="h-entry toc-sidebar"><div id="respecHeader" role="contentinfo" class="head">
   <p>
-            <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
+            <a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C" height="48" width="72"></a>
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Vocabulary</h1>
   <h2 id="w3c-working-draft-31-march-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-03-31">31 March 2016</time></h2>
@@ -389,7 +404,7 @@ code.prettyprint {
       <dt>Latest editor's draft:</dt>
       <dd><a href="http://w3c.github.io/web-annotation/">http://w3c.github.io/web-annotation/</a></dd>
       <dt>Previous version:</dt>
-      <dd><a rel="dcterms:replaces" href="https://www.w3.org/TR/2015/WD-annotation-model-20151015/">https://www.w3.org/TR/2015/WD-annotation-model-20151015/</a></dd>
+      <dd><a rel="dcterms:replaces" href="http://www.w3.org/TR/2015/WD-annotation-vocab-20151015/">http://www.w3.org/TR/2015/WD-annotation-vocab-20151015/</a></dd>
     <dt>Editors:</dt>
     <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Robert Sanderson"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.stanford.edu/~azaroth/">Robert Sanderson</a>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
 <span property="rdf:rest" resource="_:editor1"></span>
@@ -411,11 +426,11 @@ code.prettyprint {
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
         2016
-
+        
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
         <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). 
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
             <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
@@ -425,25 +440,24 @@ code.prettyprint {
 </div>
 
 
-<section id="abstract" class="introductory" property="dc:abstract"><h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+<section property="dc:abstract" class="introductory" id="abstract"><h2 resource="#h-abstract" id="h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
 
-<p>The Web Annotation Vocabulary specifies the set of RDF classes, predicates and named entities that are used by the Web Annotation Data Model [<cite><a class="bibref" href="#bib-web-annotation">web-annotation</a></cite>].  It also lists recommended terms from other ontologies that are used in the model, and provides the JSON-LD Context and profile definitions needed to use the Web Annotation JSON serialization in a Linked Data context.</p>
+<p>The Web Annotation Vocabulary specifies the set of RDF classes, predicates and named entities that are used by the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].  It also lists recommended terms from other ontologies that are used in the model, and provides the JSON-LD Context and profile definitions needed to use the Web Annotation JSON serialization in a Linked Data context.</p>
 
-</section><section id="sotd" class="introductory"><h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+</section><section id="sotd" class="introductory"><h2 resource="#h-sotd" id="h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
         <p>
           <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
         </p>
-
+          
 <p>
   <b>This is a work in progress. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future. If you feel something should be covered, please <a href="mailto:public-annotation@w3.org">tell us!</a></b>
 </p>
 
-<div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note1"><span>Note</span></div><div class="">
-  The content of this document, along with the latest release of the Web Annotation Data Model [<cite><a class="bibref" href="#bib-web-annotation">web-annotation</a></cite>] specification, is the result of the split of the previous release of the <a href="https://www.w3.org/TR/2015/WD-annotation-model-20151015/">previous release</a> of the  Web Annotation Data Model Working Draft into two documents.
+<div class="note"><div id="h-note1" role="heading" aria-level="3" class="note-title marker"><span>Note</span></div><div class="">
+  The content of this document, along with the latest release of the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>] specification, is the result of the split of the <a href="https://www.w3.org/TR/2015/WD-annotation-model-20151015/">previous release</a> of the  Web Annotation Data Model Working Draft into two documents.
 </div></div>
 
-
-<div class="issue" id="issue-1"><div class="issue-title marker" aria-level="3" role="heading" id="h-issue1"><span>Issue 1</span></div><p class="">
+<div id="issue-1" class="issue"><div id="h-issue1" role="heading" aria-level="3" class="issue-title marker"><span>Issue 1</span></div><p class="">
 The use of the W3CDTF format, instead of the more restrictive but more common xsd:datetime format, is considered to be at-risk.
 </p></div>
 
@@ -455,7 +469,7 @@ The use of the W3CDTF format, instead of the more restrictive but more common xs
               <a href="mailto:public-annotation@w3.org">public-annotation@w3.org</a>
               (<a href="mailto:public-annotation-request@w3.org?subject=subscribe">subscribe</a>,
               <a href="http://lists.w3.org/Archives/Public/public-annotation/">archives</a>).
-
+            
               All comments are welcome.
           </p>
             <p>
@@ -483,47 +497,47 @@ The use of the W3CDTF format, instead of the more restrictive but more common xs
           </p>
             <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
             </p>
+          
+</section><nav id="toc"><h2 resource="#table-of-contents" id="table-of-contents" class="introductory"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul role="directory" class="toc"><li class="tocline"><a class="tocxref" href="#introduction"><span class="secno">1. </span>Introduction</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#namespaces"><span class="secno">1.1 </span>Namespaces</a></li><li class="tocline"><a class="tocxref" href="#diagrams-and-examples"><span class="secno">1.2 </span>Diagrams and Examples</a></li><li class="tocline"><a class="tocxref" href="#conformance"><span class="secno">1.3 </span>Conformance</a></li></ul></li><li class="tocline"><a class="tocxref" href="#web-annotation-ontology"><span class="secno">2. </span>Web Annotation Ontology</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#classes"><span class="secno">2.1 </span>Classes</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#annotation"><span class="secno">2.1.1 </span>Annotation</a></li><li class="tocline"><a class="tocxref" href="#choice"><span class="secno">2.1.2 </span>Choice</a></li><li class="tocline"><a class="tocxref" href="#content"><span class="secno">2.1.3 </span>Content</a></li><li class="tocline"><a class="tocxref" href="#cssselector"><span class="secno">2.1.4 </span>CssSelector</a></li><li class="tocline"><a class="tocxref" href="#cssstyle"><span class="secno">2.1.5 </span>CssStyle</a></li><li class="tocline"><a class="tocxref" href="#datapositionselector"><span class="secno">2.1.6 </span>DataPositionSelector</a></li><li class="tocline"><a class="tocxref" href="#fragmentselector"><span class="secno">2.1.7 </span>FragmentSelector</a></li><li class="tocline"><a class="tocxref" href="#httprequeststate"><span class="secno">2.1.8 </span>HttpRequestState</a></li><li class="tocline"><a class="tocxref" href="#motivation"><span class="secno">2.1.9 </span>Motivation</a></li><li class="tocline"><a class="tocxref" href="#rangeselector"><span class="secno">2.1.10 </span>RangeSelector</a></li><li class="tocline"><a class="tocxref" href="#resourceselection"><span class="secno">2.1.11 </span>ResourceSelection</a></li><li class="tocline"><a class="tocxref" href="#selector"><span class="secno">2.1.12 </span>Selector</a></li><li class="tocline"><a class="tocxref" href="#specificresource"><span class="secno">2.1.13 </span>SpecificResource</a></li><li class="tocline"><a class="tocxref" href="#state"><span class="secno">2.1.14 </span>State</a></li><li class="tocline"><a class="tocxref" href="#style"><span class="secno">2.1.15 </span>Style</a></li><li class="tocline"><a class="tocxref" href="#svgselector"><span class="secno">2.1.16 </span>SvgSelector</a></li><li class="tocline"><a class="tocxref" href="#textpositionselector"><span class="secno">2.1.17 </span>TextPositionSelector</a></li><li class="tocline"><a class="tocxref" href="#textquoteselector"><span class="secno">2.1.18 </span>TextQuoteSelector</a></li><li class="tocline"><a class="tocxref" href="#textualbody"><span class="secno">2.1.19 </span>TextualBody</a></li><li class="tocline"><a class="tocxref" href="#timestate"><span class="secno">2.1.20 </span>TimeState</a></li><li class="tocline"><a class="tocxref" href="#xpathselector"><span class="secno">2.1.21 </span>XPathSelector</a></li></ul></li><li class="tocline"><a class="tocxref" href="#properties"><span class="secno">2.2 </span>Properties</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#annotationservice"><span class="secno">2.2.1 </span>annotationService</a></li><li class="tocline"><a class="tocxref" href="#bodytext"><span class="secno">2.2.2 </span>bodyText</a></li><li class="tocline"><a class="tocxref" href="#cachedsource"><span class="secno">2.2.3 </span>cachedSource</a></li><li class="tocline"><a class="tocxref" href="#canonical"><span class="secno">2.2.4 </span>canonical</a></li><li class="tocline"><a class="tocxref" href="#end"><span class="secno">2.2.5 </span>end</a></li><li class="tocline"><a class="tocxref" href="#exact"><span class="secno">2.2.6 </span>exact</a></li><li class="tocline"><a class="tocxref" href="#hasbody"><span class="secno">2.2.7 </span>hasBody</a></li><li class="tocline"><a class="tocxref" href="#hasendselector"><span class="secno">2.2.8 </span>hasEndSelector</a></li><li class="tocline"><a class="tocxref" href="#haspurpose"><span class="secno">2.2.9 </span>hasPurpose</a></li><li class="tocline"><a class="tocxref" href="#hasscope"><span class="secno">2.2.10 </span>hasScope</a></li><li class="tocline"><a class="tocxref" href="#hasselector"><span class="secno">2.2.11 </span>hasSelector</a></li><li class="tocline"><a class="tocxref" href="#hassource"><span class="secno">2.2.12 </span>hasSource</a></li><li class="tocline"><a class="tocxref" href="#hasstartselector"><span class="secno">2.2.13 </span>hasStartSelector</a></li><li class="tocline"><a class="tocxref" href="#hasstate"><span class="secno">2.2.14 </span>hasState</a></li><li class="tocline"><a class="tocxref" href="#hastarget"><span class="secno">2.2.15 </span>hasTarget</a></li><li class="tocline"><a class="tocxref" href="#motivatedby"><span class="secno">2.2.16 </span>motivatedBy</a></li><li class="tocline"><a class="tocxref" href="#prefix"><span class="secno">2.2.17 </span>prefix</a></li><li class="tocline"><a class="tocxref" href="#refinedby"><span class="secno">2.2.18 </span>refinedBy</a></li><li class="tocline"><a class="tocxref" href="#renderedvia"><span class="secno">2.2.19 </span>renderedVia</a></li><li class="tocline"><a class="tocxref" href="#sourcedate"><span class="secno">2.2.20 </span>sourceDate</a></li><li class="tocline"><a class="tocxref" href="#sourcedateend"><span class="secno">2.2.21 </span>sourceDateEnd</a></li><li class="tocline"><a class="tocxref" href="#sourcedatestart"><span class="secno">2.2.22 </span>sourceDateStart</a></li><li class="tocline"><a class="tocxref" href="#start"><span class="secno">2.2.23 </span>start</a></li><li class="tocline"><a class="tocxref" href="#styleclass"><span class="secno">2.2.24 </span>styleClass</a></li><li class="tocline"><a class="tocxref" href="#styledby"><span class="secno">2.2.25 </span>styledBy</a></li><li class="tocline"><a class="tocxref" href="#suffix"><span class="secno">2.2.26 </span>suffix</a></li><li class="tocline"><a class="tocxref" href="#text"><span class="secno">2.2.27 </span>text</a></li><li class="tocline"><a class="tocxref" href="#via"><span class="secno">2.2.28 </span>via</a></li></ul></li><li class="tocline"><a class="tocxref" href="#named-individuals"><span class="secno">2.3 </span>Named Individuals</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#bookmarking"><span class="secno">2.3.1 </span>bookmarking</a></li><li class="tocline"><a class="tocxref" href="#classifying"><span class="secno">2.3.2 </span>classifying</a></li><li class="tocline"><a class="tocxref" href="#commenting"><span class="secno">2.3.3 </span>commenting</a></li><li class="tocline"><a class="tocxref" href="#describing"><span class="secno">2.3.4 </span>describing</a></li><li class="tocline"><a class="tocxref" href="#editing"><span class="secno">2.3.5 </span>editing</a></li><li class="tocline"><a class="tocxref" href="#highlighting"><span class="secno">2.3.6 </span>highlighting</a></li><li class="tocline"><a class="tocxref" href="#identifying"><span class="secno">2.3.7 </span>identifying</a></li><li class="tocline"><a class="tocxref" href="#linking"><span class="secno">2.3.8 </span>linking</a></li><li class="tocline"><a class="tocxref" href="#moderating"><span class="secno">2.3.9 </span>moderating</a></li><li class="tocline"><a class="tocxref" href="#questioning"><span class="secno">2.3.10 </span>questioning</a></li><li class="tocline"><a class="tocxref" href="#replying"><span class="secno">2.3.11 </span>replying</a></li><li class="tocline"><a class="tocxref" href="#reviewing"><span class="secno">2.3.12 </span>reviewing</a></li><li class="tocline"><a class="tocxref" href="#tagging"><span class="secno">2.3.13 </span>tagging</a></li></ul></li></ul></li><li class="tocline"><a class="tocxref" href="#recommended-ontologies"><span class="secno">3. </span>Recommended Ontologies</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#classes-1"><span class="secno">3.1 </span>Classes</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#as-application"><span class="secno">3.1.1 </span>as:Application</a></li><li class="tocline"><a class="tocxref" href="#as-orderedcollection"><span class="secno">3.1.2 </span>as:OrderedCollection</a></li><li class="tocline"><a class="tocxref" href="#as-orderedcollectionpage"><span class="secno">3.1.3 </span>as:OrderedCollectionPage</a></li><li class="tocline"><a class="tocxref" href="#dctypes-dataset"><span class="secno">3.1.4 </span>dctypes:Dataset</a></li><li class="tocline"><a class="tocxref" href="#dctypes-movingimage"><span class="secno">3.1.5 </span>dctypes:MovingImage</a></li><li class="tocline"><a class="tocxref" href="#dctypes-stillimage"><span class="secno">3.1.6 </span>dctypes:StillImage</a></li><li class="tocline"><a class="tocxref" href="#dctypes-sound"><span class="secno">3.1.7 </span>dctypes:Sound</a></li><li class="tocline"><a class="tocxref" href="#dctypes-text"><span class="secno">3.1.8 </span>dctypes:Text</a></li><li class="tocline"><a class="tocxref" href="#foaf-organization"><span class="secno">3.1.9 </span>foaf:Organization</a></li><li class="tocline"><a class="tocxref" href="#foaf-person"><span class="secno">3.1.10 </span>foaf:Person</a></li><li class="tocline"><a class="tocxref" href="#schema-audience"><span class="secno">3.1.11 </span>schema:Audience</a></li></ul></li><li class="tocline"><a class="tocxref" href="#properties-1"><span class="secno">3.2 </span>Properties</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#as-first"><span class="secno">3.2.1 </span>as:first</a></li><li class="tocline"><a class="tocxref" href="#as-generator"><span class="secno">3.2.2 </span>as:generator</a></li><li class="tocline"><a class="tocxref" href="#as-items"><span class="secno">3.2.3 </span>as:items</a></li><li class="tocline"><a class="tocxref" href="#as-last"><span class="secno">3.2.4 </span>as:last</a></li><li class="tocline"><a class="tocxref" href="#as-next"><span class="secno">3.2.5 </span>as:next</a></li><li class="tocline"><a class="tocxref" href="#as-partof"><span class="secno">3.2.6 </span>as:partOf</a></li><li class="tocline"><a class="tocxref" href="#as-prev"><span class="secno">3.2.7 </span>as:prev</a></li><li class="tocline"><a class="tocxref" href="#as-startindex"><span class="secno">3.2.8 </span>as:startIndex</a></li><li class="tocline"><a class="tocxref" href="#as-totalitems"><span class="secno">3.2.9 </span>as:totalItems</a></li><li class="tocline"><a class="tocxref" href="#dc-format"><span class="secno">3.2.10 </span>dc:format</a></li><li class="tocline"><a class="tocxref" href="#dc-language"><span class="secno">3.2.11 </span>dc:language</a></li><li class="tocline"><a class="tocxref" href="#dcterms-conformsto"><span class="secno">3.2.12 </span>dcterms:conformsTo</a></li><li class="tocline"><a class="tocxref" href="#dcterms-created"><span class="secno">3.2.13 </span>dcterms:created</a></li><li class="tocline"><a class="tocxref" href="#dcterms-creator"><span class="secno">3.2.14 </span>dcterms:creator</a></li><li class="tocline"><a class="tocxref" href="#dcterms-issued"><span class="secno">3.2.15 </span>dcterms:issued</a></li><li class="tocline"><a class="tocxref" href="#dcterms-modified"><span class="secno">3.2.16 </span>dcterms:modified</a></li><li class="tocline"><a class="tocxref" href="#dcterms-rights"><span class="secno">3.2.17 </span>dcterms:rights</a></li><li class="tocline"><a class="tocxref" href="#foaf-homepage"><span class="secno">3.2.18 </span>foaf:homepage</a></li><li class="tocline"><a class="tocxref" href="#foaf-mbox"><span class="secno">3.2.19 </span>foaf:mbox</a></li><li class="tocline"><a class="tocxref" href="#foaf-mbox_sha1sum"><span class="secno">3.2.20 </span>foaf:mbox_sha1sum</a></li><li class="tocline"><a class="tocxref" href="#foaf-name"><span class="secno">3.2.21 </span>foaf:name</a></li><li class="tocline"><a class="tocxref" href="#foaf-nick"><span class="secno">3.2.22 </span>foaf:nick</a></li><li class="tocline"><a class="tocxref" href="#rdf-type"><span class="secno">3.2.23 </span>rdf:type</a></li><li class="tocline"><a class="tocxref" href="#rdf-value"><span class="secno">3.2.24 </span>rdf:value</a></li><li class="tocline"><a class="tocxref" href="#rdfs-label"><span class="secno">3.2.25 </span>rdfs:label</a></li><li class="tocline"><a class="tocxref" href="#schema-audience-1"><span class="secno">3.2.26 </span>schema:audience</a></li></ul></li></ul></li><li class="tocline"><a class="tocxref" href="#extensions"><span class="secno">4. </span>Extensions</a></li><li class="tocline"><a class="tocxref" href="#json-ld-context"><span class="secno">A. </span>JSON-LD Context</a></li><li class="tocline"><a class="tocxref" href="#json-ld-frames"><span class="secno">B. </span>JSON-LD Frames</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#annotation-frame"><span class="secno">B.1 </span>Annotation Frame</a></li><li class="tocline"><a class="tocxref" href="#annotation-collection-frame"><span class="secno">B.2 </span>Annotation Collection Frame</a></li><li class="tocline"><a class="tocxref" href="#annotation-page-frame"><span class="secno">B.3 </span>Annotation Page Frame</a></li></ul></li><li class="tocline"><a class="tocxref" href="#extending-motivations"><span class="secno">C. </span>Extending Motivations</a></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><span class="secno">D. </span>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#references"><span class="secno">E. </span>References</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><span class="secno">E.1 </span>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><span class="secno">E.2 </span>Informative references</a></li></ul></li></ul></nav>
 
-</section><nav id="toc"><h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a><ul class="toc"><li class="tocline"><a href="#namespaces" class="tocxref"><span class="secno">1.1 </span>Namespaces</a></li><li class="tocline"><a href="#diagrams-and-examples" class="tocxref"><span class="secno">1.2 </span>Diagrams and Examples</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">1.3 </span>Conformance</a></li></ul></li><li class="tocline"><a href="#web-annotation-ontology" class="tocxref"><span class="secno">2. </span>Web Annotation Ontology</a><ul class="toc"><li class="tocline"><a href="#classes" class="tocxref"><span class="secno">2.1 </span>Classes</a><ul class="toc"><li class="tocline"><a href="#annotation" class="tocxref"><span class="secno">2.1.1 </span>Annotation</a></li><li class="tocline"><a href="#choice" class="tocxref"><span class="secno">2.1.2 </span>Choice</a></li><li class="tocline"><a href="#content" class="tocxref"><span class="secno">2.1.3 </span>Content</a></li><li class="tocline"><a href="#cssselector" class="tocxref"><span class="secno">2.1.4 </span>CssSelector</a></li><li class="tocline"><a href="#cssstyle" class="tocxref"><span class="secno">2.1.5 </span>CssStyle</a></li><li class="tocline"><a href="#datapositionselector" class="tocxref"><span class="secno">2.1.6 </span>DataPositionSelector</a></li><li class="tocline"><a href="#fragmentselector" class="tocxref"><span class="secno">2.1.7 </span>FragmentSelector</a></li><li class="tocline"><a href="#httprequeststate" class="tocxref"><span class="secno">2.1.8 </span>HttpRequestState</a></li><li class="tocline"><a href="#motivation" class="tocxref"><span class="secno">2.1.9 </span>Motivation</a></li><li class="tocline"><a href="#rangeselector" class="tocxref"><span class="secno">2.1.10 </span>RangeSelector</a></li><li class="tocline"><a href="#resourceselection" class="tocxref"><span class="secno">2.1.11 </span>ResourceSelection</a></li><li class="tocline"><a href="#selector" class="tocxref"><span class="secno">2.1.12 </span>Selector</a></li><li class="tocline"><a href="#specificresource" class="tocxref"><span class="secno">2.1.13 </span>SpecificResource</a></li><li class="tocline"><a href="#state" class="tocxref"><span class="secno">2.1.14 </span>State</a></li><li class="tocline"><a href="#style" class="tocxref"><span class="secno">2.1.15 </span>Style</a></li><li class="tocline"><a href="#svgselector" class="tocxref"><span class="secno">2.1.16 </span>SvgSelector</a></li><li class="tocline"><a href="#textpositionselector" class="tocxref"><span class="secno">2.1.17 </span>TextPositionSelector</a></li><li class="tocline"><a href="#textquoteselector" class="tocxref"><span class="secno">2.1.18 </span>TextQuoteSelector</a></li><li class="tocline"><a href="#textualbody" class="tocxref"><span class="secno">2.1.19 </span>TextualBody</a></li><li class="tocline"><a href="#timestate" class="tocxref"><span class="secno">2.1.20 </span>TimeState</a></li><li class="tocline"><a href="#xpathselector" class="tocxref"><span class="secno">2.1.21 </span>XPathSelector</a></li></ul></li><li class="tocline"><a href="#properties" class="tocxref"><span class="secno">2.2 </span>Properties</a><ul class="toc"><li class="tocline"><a href="#annotationservice" class="tocxref"><span class="secno">2.2.1 </span>annotationService</a></li><li class="tocline"><a href="#bodytext" class="tocxref"><span class="secno">2.2.2 </span>bodyText</a></li><li class="tocline"><a href="#cachedsource" class="tocxref"><span class="secno">2.2.3 </span>cachedSource</a></li><li class="tocline"><a href="#canonical" class="tocxref"><span class="secno">2.2.4 </span>canonical</a></li><li class="tocline"><a href="#end" class="tocxref"><span class="secno">2.2.5 </span>end</a></li><li class="tocline"><a href="#exact" class="tocxref"><span class="secno">2.2.6 </span>exact</a></li><li class="tocline"><a href="#hasbody" class="tocxref"><span class="secno">2.2.7 </span>hasBody</a></li><li class="tocline"><a href="#hasendselector" class="tocxref"><span class="secno">2.2.8 </span>hasEndSelector</a></li><li class="tocline"><a href="#haspurpose" class="tocxref"><span class="secno">2.2.9 </span>hasPurpose</a></li><li class="tocline"><a href="#hasscope" class="tocxref"><span class="secno">2.2.10 </span>hasScope</a></li><li class="tocline"><a href="#hasselector" class="tocxref"><span class="secno">2.2.11 </span>hasSelector</a></li><li class="tocline"><a href="#hassource" class="tocxref"><span class="secno">2.2.12 </span>hasSource</a></li><li class="tocline"><a href="#hasstartselector" class="tocxref"><span class="secno">2.2.13 </span>hasStartSelector</a></li><li class="tocline"><a href="#hasstate" class="tocxref"><span class="secno">2.2.14 </span>hasState</a></li><li class="tocline"><a href="#hastarget" class="tocxref"><span class="secno">2.2.15 </span>hasTarget</a></li><li class="tocline"><a href="#motivatedby" class="tocxref"><span class="secno">2.2.16 </span>motivatedBy</a></li><li class="tocline"><a href="#prefix" class="tocxref"><span class="secno">2.2.17 </span>prefix</a></li><li class="tocline"><a href="#refinedby" class="tocxref"><span class="secno">2.2.18 </span>refinedBy</a></li><li class="tocline"><a href="#renderedvia" class="tocxref"><span class="secno">2.2.19 </span>renderedVia</a></li><li class="tocline"><a href="#sourcedate" class="tocxref"><span class="secno">2.2.20 </span>sourceDate</a></li><li class="tocline"><a href="#sourcedateend" class="tocxref"><span class="secno">2.2.21 </span>sourceDateEnd</a></li><li class="tocline"><a href="#sourcedatestart" class="tocxref"><span class="secno">2.2.22 </span>sourceDateStart</a></li><li class="tocline"><a href="#start" class="tocxref"><span class="secno">2.2.23 </span>start</a></li><li class="tocline"><a href="#styleclass" class="tocxref"><span class="secno">2.2.24 </span>styleClass</a></li><li class="tocline"><a href="#styledby" class="tocxref"><span class="secno">2.2.25 </span>styledBy</a></li><li class="tocline"><a href="#suffix" class="tocxref"><span class="secno">2.2.26 </span>suffix</a></li><li class="tocline"><a href="#text" class="tocxref"><span class="secno">2.2.27 </span>text</a></li><li class="tocline"><a href="#via" class="tocxref"><span class="secno">2.2.28 </span>via</a></li></ul></li><li class="tocline"><a href="#named-individuals" class="tocxref"><span class="secno">2.3 </span>Named Individuals</a><ul class="toc"><li class="tocline"><a href="#bookmarking" class="tocxref"><span class="secno">2.3.1 </span>bookmarking</a></li><li class="tocline"><a href="#classifying" class="tocxref"><span class="secno">2.3.2 </span>classifying</a></li><li class="tocline"><a href="#commenting" class="tocxref"><span class="secno">2.3.3 </span>commenting</a></li><li class="tocline"><a href="#describing" class="tocxref"><span class="secno">2.3.4 </span>describing</a></li><li class="tocline"><a href="#editing" class="tocxref"><span class="secno">2.3.5 </span>editing</a></li><li class="tocline"><a href="#highlighting" class="tocxref"><span class="secno">2.3.6 </span>highlighting</a></li><li class="tocline"><a href="#identifying" class="tocxref"><span class="secno">2.3.7 </span>identifying</a></li><li class="tocline"><a href="#linking" class="tocxref"><span class="secno">2.3.8 </span>linking</a></li><li class="tocline"><a href="#moderating" class="tocxref"><span class="secno">2.3.9 </span>moderating</a></li><li class="tocline"><a href="#questioning" class="tocxref"><span class="secno">2.3.10 </span>questioning</a></li><li class="tocline"><a href="#replying" class="tocxref"><span class="secno">2.3.11 </span>replying</a></li><li class="tocline"><a href="#reviewing" class="tocxref"><span class="secno">2.3.12 </span>reviewing</a></li><li class="tocline"><a href="#tagging" class="tocxref"><span class="secno">2.3.13 </span>tagging</a></li></ul></li></ul></li><li class="tocline"><a href="#recommended-ontologies" class="tocxref"><span class="secno">3. </span>Recommended Ontologies</a><ul class="toc"><li class="tocline"><a href="#classes-1" class="tocxref"><span class="secno">3.1 </span>Classes</a><ul class="toc"><li class="tocline"><a href="#as-application" class="tocxref"><span class="secno">3.1.1 </span>as:Application</a></li><li class="tocline"><a href="#as-orderedcollection" class="tocxref"><span class="secno">3.1.2 </span>as:OrderedCollection</a></li><li class="tocline"><a href="#as-orderedcollectionpage" class="tocxref"><span class="secno">3.1.3 </span>as:OrderedCollectionPage</a></li><li class="tocline"><a href="#dctypes-dataset" class="tocxref"><span class="secno">3.1.4 </span>dctypes:Dataset</a></li><li class="tocline"><a href="#dctypes-movingimage" class="tocxref"><span class="secno">3.1.5 </span>dctypes:MovingImage</a></li><li class="tocline"><a href="#dctypes-stillimage" class="tocxref"><span class="secno">3.1.6 </span>dctypes:StillImage</a></li><li class="tocline"><a href="#dctypes-sound" class="tocxref"><span class="secno">3.1.7 </span>dctypes:Sound</a></li><li class="tocline"><a href="#dctypes-text" class="tocxref"><span class="secno">3.1.8 </span>dctypes:Text</a></li><li class="tocline"><a href="#foaf-organization" class="tocxref"><span class="secno">3.1.9 </span>foaf:Organization</a></li><li class="tocline"><a href="#foaf-person" class="tocxref"><span class="secno">3.1.10 </span>foaf:Person</a></li><li class="tocline"><a href="#schema-audience" class="tocxref"><span class="secno">3.1.11 </span>schema:Audience</a></li></ul></li><li class="tocline"><a href="#properties-1" class="tocxref"><span class="secno">3.2 </span>Properties</a><ul class="toc"><li class="tocline"><a href="#as-first" class="tocxref"><span class="secno">3.2.1 </span>as:first</a></li><li class="tocline"><a href="#as-generator" class="tocxref"><span class="secno">3.2.2 </span>as:generator</a></li><li class="tocline"><a href="#as-items" class="tocxref"><span class="secno">3.2.3 </span>as:items</a></li><li class="tocline"><a href="#as-last" class="tocxref"><span class="secno">3.2.4 </span>as:last</a></li><li class="tocline"><a href="#as-next" class="tocxref"><span class="secno">3.2.5 </span>as:next</a></li><li class="tocline"><a href="#as-partof" class="tocxref"><span class="secno">3.2.6 </span>as:partOf</a></li><li class="tocline"><a href="#as-prev" class="tocxref"><span class="secno">3.2.7 </span>as:prev</a></li><li class="tocline"><a href="#as-startindex" class="tocxref"><span class="secno">3.2.8 </span>as:startIndex</a></li><li class="tocline"><a href="#as-totalitems" class="tocxref"><span class="secno">3.2.9 </span>as:totalItems</a></li><li class="tocline"><a href="#dc-format" class="tocxref"><span class="secno">3.2.10 </span>dc:format</a></li><li class="tocline"><a href="#dc-language" class="tocxref"><span class="secno">3.2.11 </span>dc:language</a></li><li class="tocline"><a href="#dcterms-conformsto" class="tocxref"><span class="secno">3.2.12 </span>dcterms:conformsTo</a></li><li class="tocline"><a href="#dcterms-created" class="tocxref"><span class="secno">3.2.13 </span>dcterms:created</a></li><li class="tocline"><a href="#dcterms-creator" class="tocxref"><span class="secno">3.2.14 </span>dcterms:creator</a></li><li class="tocline"><a href="#dcterms-issued" class="tocxref"><span class="secno">3.2.15 </span>dcterms:issued</a></li><li class="tocline"><a href="#dcterms-modified" class="tocxref"><span class="secno">3.2.16 </span>dcterms:modified</a></li><li class="tocline"><a href="#dcterms-rights" class="tocxref"><span class="secno">3.2.17 </span>dcterms:rights</a></li><li class="tocline"><a href="#foaf-homepage" class="tocxref"><span class="secno">3.2.18 </span>foaf:homepage</a></li><li class="tocline"><a href="#foaf-mbox" class="tocxref"><span class="secno">3.2.19 </span>foaf:mbox</a></li><li class="tocline"><a href="#foaf-mbox_sha1sum" class="tocxref"><span class="secno">3.2.20 </span>foaf:mbox_sha1sum</a></li><li class="tocline"><a href="#foaf-name" class="tocxref"><span class="secno">3.2.21 </span>foaf:name</a></li><li class="tocline"><a href="#foaf-nick" class="tocxref"><span class="secno">3.2.22 </span>foaf:nick</a></li><li class="tocline"><a href="#rdf-type" class="tocxref"><span class="secno">3.2.23 </span>rdf:type</a></li><li class="tocline"><a href="#rdf-value" class="tocxref"><span class="secno">3.2.24 </span>rdf:value</a></li><li class="tocline"><a href="#rdfs-label" class="tocxref"><span class="secno">3.2.25 </span>rdfs:label</a></li><li class="tocline"><a href="#schema-audience-1" class="tocxref"><span class="secno">3.2.26 </span>schema:audience</a></li></ul></li></ul></li><li class="tocline"><a href="#extensions" class="tocxref"><span class="secno">4. </span>Extensions</a></li><li class="tocline"><a href="#json-ld-context" class="tocxref"><span class="secno">A. </span>JSON-LD Context</a></li><li class="tocline"><a href="#json-ld-frames" class="tocxref"><span class="secno">B. </span>JSON-LD Frames</a><ul class="toc"><li class="tocline"><a href="#annotation-frame" class="tocxref"><span class="secno">B.1 </span>Annotation Frame</a></li><li class="tocline"><a href="#annotation-collection-frame" class="tocxref"><span class="secno">B.2 </span>Annotation Collection Frame</a></li><li class="tocline"><a href="#annotation-page-frame" class="tocxref"><span class="secno">B.3 </span>Annotation Page Frame</a></li></ul></li><li class="tocline"><a href="#extending-motivations" class="tocxref"><span class="secno">C. </span>Extending Motivations</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">D. </span>Acknowledgements</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">E. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">E.1 </span>Normative references</a></li><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">E.2 </span>Informative references</a></li></ul></li></ul></nav>
 
 
-
-<section class="informative" id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2><p><em>This section is non-normative.</em></p>
+<section property="bibo:hasPart" resource="#introduction" typeof="bibo:Chapter" id="introduction" class="informative">
+<!--OddPage--><h2 resource="#h-introduction" id="h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2><p><em>This section is non-normative.</em></p>
 
 <p>
 The specification is divided into two major sections: the terms defined in the Web Annotation ontology, and terms from other ontologies used in the model.
 </p>
 
 <p>
-Each class lists the recommendations from the model for the <em class="rfc2119" title="REQUIRED">REQUIRED</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> and <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> object and data properties for instances of the class.  Instances may, of course, be the subject of any other triples that implementers find useful, however there is no expectation of interoperability in these cases.
+Each class lists the recommendations from the model for the <em title="REQUIRED" class="rfc2119">REQUIRED</em>, <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> and <em title="OPTIONAL" class="rfc2119">OPTIONAL</em> object and data properties for instances of the class.  Instances may, of course, be the subject of any other triples that implementers find useful, however there is no expectation of interoperability in these cases.
 </p>
 
-<section id="namespaces" typeof="bibo:Chapter" resource="#namespaces" property="bibo:hasPart">
-  <h3 id="h-namespaces" resource="#h-namespaces"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Namespaces</span></h3>
+<section property="bibo:hasPart" resource="#namespaces" typeof="bibo:Chapter" id="namespaces">
+  <h3 resource="#h-namespaces" id="h-namespaces"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Namespaces</span></h3>
 
   <table class="model">
 <tbody><tr><th>Prefix</th><th>Namespace</th><th>Description</th></tr>
 <tr><td>oa</td><td>http://www.w3.org/ns/oa#</td> <td>The Web Annotation Data Model</td></tr>
-<tr><td>as</td><td>http://www.w3.org/ns/activitystreams#</td><td>[<cite><a class="bibref" href="#bib-activitystreams-vocabulary">activitystreams-vocabulary</a></cite>]</td></tr>
-<tr><td>dc</td><td>http://purl.org/dc/elements/1.1/</td><td>[<cite><a class="bibref" href="#bib-DC11">DC11</a></cite>]</td></tr>
-<tr><td>dcterms</td><td>http://purl.org/dc/terms/</td><td>[<cite><a class="bibref" href="#bib-DC-TERMS">DC-TERMS</a></cite>]</td></tr>
-<tr><td>dctypes</td><td>http://purl.org/dc/dcmitype/</td><td>[<cite><a class="bibref" href="#bib-DC-TERMS">DC-TERMS</a></cite>]</td></tr>
-<tr><td>foaf</td><td>http://xmlns.com/foaf/0.1/</td><td>[<cite><a class="bibref" href="#bib-FOAF">FOAF</a></cite>]</td></tr>
-<tr><td>rdf</td><td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td><td>[<cite><a class="bibref" href="#bib-rdf-schema">rdf-schema</a></cite>]</td></tr>
-<tr><td>rdfs</td><td>http://www.w3.org/2000/01/rdf-schema#</td><td>[<cite><a class="bibref" href="#bib-rdf-schema">rdf-schema</a></cite>]</td></tr>
+<tr><td>as</td><td>http://www.w3.org/ns/activitystreams#</td><td>[<cite><a href="#bib-activitystreams-vocabulary" class="bibref">activitystreams-vocabulary</a></cite>]</td></tr>
+<tr><td>dc</td><td>http://purl.org/dc/elements/1.1/</td><td>[<cite><a href="#bib-DC11" class="bibref">DC11</a></cite>]</td></tr>
+<tr><td>dcterms</td><td>http://purl.org/dc/terms/</td><td>[<cite><a href="#bib-DC-TERMS" class="bibref">DC-TERMS</a></cite>]</td></tr>
+<tr><td>dctypes</td><td>http://purl.org/dc/dcmitype/</td><td>[<cite><a href="#bib-DC-TERMS" class="bibref">DC-TERMS</a></cite>]</td></tr>
+<tr><td>foaf</td><td>http://xmlns.com/foaf/0.1/</td><td>[<cite><a href="#bib-FOAF" class="bibref">FOAF</a></cite>]</td></tr>
+<tr><td>rdf</td><td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td><td>[<cite><a href="#bib-rdf-schema" class="bibref">rdf-schema</a></cite>]</td></tr>
+<tr><td>rdfs</td><td>http://www.w3.org/2000/01/rdf-schema#</td><td>[<cite><a href="#bib-rdf-schema" class="bibref">rdf-schema</a></cite>]</td></tr>
 <tr><td>schema</td><td>http://schema.org/</td><td><a href="http://schema.org/">schema.org</a></td></tr>
-<tr><td>skos</td><td>http://www.w3.org/2004/02/skos/core#</td><td>[<cite><a class="bibref" href="#bib-skos-reference">skos-reference</a></cite>]</td></tr>
-<tr><td>xsd</td><td>http://www.w3.org/2001/XMLSchema#</td><td>[<cite><a class="bibref" href="#bib-xmlschema-2">xmlschema-2</a></cite>]</td></tr>
+<tr><td>skos</td><td>http://www.w3.org/2004/02/skos/core#</td><td>[<cite><a href="#bib-skos-reference" class="bibref">skos-reference</a></cite>]</td></tr>
+<tr><td>xsd</td><td>http://www.w3.org/2001/XMLSchema#</td><td>[<cite><a href="#bib-xmlschema-2" class="bibref">xmlschema-2</a></cite>]</td></tr>
 </tbody></table>
 
 </section>
 
-<section id="diagrams-and-examples" typeof="bibo:Chapter" resource="#diagrams-and-examples" property="bibo:hasPart">
-<h3 id="h-diagrams-and-examples" resource="#h-diagrams-and-examples"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Diagrams and Examples</span></h3>
+<section property="bibo:hasPart" resource="#diagrams-and-examples" typeof="bibo:Chapter" id="diagrams-and-examples">
+<h3 resource="#h-diagrams-and-examples" id="h-diagrams-and-examples"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Diagrams and Examples</span></h3>
 
 <p>
-The examples throughout the document are serialized as [<cite><a class="bibref" href="#bib-Turtle">Turtle</a></cite>] with the prefixes taken from the namespace declarations given in <a href="#namespaces">Appendix A</a>.  The examples are informative only.
+The examples throughout the document are serialized as [<cite><a href="#bib-Turtle" class="bibref">Turtle</a></cite>] with the prefixes taken from the namespace declarations given in <a href="#namespaces">Appendix A</a>.  The examples are informative only.
 </p>
 
 <p>The diagrams use the following style</p>
@@ -541,40 +555,40 @@ The examples throughout the document are serialized as [<cite><a class="bibref" 
 <li>Conceptual resource boundaries not explicit in the model, but considered important for understanding, are depicted as grey dashed boxes around the components.  They are used to convey spatial parts of the diagrams and may be safely ignored.</li>
 </ul>
 
-<div class="issue" id="issue-2"><div class="issue-title marker" aria-level="4" role="heading" id="h-issue2"><span>Issue 2</span></div><div class="">
+<div id="issue-2" class="issue"><div id="h-issue2" role="heading" aria-level="4" class="issue-title marker"><span>Issue 2</span></div><div class="">
 The diagrams have yet to be completed (<a href="https://github.com/w3c/web-annotation/issues/131">Github Issue</a>).
 </div></div>
 
 </section>
 
-<section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart"><h3 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
+<section property="bibo:hasPart" resource="#conformance" typeof="bibo:Chapter" id="conformance"><h3 resource="#h-conformance" id="h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
 <p>
   As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
   and notes in this specification are non-normative. Everything else in this specification is
   normative.
 </p>
-<p id="respecRFC2119">The key words <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="OPTIONAL">OPTIONAL</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="REQUIRED">REQUIRED</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are
-  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+<p id="respecRFC2119">The key words <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="OPTIONAL">OPTIONAL</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="REQUIRED">REQUIRED</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are 
+  to be interpreted as described in [<cite><a href="#bib-RFC2119" class="bibref">RFC2119</a></cite>].
 </p>
 
 </section>
 </section> <!-- End Introduction -->
 
-<section id="web-annotation-ontology" typeof="bibo:Chapter" resource="#web-annotation-ontology" property="bibo:hasPart">
-  <!--OddPage--><h2 id="h-web-annotation-ontology" resource="#h-web-annotation-ontology"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Ontology</span></h2>
+<section property="bibo:hasPart" resource="#web-annotation-ontology" typeof="bibo:Chapter" id="web-annotation-ontology">
+  <!--OddPage--><h2 resource="#h-web-annotation-ontology" id="h-web-annotation-ontology"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Ontology</span></h2>
 
 The namespace used for the Web Annotation Ontology is:
 <code>http://www.w3.org/ns/oa#</code>
 
-<section id="classes" typeof="bibo:Chapter" resource="#classes" property="bibo:hasPart">
-<h3 id="h-classes" resource="#h-classes"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1 </span>Classes</span></h3>
+<section property="bibo:hasPart" resource="#classes" typeof="bibo:Chapter" id="classes">
+<h3 resource="#h-classes" id="h-classes"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1 </span>Classes</span></h3>
 
 <div class="termtoc">
 <a href="#annotation">Annotation</a> | <a href="#choice">Choice</a> | <a href="#content">Content</a> | <a href="#cssselector">CssSelector</a> | <a href="#cssstyle">CssStyle</a> | <a href="#datapositionselector">DataPositionSelector</a> | <a href="#fragmentselector">FragmentSelector</a> | <a href="#httprequeststate">HttpRequestState</a> | <a href="#motivation">Motivation</a> | <a href="#rangeselector">RangeSelector</a> | <a href="#resourceselection">ResourceSelection</a> | <a href="#selector">Selector</a> | <a href="#specificresource">SpecificResource</a> | <a href="#state">State</a> | <a href="#style">Style</a> | <a href="#svgselector">SvgSelector</a> | <a href="#textpositionselector">TextPositionSelector</a> | <a href="#textquoteselector">TextQuoteSelector</a> | <a href="#textualbody">TextualBody</a> | <a href="#timestate">TimeState</a> | <a href="#xpathselector">XPathSelector</a>
 </div>
 
-<section class="term" id="annotation" typeof="bibo:Chapter" resource="#annotation" property="bibo:hasPart">
-  <h4 id="h-annotation" resource="#h-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.1 </span>Annotation</span></h4>
+<section property="bibo:hasPart" resource="#annotation" typeof="bibo:Chapter" id="annotation" class="term">
+  <h4 resource="#h-annotation" id="h-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.1 </span>Annotation</span></h4>
   <p>The class for Web Annotations.</p>
   <div class="tech">
     <ul>
@@ -588,7 +602,7 @@ The namespace used for the Web Annotation Ontology is:
     <img src="images/examples/annotation.png" alt="oa:Annotation with properties" longdesc="#example_anno">
   </div>
   <div id="example_anno">
-    <div class="example"><div class="example-title marker"><span>Example 1</span><span style="text-transform: none">: oa:Annotation</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 1</span><span style="text-transform: none">: oa:Annotation</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">post1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:commenting ;
@@ -597,8 +611,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="choice" typeof="bibo:Chapter" resource="#choice" property="bibo:hasPart">
-  <h4 id="h-choice" resource="#h-choice"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.2 </span>Choice</span></h4>
+<section property="bibo:hasPart" resource="#choice" typeof="bibo:Chapter" id="choice" class="term">
+  <h4 resource="#h-choice" id="h-choice"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.2 </span>Choice</span></h4>
   <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that it should select one of the resources in the <code>as:items</code> list to use, rather than all of them.  This is typically used to provide a choice of resources to render to the user, based on further supplied properties.  If the consuming application cannot determine the user's preference, then it should use the first in the list.</p>
   <div class="tech">
     <ul>
@@ -611,7 +625,7 @@ The namespace used for the Web Annotation Ontology is:
     <img src="images/examples/choice.png" alt="oa:Choice with list of items" longdesc="#example_choice">
   </div>
   <div id="example_choice">
-    <div class="example"><div class="example-title marker"><span>Example 2</span><span style="text-transform: none">: oa:Choice</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno2</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 2</span><span style="text-transform: none">: oa:Choice</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno2</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">site1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasBody [
         a oa:Choice ;
@@ -622,8 +636,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="content" typeof="bibo:Chapter" resource="#content" property="bibo:hasPart">
-  <h4 id="h-content" resource="#h-content"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.3 </span>Content</span></h4>
+<section property="bibo:hasPart" resource="#content" typeof="bibo:Chapter" id="content" class="term">
+  <h4 resource="#h-content" id="h-content"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.3 </span>Content</span></h4>
   <p>The class for resources embedded in the Annotation graph, other than for textual content that is the object of the <code>hasBody</code> relationship.</p>
   <div class="tech">
     <ul>
@@ -635,7 +649,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 3</span><span style="text-transform: none">: oa:Content</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno3</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 3</span><span style="text-transform: none">: oa:Content</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno3</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">body1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:styledBy [
         a oa:CssStyle, oa:Content ;
@@ -647,8 +661,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="cssselector" typeof="bibo:Chapter" resource="#cssselector" property="bibo:hasPart">
-  <h4 id="h-cssselector" resource="#h-cssselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.4 </span>CssSelector</span></h4>
+<section property="bibo:hasPart" resource="#cssselector" typeof="bibo:Chapter" id="cssselector" class="term">
+  <h4 resource="#h-cssselector" id="h-cssselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.4 </span>CssSelector</span></h4>
   <p>A CssSelector describes a Segment of interest in a representation that conforms to the Document Object Model through the use of the CSS selector specification.</p>
   <div class="tech">
     <ul>
@@ -657,18 +671,18 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 4</span></div><pre class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno4</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 4</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno4</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
         oa:hasSelector [
             a oa:CssSelector ;
-            rdf:value "#elemid &gt; .elemclass + p" ] ] . </span></pre></div>
+            rdf:value "#elemid &gt; .elemclass + p" ] ] .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="cssstyle" typeof="bibo:Chapter" resource="#cssstyle" property="bibo:hasPart">
-  <h4 id="h-cssstyle" resource="#h-cssstyle"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.5 </span>CssStyle</span></h4>
+<section property="bibo:hasPart" resource="#cssstyle" typeof="bibo:Chapter" id="cssstyle" class="term">
+  <h4 resource="#h-cssstyle" id="h-cssstyle"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.5 </span>CssStyle</span></h4>
   <p>A resource which describes styles for resources participating in the Annotation using CSS.</p>
   <div class="tech">
     <ul>
@@ -677,7 +691,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 5</span></div><pre class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno5</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 5</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno5</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:styledBy </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">style1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
@@ -688,8 +702,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="datapositionselector" typeof="bibo:Chapter" resource="#datapositionselector" property="bibo:hasPart">
-  <h4 id="h-datapositionselector" resource="#h-datapositionselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.6 </span>DataPositionSelector</span></h4>
+<section property="bibo:hasPart" resource="#datapositionselector" typeof="bibo:Chapter" id="datapositionselector" class="term">
+  <h4 resource="#h-datapositionselector" id="h-datapositionselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.6 </span>DataPositionSelector</span></h4>
   <p>DataPositionSelector describes a range of data by recording the start and end positions of the selection in the stream. Position 0 would be immediately before the first byte, position 1 would be immediately before the second byte, and so on. The start byte is thus included in the list, but the end byte is not.</p>
   <div class="tech">
     <ul>
@@ -699,7 +713,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: oa:DataPositionSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno6</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: oa:DataPositionSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno6</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">diskimg1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -710,8 +724,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="fragmentselector" typeof="bibo:Chapter" resource="#fragmentselector" property="bibo:hasPart">
-  <h4 id="h-fragmentselector" resource="#h-fragmentselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.7 </span>FragmentSelector</span></h4>
+<section property="bibo:hasPart" resource="#fragmentselector" typeof="bibo:Chapter" id="fragmentselector" class="term">
+  <h4 resource="#h-fragmentselector" id="h-fragmentselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.7 </span>FragmentSelector</span></h4>
   <p>The FragmentSelector class is used to record the segment of a representation using the URI fragment specification defined by the representation's media type.</p>
   <div class="tech">
     <ul>
@@ -722,7 +736,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: oa:FragmentSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno7</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: oa:FragmentSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno7</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasBody [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">video1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -734,9 +748,9 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="httprequeststate" typeof="bibo:Chapter" resource="#httprequeststate" property="bibo:hasPart">
-  <h4 id="h-httprequeststate" resource="#h-httprequeststate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.8 </span>HttpRequestState</span></h4>
-  <p>The HttpRequestState class is used to record the HTTP request headers that a client <em class="rfc2119" title="SHOULD">SHOULD</em> use to request the correct representation from the resource. </p>
+<section property="bibo:hasPart" resource="#httprequeststate" typeof="bibo:Chapter" id="httprequeststate" class="term">
+  <h4 resource="#h-httprequeststate" id="h-httprequeststate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.8 </span>HttpRequestState</span></h4>
+  <p>The HttpRequestState class is used to record the HTTP request headers that a client <em title="SHOULD" class="rfc2119">SHOULD</em> use to request the correct representation from the resource. </p>
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#HttpRequestState</li>
@@ -745,18 +759,18 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: oa:HttpRequestState</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno8</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: oa:HttpRequestState</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno8</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">description1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget  [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">target1</span><span class="tag">&gt;</span><span class="pln"> ;
         oa:hasState [
             a oa:HttpRequestState ;
-            rdf:value "Accept: text/plain" ] ] .</span></pre></div>
+            rdf:value "Accept: application/pdf" ] ] .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="motivation" typeof="bibo:Chapter" resource="#motivation" property="bibo:hasPart">
-  <h4 id="h-motivation" resource="#h-motivation"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.9 </span>Motivation</span></h4>
+<section property="bibo:hasPart" resource="#motivation" typeof="bibo:Chapter" id="motivation" class="term">
+  <h4 resource="#h-motivation" id="h-motivation"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.9 </span>Motivation</span></h4>
   <p>The Motivation class is used to record the user's intent or motivation for the creation of the Annotation, or the inclusion of the body or target, that it is associated with.</p>
   <div class="tech">
     <ul>
@@ -766,15 +780,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: oa:Motivation</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno9</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: oa:Motivation</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno9</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">description1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:describing .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="rangeselector" typeof="bibo:Chapter" resource="#rangeselector" property="bibo:hasPart">
-  <h4 id="h-rangeselector" resource="#h-rangeselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.10 </span>RangeSelector</span></h4>
+<section property="bibo:hasPart" resource="#rangeselector" typeof="bibo:Chapter" id="rangeselector" class="term">
+  <h4 resource="#h-rangeselector" id="h-rangeselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.10 </span>RangeSelector</span></h4>
   <p>A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors. The selection consists of everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it.</p>
   <div class="tech">
     <ul>
@@ -784,7 +798,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 10</span><span style="text-transform: none">: oa:RangeSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno10</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 10</span><span style="text-transform: none">: oa:RangeSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno10</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -799,8 +813,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="resourceselection" typeof="bibo:Chapter" resource="#resourceselection" property="bibo:hasPart">
-  <h4 id="h-resourceselection" resource="#h-resourceselection"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.11 </span>ResourceSelection</span></h4>
+<section property="bibo:hasPart" resource="#resourceselection" typeof="bibo:Chapter" id="resourceselection" class="term">
+  <h4 resource="#h-resourceselection" id="h-resourceselection"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.11 </span>ResourceSelection</span></h4>
   <p>Instances of the ResourceSelection class identify part (described by an oa:Selector) of another resource (referenced with oa:hasSource), possibly from a particular representation of a resource (described by an oa:State). Please note that ResourceSelection is not used directly in the Web Annotation model, but is provided as a separate class for further application profiles to use, separate from oa:SpecificResource which has many Annotation specific features.</p>
   <div class="tech">
     <ul>
@@ -810,7 +824,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 11</span><span style="text-transform: none">: oa:ResourceSelection</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">cell1</span><span class="tag">&gt;</span><span class="pln"> a oa:ResourceSelection ;
+    <div class="example"><div class="example-title marker"><span>Example 11</span><span style="text-transform: none">: oa:ResourceSelection</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">cell1</span><span class="tag">&gt;</span><span class="pln"> a oa:ResourceSelection ;
     oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasSelector [
       a oa:XPathSelector ;
@@ -818,8 +832,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="selector" typeof="bibo:Chapter" resource="#selector" property="bibo:hasPart">
-  <h4 id="h-selector" resource="#h-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.12 </span>Selector</span></h4>
+<section property="bibo:hasPart" resource="#selector" typeof="bibo:Chapter" id="selector" class="term">
+  <h4 resource="#h-selector" id="h-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.12 </span>Selector</span></h4>
   <p>A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. This class is not used directly in the Annotation model, only its subclasses.</p>
   <div class="tech">
     <ul>
@@ -828,13 +842,13 @@ The namespace used for the Web Annotation Ontology is:
       <li><strong>Range Of:</strong> <a href="#hasselector">oa:hasSelector</a></li>
     </ul>
   </div>
-  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note2"><span>Note</span><span style="text-transform: none">: oa:Selector</span></div><div class="">
+  <div class="note"><div id="h-note2" role="heading" aria-level="5" class="note-title marker"><span>Note</span><span style="text-transform: none">: oa:Selector</span></div><div class="">
     No example is given. The class should only be used to derive subClasses.
   </div></div>
 </section>
 
-<section class="term" id="specificresource" typeof="bibo:Chapter" resource="#specificresource" property="bibo:hasPart">
-  <h4 id="h-specificresource" resource="#h-specificresource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.13 </span>SpecificResource</span></h4>
+<section property="bibo:hasPart" resource="#specificresource" typeof="bibo:Chapter" id="specificresource" class="term">
+  <h4 resource="#h-specificresource" id="h-specificresource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.13 </span>SpecificResource</span></h4>
   <p>Instances of the SpecificResource class identify part of another resource (referenced with oa:hasSource), a particular representation of a resource, a resource with styling hints for renders, or any combination of these, as used within an Annotation.</p>
   <div class="tech">
     <ul>
@@ -846,7 +860,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 12</span><span style="text-transform: none">: oa:SpecificResource</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno11</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 12</span><span style="text-transform: none">: oa:SpecificResource</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno11</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> .
 
@@ -855,8 +869,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="state" typeof="bibo:Chapter" resource="#state" property="bibo:hasPart">
-  <h4 id="h-state" resource="#h-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.14 </span>State</span></h4>
+<section property="bibo:hasPart" resource="#state" typeof="bibo:Chapter" id="state" class="term">
+  <h4 resource="#h-state" id="h-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.14 </span>State</span></h4>
   <p>A State describes the intended state of a resource as applied to the particular Annotation, and thus provides the information needed to retrieve the correct representation of that resource.</p>
   <div class="tech">
     <ul>
@@ -865,13 +879,13 @@ The namespace used for the Web Annotation Ontology is:
       <li><strong>Range Of:</strong> <a href="#hasstate">oa:hasState</a></li>
     </ul>
   </div>
-  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note3"><span>Note</span><span style="text-transform: none">: oa:State</span></div><div class="">
+  <div class="note"><div id="h-note3" role="heading" aria-level="5" class="note-title marker"><span>Note</span><span style="text-transform: none">: oa:State</span></div><div class="">
     No example is given. The class should only be used in further ontologies to derive subclasses.
   </div></div>
 </section>
 
-<section class="term" id="style" typeof="bibo:Chapter" resource="#style" property="bibo:hasPart">
-  <h4 id="h-style" resource="#h-style"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.15 </span>Style</span></h4>
+<section property="bibo:hasPart" resource="#style" typeof="bibo:Chapter" id="style" class="term">
+  <h4 resource="#h-style" id="h-style"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.15 </span>Style</span></h4>
   <p>A Style describes the intended styling of a resource as applied to the particular Annotation, and thus provides the information ndeed to ensure that rendering is consistent across implementations.</p>
   <div class="tech">
     <ul>
@@ -880,13 +894,13 @@ The namespace used for the Web Annotation Ontology is:
       <li><strong>Range Of:</strong> <a href="#styledby">oa:styledBy</a></li>
     </ul>
   </div>
-  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note4"><span>Note</span><span style="text-transform: none">: oa:Style</span></div><div class="">
+  <div class="note"><div id="h-note4" role="heading" aria-level="5" class="note-title marker"><span>Note</span><span style="text-transform: none">: oa:Style</span></div><div class="">
     No example is given. The class should only be used in further ontologies to derive subclasses.
   </div></div>
 </section>
 
-<section class="term" id="svgselector" typeof="bibo:Chapter" resource="#svgselector" property="bibo:hasPart">
-  <h4 id="h-svgselector" resource="#h-svgselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.16 </span>SvgSelector</span></h4>
+<section property="bibo:hasPart" resource="#svgselector" typeof="bibo:Chapter" id="svgselector" class="term">
+  <h4 resource="#h-svgselector" id="h-svgselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.16 </span>SvgSelector</span></h4>
   <p>An SvgSelector defines an area through the use of the Scalable Vector Graphics [SVG] standard. This allows the user to select a non-rectangular area of the content, such as a circle or polygon by describing the region using SVG. The SVG may be either embedded within the Annotation or referenced as an External Resource.</p>
   <div class="tech">
     <ul>
@@ -897,7 +911,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 13</span><span style="text-transform: none">: oa:SvgSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno12</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 13</span><span style="text-transform: none">: oa:SvgSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno12</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">road1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">map1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -908,8 +922,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="textpositionselector" typeof="bibo:Chapter" resource="#textpositionselector" property="bibo:hasPart">
-  <h4 id="h-textpositionselector" resource="#h-textpositionselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.17 </span>TextPositionSelector</span></h4>
+<section property="bibo:hasPart" resource="#textpositionselector" typeof="bibo:Chapter" id="textpositionselector" class="term">
+  <h4 resource="#h-textpositionselector" id="h-textpositionselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.17 </span>TextPositionSelector</span></h4>
   <p>The TextPositionSelector describes a range of text by recording the start and end positions of the selection in the stream. Position 0 would be immediately before the first character, position 1 would be immediately before the second character, and so on.</p>
   <div class="tech">
     <ul>
@@ -919,19 +933,19 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 14</span><span style="text-transform: none">: oa:TextPositionSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno13</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 14</span><span style="text-transform: none">: oa:TextPositionSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno13</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">ebook1</span><span class="tag">&gt;</span><span class="pln"> ;
         oa:hasSelector [
             a oa:TextPositionSelector ;
             oa:start 412 ;
-            oa:end 795 ] ] .      </span></pre></div>
+            oa:end 795 ] ] .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="textquoteselector" typeof="bibo:Chapter" resource="#textquoteselector" property="bibo:hasPart">
-  <h4 id="h-textquoteselector" resource="#h-textquoteselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.18 </span>TextQuoteSelector</span></h4>
+<section property="bibo:hasPart" resource="#textquoteselector" typeof="bibo:Chapter" id="textquoteselector" class="term">
+  <h4 resource="#h-textquoteselector" id="h-textquoteselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.18 </span>TextQuoteSelector</span></h4>
   <p>The TextQuoteSelector describes a range of text by copying it, and including some of the text immediately before (a prefix) and after (a suffix) it to distinguish between multiple copies of the same sequence of characters.</p>
   <div class="tech">
     <ul>
@@ -942,7 +956,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 15</span><span style="text-transform: none">: oa:TextQuoteSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno14</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 15</span><span style="text-transform: none">: oa:TextQuoteSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno14</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -950,12 +964,12 @@ The namespace used for the Web Annotation Ontology is:
             a oa:TextQuoteSelector ;
             oa:exact "anotation" ;
             oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .      </span></pre></div>
+            oa:suffix " that has some" ] ] .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="textualbody" typeof="bibo:Chapter" resource="#textualbody" property="bibo:hasPart">
-  <h4 id="h-textualbody" resource="#h-textualbody"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.19 </span>TextualBody</span></h4>
+<section property="bibo:hasPart" resource="#textualbody" typeof="bibo:Chapter" id="textualbody" class="term">
+  <h4 resource="#h-textualbody" id="h-textualbody"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.19 </span>TextualBody</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -968,7 +982,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 16</span><span style="text-transform: none">: oa:TextualBody</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno15</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 16</span><span style="text-transform: none">: oa:TextualBody</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno15</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">photo1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasBody [
         a oa:TextualBody;
@@ -978,8 +992,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="timestate" typeof="bibo:Chapter" resource="#timestate" property="bibo:hasPart">
-  <h4 id="h-timestate" resource="#h-timestate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.20 </span>TimeState</span></h4>
+<section property="bibo:hasPart" resource="#timestate" typeof="bibo:Chapter" id="timestate" class="term">
+  <h4 resource="#h-timestate" id="h-timestate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.20 </span>TimeState</span></h4>
   <p>A TimeState records the time at which the resource's state is appropriate for the Annotation, typically the time that the Annotation was created and/or a link to a persistent copy of the current version.</p>
   <div class="tech">
     <ul>
@@ -990,96 +1004,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 17</span><span style="text-transform: none">: oa:TimeState</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno16</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:cachedSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">copy1</span><span class="tag">&gt;</span><span class="pln"> ;
-            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .      </span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="xpathselector" typeof="bibo:Chapter" resource="#xpathselector" property="bibo:hasPart">
-  <h4 id="h-xpathselector" resource="#h-xpathselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.21 </span>XPathSelector</span></h4>
-  <p> An XPathSelector is used to select elements and content within a resource that supports the Document Object Model via a specified XPath value.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#XPathSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 18</span><span style="text-transform: none">: oa:TimeState</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno17</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-          a oa:XPathSelector ;
-          rdfs:value "//div[@id='elem1']" ] ] .      </span></pre></div>
-  </div>
-</section>
-
-</section>  <!-- End of oa Classes -->
-
-
-<section id="properties" typeof="bibo:Chapter" resource="#properties" property="bibo:hasPart">
-<h3 id="h-properties" resource="#h-properties"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2 </span>Properties</span></h3>
-
-
-<div class="termtoc">
-<a href="#annotationservice">annotationService</a> | <a href="#bodytext">bodyText</a> | <a href="#cachedsource">cachedSource</a> | <a href="#canonical">canonical</a> | <a href="#end">end</a> | <a href="#exact">exact</a> | <a href="#hasbody">hasBody</a> | <a href="#haspurpose">hasPurpose</a> | <a href="#hasscope">hasScope</a> | <a href="#hasselector">hasSelector</a> | <a href="#hassource">hasSource</a> | <a href="#hasstate">hasState</a> | <a href="#hastarget">hasTarget</a> | <a href="#motivatedby">motivatedBy</a> | <a href="#prefix">prefix</a> | <a href="#refinedby">refinedBy</a> | <a href="#sourcedate">sourceDate</a> | <a href="#sourcedateend">sourceDateEnd</a> | <a href="#sourcedatestart">sourceDateStart</a> | <a href="#start">start</a> | <a href="#styleclass">styleClass</a> | <a href="#styledby">styledBy</a> | <a href="#suffix">suffix</a> | <a href="#text">text</a> | <a href="#via">via</a>
-</div>
-
-<section class="term" id="annotationservice" typeof="bibo:Chapter" resource="#annotationservice" property="bibo:hasPart">
-  <h4 id="h-annotationservice" resource="#h-annotationservice"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.1 </span>annotationService</span></h4>
-  <p>The object of the relationship is the end point of a service that conforms to the [<cite><a class="bibref" href="#bib-annotation-protocol">annotation-protocol</a></cite>], and it may be associated with any resource.  The expectation of asserting the relationship is that the object is the preferred service for maintaining annotations about the subject resource, according to the publisher of the relationship.
-  </p>
-  <p>
-  This relationship is intended to be used both within Linked Data descriptions and as the <code>rel</code> type of a Link, via HTTP Link Headers [<cite><a class="bibref" href="#bib-rfc5988">rfc5988</a></cite>] for binary resources and in HTML &lt;link&gt; elements.  For more information about these, please see the Annotation Protocol specification [<cite><a class="bibref" href="#bib-annotation-protocol">annotation-protocol</a></cite>].
-  </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#annotationService</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 19</span><span style="text-transform: none">: oa:annotationService</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">diagram</span><span class="pln">.</span><span class="atn">jpg</span><span class="tag">&gt;</span><span class="pln"> a dctypes:Image ;
-    oa:annotationService </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">services</span><span class="pun">/</span><span class="atn">annotations</span><span class="tag">/&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="bodytext" typeof="bibo:Chapter" resource="#bodytext" property="bibo:hasPart">
-  <h4 id="h-bodytext" resource="#h-bodytext"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.2 </span>bodyText</span></h4>
-  <p>The object of the predicate is a plain text string to be used as the content of the body of the Annotation.  The value <em class="rfc2119" title="MUST">MUST</em> be an <code>xsd:string</code> and that data type <em class="rfc2119" title="MUST NOT">MUST NOT</em> be expressed in the serialization. Note that language <em class="rfc2119" title="MUST NOT">MUST NOT</em> be associated with the value either as a language tag, as that is only available for <code>rdf:langString</code>.
-  </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#bodyText</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 20</span><span style="text-transform: none">: oa:bodyText</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno18</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:bodyText "Comment text" ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">target1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="cachedsource" typeof="bibo:Chapter" resource="#cachedsource" property="bibo:hasPart">
-  <h4 id="h-cachedsource" resource="#h-cachedsource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.3 </span>cachedSource</span></h4>
-  <p>A object of the relationship is a copy of the Source resource's representation, appropriate for the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#cachedSource</li>
-      <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 21</span></div><pre class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno19</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 17</span><span style="text-transform: none">: oa:TimeState</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno16</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -1090,8 +1015,97 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="canonical" typeof="bibo:Chapter" resource="#canonical" property="bibo:hasPart">
-  <h4 id="h-canonical" resource="#h-canonical"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.4 </span>canonical</span></h4>
+<section property="bibo:hasPart" resource="#xpathselector" typeof="bibo:Chapter" id="xpathselector" class="term">
+  <h4 resource="#h-xpathselector" id="h-xpathselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.21 </span>XPathSelector</span></h4>
+  <p> An XPathSelector is used to select elements and content within a resource that supports the Document Object Model via a specified XPath value.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#XPathSelector</li>
+      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+      <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 18</span><span style="text-transform: none">: oa:TimeState</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno17</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget [
+        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
+        oa:hasSelector [
+          a oa:XPathSelector ;
+          rdfs:value "/html/body/p[2]/table/tr[2]/td[3]/span" ] ] .</span></pre></div>
+  </div>
+</section>
+
+</section>  <!-- End of oa Classes -->
+
+
+<section property="bibo:hasPart" resource="#properties" typeof="bibo:Chapter" id="properties">
+<h3 resource="#h-properties" id="h-properties"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2 </span>Properties</span></h3>
+
+
+<div class="termtoc">
+<a href="#annotationservice">annotationService</a> | <a href="#bodytext">bodyText</a> | <a href="#cachedsource">cachedSource</a> | <a href="#canonical">canonical</a> | <a href="#end">end</a> | <a href="#exact">exact</a> | <a href="#hasbody">hasBody</a> | <a href="#haspurpose">hasPurpose</a> | <a href="#hasscope">hasScope</a> | <a href="#hasselector">hasSelector</a> | <a href="#hassource">hasSource</a> | <a href="#hasstate">hasState</a> | <a href="#hastarget">hasTarget</a> | <a href="#motivatedby">motivatedBy</a> | <a href="#prefix">prefix</a> | <a href="#refinedby">refinedBy</a> | <a href="#sourcedate">sourceDate</a> | <a href="#sourcedateend">sourceDateEnd</a> | <a href="#sourcedatestart">sourceDateStart</a> | <a href="#start">start</a> | <a href="#styleclass">styleClass</a> | <a href="#styledby">styledBy</a> | <a href="#suffix">suffix</a> | <a href="#text">text</a> | <a href="#via">via</a>
+</div>
+
+<section property="bibo:hasPart" resource="#annotationservice" typeof="bibo:Chapter" id="annotationservice" class="term">
+  <h4 resource="#h-annotationservice" id="h-annotationservice"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.1 </span>annotationService</span></h4>
+  <p>The object of the relationship is the end point of a service that conforms to the [<cite><a href="#bib-annotation-protocol" class="bibref">annotation-protocol</a></cite>], and it may be associated with any resource.  The expectation of asserting the relationship is that the object is the preferred service for maintaining annotations about the subject resource, according to the publisher of the relationship.
+  </p>
+  <p>
+  This relationship is intended to be used both within Linked Data descriptions and as the <code>rel</code> type of a Link, via HTTP Link Headers [<cite><a href="#bib-rfc5988" class="bibref">rfc5988</a></cite>] for binary resources and in HTML &lt;link&gt; elements.  For more information about these, please see the Annotation Protocol specification [<cite><a href="#bib-annotation-protocol" class="bibref">annotation-protocol</a></cite>].
+  </p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#annotationService</li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 19</span><span style="text-transform: none">: oa:annotationService</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">diagram</span><span class="pln">.</span><span class="atn">jpg</span><span class="tag">&gt;</span><span class="pln"> a dctypes:Image ;
+    oa:annotationService </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">services</span><span class="pun">/</span><span class="atn">annotations</span><span class="tag">/&gt;</span><span class="pln"> .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#bodytext" typeof="bibo:Chapter" id="bodytext" class="term">
+  <h4 resource="#h-bodytext" id="h-bodytext"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.2 </span>bodyText</span></h4>
+  <p>The object of the predicate is a plain text string to be used as the content of the body of the Annotation.  The value <em title="MUST" class="rfc2119">MUST</em> be an <code>xsd:string</code> and that data type <em title="MUST NOT" class="rfc2119">MUST NOT</em> be expressed in the serialization. Note that language <em title="MUST NOT" class="rfc2119">MUST NOT</em> be associated with the value either as a language tag, as that is only available for <code>rdf:langString</code>.
+  </p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#bodyText</li>
+      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+      <li><strong>Range:</strong> xsd:string</li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 20</span><span style="text-transform: none">: oa:bodyText</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno18</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:bodyText "Comment text" ;
+    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">target1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#cachedsource" typeof="bibo:Chapter" id="cachedsource" class="term">
+  <h4 resource="#h-cachedsource" id="h-cachedsource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.3 </span>cachedSource</span></h4>
+  <p>A object of the relationship is a copy of the Source resource's representation, appropriate for the Annotation.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#cachedSource</li>
+      <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 21</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno19</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget [
+        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
+        oa:hasState [
+            a oa:TimeState ;
+            oa:cachedSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">copy1</span><span class="tag">&gt;</span><span class="pln"> ;
+            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#canonical" typeof="bibo:Chapter" id="canonical" class="term">
+  <h4 resource="#h-canonical" id="h-canonical"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.4 </span>canonical</span></h4>
   <p>A object of the relationship is the canonical URI that can always be used to deduplicate the Annotation, regardless of the current URI used to access the representation.</p>
   <div class="tech">
     <ul>
@@ -1099,15 +1113,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 22</span></div><pre class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno20</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 22</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno20</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:canonical </span><span class="tag">&lt;urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df&gt;</span><span class="pln"> .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="end" typeof="bibo:Chapter" resource="#end" property="bibo:hasPart">
-  <h4 id="h-end" resource="#h-end"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.5 </span>end</span></h4>
+<section property="bibo:hasPart" resource="#end" typeof="bibo:Chapter" id="end" class="term">
+  <h4 resource="#h-end" id="h-end"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.5 </span>end</span></h4>
   <p>The end property is used to convey the 0-based index of the end position of a range of content.</p>
   <div class="tech">
     <ul>
@@ -1116,7 +1130,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 23</span><span style="text-transform: none">: oa:end</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno21</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 23</span><span style="text-transform: none">: oa:end</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno21</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">diskimg1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -1127,8 +1141,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="exact" typeof="bibo:Chapter" resource="#exact" property="bibo:hasPart">
-  <h4 id="h-exact" resource="#h-exact"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.6 </span>exact</span></h4>
+<section property="bibo:hasPart" resource="#exact" typeof="bibo:Chapter" id="exact" class="term">
+  <h4 resource="#h-exact" id="h-exact"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.6 </span>exact</span></h4>
   <p>The object of the predicate is a copy of the text which is being selected, after normalization.</p>
   <div class="tech">
     <ul>
@@ -1137,231 +1151,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 24</span><span style="text-transform: none">: oa:exact</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno22</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .      </span></pre></div>
-  </div>
-</section>
-
-
-<section class="term" id="hasbody" typeof="bibo:Chapter" resource="#hasbody" property="bibo:hasPart">
-  <h4 id="h-hasbody" resource="#h-hasbody"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.7 </span>hasBody</span></h4>
-  <p>The object of the relationship is a resource that is a body of the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasBody</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 25</span><span style="text-transform: none">: oa:hasBody</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno23</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">post1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .      </span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="hasendselector" typeof="bibo:Chapter" resource="#hasendselector" property="bibo:hasPart">
-  <h4 id="h-hasendselector" resource="#h-hasendselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.8 </span>hasEndSelector</span></h4>
-  <p>The relationship between a RangeSelector and the Selector that describes the end position of the range. </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasEndSelector</li>
-      <li><strong>Domain:</strong> <a href="#rangeselector">oa:RangeSelector</a></li>
-      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 26</span><span style="text-transform: none">: oa:hasEndSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno24</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-          a oa:RangeSelector ;
-          oa:hasStartSelector [
-            a oa:XPathSelector ;
-            rdfs:value "//table[1]/tr[1]/td[2]" ] ;
-          oa:hasEndSelector [
-            a oa:XPathSelector ;
-            rdfs:value "//table[1]/tr[1]/td[4]" ] ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="haspurpose" typeof="bibo:Chapter" resource="#haspurpose" property="bibo:hasPart">
-  <h4 id="h-haspurpose" resource="#h-haspurpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.9 </span>hasPurpose</span></h4>
-  <p>The purpose served by the resource in the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasPurpose</li>
-      <li><strong>Range:</strong> <a href="#motivation">oa:Motivation</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 27</span><span style="text-transform: none">: oa:hasPurpose</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno25</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:bookmarking ;
-    oa:hasBody [
-        oa:text "readme" ;
-        oa:hasPurpose oa:tagging ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="hasscope" typeof="bibo:Chapter" resource="#hasscope" property="bibo:hasPart">
-  <h4 id="h-hasscope" resource="#h-hasscope"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.10 </span>hasScope</span></h4>
-  <p>The scope or context in which the resource is used within the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasScope</li>
-      <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
-      <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#context">as:context</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 28</span><span style="text-transform: none">: oa:hasPurpose</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno26</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:bookmarking ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">logo1</span><span class="pln">.</span><span class="atn">jpg</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasScope </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">index</span><span class="pln">.</span><span class="atn">html</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="hasselector" typeof="bibo:Chapter" resource="#hasselector" property="bibo:hasPart">
-  <h4 id="h-hasselector" resource="#h-hasselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.11 </span>hasSelector</span></h4>
-  <p>The object of the relationship is a Selector that describes the segment or region of interest within the source resource.  Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasSelector</li>
-      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
-      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 29</span><span style="text-transform: none">: oa:hasSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno27</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [
-      oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-      oa:hasSelector </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">paraselector1</span><span class="tag">&gt;</span><span class="pln"> ] ;
-    oa:hasTarget [
-      oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">dataset1</span><span class="tag">&gt;</span><span class="pln"> ;
-      oa:hasSelector </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">dataselector1</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="hassource" typeof="bibo:Chapter" resource="#hassource" property="bibo:hasPart">
-  <h4 id="h-hassource" resource="#h-hassource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.12 </span>hasSource</span></h4>
-  <p>The resource that the ResourceSelection, or its subclass SpecificResource, is refined from, or more specific than. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p><p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasSource</li>
-      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 30</span><span style="text-transform: none">: oa:hasSource</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno28</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> a oa:SpecificResource ;
-    oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-
-  </div>
-</section>
-
-<section class="term" id="hasstartselector" typeof="bibo:Chapter" resource="#hasstartselector" property="bibo:hasPart">
-  <h4 id="h-hasstartselector" resource="#h-hasstartselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.13 </span>hasStartSelector</span></h4>
-  <p>The relationship between a RangeSelector and the Selector that describes the start position of the range. </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasStartSelector</li>
-      <li><strong>Domain:</strong> <a href="#rangeselector">oa:RangeSelector</a></li>
-      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 31</span><span style="text-transform: none">: oa:hasStartSelector</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno29</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-          a oa:RangeSelector ;
-          oa:hasStartSelector [
-            a oa:XPathSelector ;
-            rdfs:value "//table[1]/tr[1]/td[2]" ] ;
-          oa:hasEndSelector [
-            a oa:XPathSelector ;
-            rdfs:value "//table[1]/tr[1]/td[4]" ] ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="hasstate" typeof="bibo:Chapter" resource="#hasstate" property="bibo:hasPart">
-  <h4 id="h-hasstate" resource="#h-hasstate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.14 </span>hasState</span></h4>
-  <p>The relationship between the ResourceSelection, or its subclass SpecificResource, and a State resource. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p><p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasState</li>
-      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
-      <li><strong>Range:</strong> <a href="#state">oa:State</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 32</span><span style="text-transform: none">: oa:hasState</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno30</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasState </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">state1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="hastarget" typeof="bibo:Chapter" resource="#hastarget" property="bibo:hasPart">
-  <h4 id="h-hastarget" resource="#h-hastarget"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.15 </span>hasTarget</span></h4>
-  <p>The relationship between an Annotation and its Target.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasTarget</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 33</span><span style="text-transform: none">: oa:hasTarget</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno31</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">post1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="motivatedby" typeof="bibo:Chapter" resource="#motivatedby" property="bibo:hasPart">
-  <h4 id="h-motivatedby" resource="#h-motivatedby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.16 </span>motivatedBy</span></h4>
-  <p>The relationship between an Annotation and a Motivation that describes the reason for the Annotation's creation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#motivatedBy</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-      <li><strong>Range:</strong> <a href="#motivation">oa:Motivation</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 34</span><span style="text-transform: none">: oa:motivatedBy</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno32</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">description1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:describing .</span></pre></div>
-  </div>
-</section>
-
-<section class="term" id="prefix" typeof="bibo:Chapter" resource="#prefix" property="bibo:hasPart">
-  <h4 id="h-prefix" resource="#h-prefix"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.17 </span>prefix</span></h4>
-  <p>The object of the property is a snippet of content that occurs immediately before the content which is being selected by the Selector.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#prefix</li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 35</span><span style="text-transform: none">: oa:prefix</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno33</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 24</span><span style="text-transform: none">: oa:exact</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno22</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -1373,8 +1163,232 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="refinedby" typeof="bibo:Chapter" resource="#refinedby" property="bibo:hasPart">
-  <h4 id="h-refinedby" resource="#h-refinedby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.18 </span>refinedBy</span></h4>
+
+<section property="bibo:hasPart" resource="#hasbody" typeof="bibo:Chapter" id="hasbody" class="term">
+  <h4 resource="#h-hasbody" id="h-hasbody"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.7 </span>hasBody</span></h4>
+  <p>The object of the relationship is a resource that is a body of the Annotation.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasBody</li>
+      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 25</span><span style="text-transform: none">: oa:hasBody</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno23</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">post1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#hasendselector" typeof="bibo:Chapter" id="hasendselector" class="term">
+  <h4 resource="#h-hasendselector" id="h-hasendselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.8 </span>hasEndSelector</span></h4>
+  <p>The relationship between a RangeSelector and the Selector that describes the end position of the range. </p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasEndSelector</li>
+      <li><strong>Domain:</strong> <a href="#rangeselector">oa:RangeSelector</a></li>
+      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 26</span><span style="text-transform: none">: oa:hasEndSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno24</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget [
+        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
+        oa:hasSelector [
+          a oa:RangeSelector ;
+          oa:hasStartSelector [
+            a oa:XPathSelector ;
+            rdfs:value "//table[1]/tr[1]/td[2]" ] ;
+          oa:hasEndSelector [
+            a oa:XPathSelector ;
+            rdfs:value "//table[1]/tr[1]/td[4]" ] ] ] .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#haspurpose" typeof="bibo:Chapter" id="haspurpose" class="term">
+  <h4 resource="#h-haspurpose" id="h-haspurpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.9 </span>hasPurpose</span></h4>
+  <p>The purpose served by the resource in the Annotation.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasPurpose</li>
+      <li><strong>Range:</strong> <a href="#motivation">oa:Motivation</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 27</span><span style="text-transform: none">: oa:hasPurpose</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno25</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:motivatedBy oa:bookmarking ;
+    oa:hasBody [
+        oa:text "readme" ;
+        oa:hasPurpose oa:tagging ] ;
+    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#hasscope" typeof="bibo:Chapter" id="hasscope" class="term">
+  <h4 resource="#h-hasscope" id="h-hasscope"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.10 </span>hasScope</span></h4>
+  <p>The scope or context in which the resource is used within the Annotation.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasScope</li>
+      <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
+      <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#context">as:context</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 28</span><span style="text-transform: none">: oa:hasPurpose</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno26</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:motivatedBy oa:bookmarking ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget [
+        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">logo1</span><span class="pln">.</span><span class="atn">jpg</span><span class="tag">&gt;</span><span class="pln"> ;
+        oa:hasScope </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">index</span><span class="pln">.</span><span class="atn">html</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#hasselector" typeof="bibo:Chapter" id="hasselector" class="term">
+  <h4 resource="#h-hasselector" id="h-hasselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.11 </span>hasSelector</span></h4>
+  <p>The object of the relationship is a Selector that describes the segment or region of interest within the source resource.  Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasSelector</li>
+      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
+      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 29</span><span style="text-transform: none">: oa:hasSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno27</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody [
+      oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
+      oa:hasSelector </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">paraselector1</span><span class="tag">&gt;</span><span class="pln"> ] ;
+    oa:hasTarget [
+      oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">dataset1</span><span class="tag">&gt;</span><span class="pln"> ;
+      oa:hasSelector </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">dataselector1</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#hassource" typeof="bibo:Chapter" id="hassource" class="term">
+  <h4 resource="#h-hassource" id="h-hassource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.12 </span>hasSource</span></h4>
+  <p>The resource that the ResourceSelection, or its subclass SpecificResource, is refined from, or more specific than. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p><p></p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasSource</li>
+      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 30</span><span style="text-transform: none">: oa:hasSource</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno28</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> .
+
+</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> a oa:SpecificResource ;
+    oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
+    
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#hasstartselector" typeof="bibo:Chapter" id="hasstartselector" class="term">
+  <h4 resource="#h-hasstartselector" id="h-hasstartselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.13 </span>hasStartSelector</span></h4>
+  <p>The relationship between a RangeSelector and the Selector that describes the start position of the range. </p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasStartSelector</li>
+      <li><strong>Domain:</strong> <a href="#rangeselector">oa:RangeSelector</a></li>
+      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 31</span><span style="text-transform: none">: oa:hasStartSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno29</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget [
+        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
+        oa:hasSelector [
+          a oa:RangeSelector ;
+          oa:hasStartSelector [
+            a oa:XPathSelector ;
+            rdfs:value "//table[1]/tr[1]/td[2]" ] ;
+          oa:hasEndSelector [
+            a oa:XPathSelector ;
+            rdfs:value "//table[1]/tr[1]/td[4]" ] ] ] .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#hasstate" typeof="bibo:Chapter" id="hasstate" class="term">
+  <h4 resource="#h-hasstate" id="h-hasstate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.14 </span>hasState</span></h4>
+  <p>The relationship between the ResourceSelection, or its subclass SpecificResource, and a State resource. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p><p></p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasState</li>
+      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
+      <li><strong>Range:</strong> <a href="#state">oa:State</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 32</span><span style="text-transform: none">: oa:hasState</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno30</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget [
+        oa:hasState </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">state1</span><span class="tag">&gt;</span><span class="pln"> ;
+        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#hastarget" typeof="bibo:Chapter" id="hastarget" class="term">
+  <h4 resource="#h-hastarget" id="h-hastarget"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.15 </span>hasTarget</span></h4>
+  <p>The relationship between an Annotation and its Target.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasTarget</li>
+      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 33</span><span style="text-transform: none">: oa:hasTarget</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno31</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">post1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#motivatedby" typeof="bibo:Chapter" id="motivatedby" class="term">
+  <h4 resource="#h-motivatedby" id="h-motivatedby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.16 </span>motivatedBy</span></h4>
+  <p>The relationship between an Annotation and a Motivation that describes the reason for the Annotation's creation.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#motivatedBy</li>
+      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+      <li><strong>Range:</strong> <a href="#motivation">oa:Motivation</a></li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 34</span><span style="text-transform: none">: oa:motivatedBy</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno32</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">description1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:motivatedBy oa:describing .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#prefix" typeof="bibo:Chapter" id="prefix" class="term">
+  <h4 resource="#h-prefix" id="h-prefix"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.17 </span>prefix</span></h4>
+  <p>The object of the property is a snippet of content that occurs immediately before the content which is being selected by the Selector.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#prefix</li>
+      <li><strong>Range:</strong> xsd:string</li>
+    </ul>
+  </div>
+  <div>
+    <div class="example"><div class="example-title marker"><span>Example 35</span><span style="text-transform: none">: oa:prefix</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno33</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
+    oa:hasTarget [
+        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "anotation" ;
+            oa:prefix "this is an " ;
+            oa:suffix " that has some" ] ] .</span></pre></div>
+  </div>
+</section>
+
+<section property="bibo:hasPart" resource="#refinedby" typeof="bibo:Chapter" id="refinedby" class="term">
+  <h4 resource="#h-refinedby" id="h-refinedby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.18 </span>refinedBy</span></h4>
   <p>The relationship between a Selector or State and another Selector or State that should be applied to the results of the first to refine the processing of the source resource. </p>
   <div class="tech">
     <ul>
@@ -1382,7 +1396,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 36</span><span style="text-transform: none">: oa:refinedBy</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno34</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 36</span><span style="text-transform: none">: oa:refinedBy</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno34</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         a oa:SpecificResource ;
@@ -1398,8 +1412,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="renderedvia" typeof="bibo:Chapter" resource="#renderedvia" property="bibo:hasPart">
-  <h4 id="h-renderedvia" resource="#h-renderedvia"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.19 </span>renderedVia</span></h4>
+<section property="bibo:hasPart" resource="#renderedvia" typeof="bibo:Chapter" id="renderedvia" class="term">
+  <h4 resource="#h-renderedvia" id="h-renderedvia"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.19 </span>renderedVia</span></h4>
   <p>A system that was used by the application that created the Annotation to render the resource.</p>
   <div class="tech">
     <ul>
@@ -1409,7 +1423,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 37</span><span style="text-transform: none">: oa:prefix</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno35</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 37</span><span style="text-transform: none">: oa:prefix</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno35</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
       a oa:SpecificResource ;
@@ -1420,8 +1434,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="sourcedate" typeof="bibo:Chapter" resource="#sourcedate" property="bibo:hasPart">
-  <h4 id="h-sourcedate" resource="#h-sourcedate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.20 </span>sourceDate</span></h4>
+<section property="bibo:hasPart" resource="#sourcedate" typeof="bibo:Chapter" id="sourcedate" class="term">
+  <h4 resource="#h-sourcedate" id="h-sourcedate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.20 </span>sourceDate</span></h4>
   <p>The timestamp at which the Source resource should be interpreted as being applicable to the Annotation.</p>
   <div class="tech">
     <ul>
@@ -1431,7 +1445,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 38</span><span style="text-transform: none">: oa:sourceDate</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno36</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 38</span><span style="text-transform: none">: oa:sourceDate</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno36</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -1441,8 +1455,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="sourcedateend" typeof="bibo:Chapter" resource="#sourcedateend" property="bibo:hasPart">
-  <h4 id="h-sourcedateend" resource="#h-sourcedateend"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.21 </span>sourceDateEnd</span></h4>
+<section property="bibo:hasPart" resource="#sourcedateend" typeof="bibo:Chapter" id="sourcedateend" class="term">
+  <h4 resource="#h-sourcedateend" id="h-sourcedateend"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.21 </span>sourceDateEnd</span></h4>
   <p>The end timestamp of the interval over which the Source resource should be interpreted as being applicable to the Annotation.</p>
   <div class="tech">
     <ul>
@@ -1452,7 +1466,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 39</span><span style="text-transform: none">: oa:sourceDate</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno37</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 39</span><span style="text-transform: none">: oa:sourceDate</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno37</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -1463,8 +1477,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="sourcedatestart" typeof="bibo:Chapter" resource="#sourcedatestart" property="bibo:hasPart">
-  <h4 id="h-sourcedatestart" resource="#h-sourcedatestart"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.22 </span>sourceDateStart</span></h4>
+<section property="bibo:hasPart" resource="#sourcedatestart" typeof="bibo:Chapter" id="sourcedatestart" class="term">
+  <h4 resource="#h-sourcedatestart" id="h-sourcedatestart"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.22 </span>sourceDateStart</span></h4>
   <p>The start timestamp of the interval over which the Source resource should be interpreted as being applicable to the Annotation.</p>
   <div class="tech">
     <ul>
@@ -1474,7 +1488,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 40</span><span style="text-transform: none">: oa:sourceDate</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno38</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 40</span><span style="text-transform: none">: oa:sourceDate</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno38</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -1485,8 +1499,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="start" typeof="bibo:Chapter" resource="#start" property="bibo:hasPart">
-  <h4 id="h-start" resource="#h-start"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.23 </span>start</span></h4>
+<section property="bibo:hasPart" resource="#start" typeof="bibo:Chapter" id="start" class="term">
+  <h4 resource="#h-start" id="h-start"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.23 </span>start</span></h4>
   <p>The start position in a 0-based index at which a range of content is selected from the data in the source resource.</p>
   <div class="tech">
     <ul>
@@ -1495,7 +1509,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 41</span><span style="text-transform: none">: oa:start</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno39</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 41</span><span style="text-transform: none">: oa:start</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno39</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">ebook1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -1506,8 +1520,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="styleclass" typeof="bibo:Chapter" resource="#styleclass" property="bibo:hasPart">
-  <h4 id="h-styleclass" resource="#h-styleclass"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.24 </span>styleClass</span></h4>
+<section property="bibo:hasPart" resource="#styleclass" typeof="bibo:Chapter" id="styleclass" class="term">
+  <h4 resource="#h-styleclass" id="h-styleclass"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.24 </span>styleClass</span></h4>
   <p>The name of the class used in the CSS description referenced from the Annotation that should be applied to the Specific Resource.</p>
   <div class="tech">
     <ul>
@@ -1517,7 +1531,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 42</span><span style="text-transform: none">: oa:styleClass</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno40</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 42</span><span style="text-transform: none">: oa:styleClass</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno40</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:styledBy </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">style1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
@@ -1528,8 +1542,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="styledby" typeof="bibo:Chapter" resource="#styledby" property="bibo:hasPart">
-  <h4 id="h-styledby" resource="#h-styledby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.25 </span>styledBy</span></h4>
+<section property="bibo:hasPart" resource="#styledby" typeof="bibo:Chapter" id="styledby" class="term">
+  <h4 resource="#h-styledby" id="h-styledby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.25 </span>styledBy</span></h4>
   <p>A reference to a Stylesheet that should be used to apply styles to the Annotation rendering.</p>
   <div class="tech">
     <ul>
@@ -1539,7 +1553,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 43</span><span style="text-transform: none">: oa:styledBy</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno41</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 43</span><span style="text-transform: none">: oa:styledBy</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno41</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">body1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:styledBy [
         a oa:CssStyle, oa:EmbeddedContent ;
@@ -1551,8 +1565,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="suffix" typeof="bibo:Chapter" resource="#suffix" property="bibo:hasPart">
-  <h4 id="h-suffix" resource="#h-suffix"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.26 </span>suffix</span></h4>
+<section property="bibo:hasPart" resource="#suffix" typeof="bibo:Chapter" id="suffix" class="term">
+  <h4 resource="#h-suffix" id="h-suffix"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.26 </span>suffix</span></h4>
   <p>The snippet of text that occurs immediately after the text which is being selected.</p>
   <div class="tech">
     <ul>
@@ -1561,7 +1575,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 44</span><span style="text-transform: none">: oa:suffix</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno42</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 44</span><span style="text-transform: none">: oa:suffix</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno42</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget [
         oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -1570,12 +1584,12 @@ The namespace used for the Web Annotation Ontology is:
             oa:exact "anotation" ;
             oa:prefix "this is an " ;
             oa:suffix " that has some" ] ] .</span></pre></div>
-
+    
   </div>
 </section>
 
-<section class="term" id="text" typeof="bibo:Chapter" resource="#text" property="bibo:hasPart">
-  <h4 id="h-text" resource="#h-text"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.27 </span>text</span></h4>
+<section property="bibo:hasPart" resource="#text" typeof="bibo:Chapter" id="text" class="term">
+  <h4 resource="#h-text" id="h-text"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.27 </span>text</span></h4>
   <p>The content of a resource, given as text.</p>
   <div class="tech">
     <ul>
@@ -1585,7 +1599,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 45</span><span style="text-transform: none">: oa:text</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno43</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 45</span><span style="text-transform: none">: oa:text</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno43</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">photo1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasBody [
         a oa:TextualBody;
@@ -1595,8 +1609,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="via" typeof="bibo:Chapter" resource="#via" property="bibo:hasPart">
-  <h4 id="h-via" resource="#h-via"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.28 </span>via</span></h4>
+<section property="bibo:hasPart" resource="#via" typeof="bibo:Chapter" id="via" class="term">
+  <h4 resource="#h-via" id="h-via"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.28 </span>via</span></h4>
   <p>A object of the relationship is a resource from which the source resource was retrieved by the providing system.</p>
   <div class="tech">
     <ul>
@@ -1604,7 +1618,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 46</span></div><pre class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno44</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 46</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno44</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:via </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">other</span><span class="pln">.</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">anno1b</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
@@ -1613,11 +1627,11 @@ The namespace used for the Web Annotation Ontology is:
 
 </section>
 
-<section id="named-individuals" typeof="bibo:Chapter" resource="#named-individuals" property="bibo:hasPart">
-  <h3 id="h-named-individuals" resource="#h-named-individuals"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3 </span>Named Individuals</span></h3>
+<section property="bibo:hasPart" resource="#named-individuals" typeof="bibo:Chapter" id="named-individuals">
+  <h3 resource="#h-named-individuals" id="h-named-individuals"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3 </span>Named Individuals</span></h3>
 
-<section class="term" id="bookmarking" typeof="bibo:Chapter" resource="#bookmarking" property="bibo:hasPart">
-  <h4 id="h-bookmarking" resource="#h-bookmarking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.1 </span>bookmarking</span></h4>
+<section property="bibo:hasPart" resource="#bookmarking" typeof="bibo:Chapter" id="bookmarking" class="term">
+  <h4 resource="#h-bookmarking" id="h-bookmarking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.1 </span>bookmarking</span></h4>
   <p>The motivation for when the user intends to create a bookmark to the Target or part thereof.</p>
   <div class="tech">
     <ul>
@@ -1625,14 +1639,14 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 47</span><span style="text-transform: none">: oa:bookmarking</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno45</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 47</span><span style="text-transform: none">: oa:bookmarking</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno45</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:bookmarking .      </span></pre></div>
+    oa:motivatedBy oa:bookmarking .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="classifying" typeof="bibo:Chapter" resource="#classifying" property="bibo:hasPart">
-  <h4 id="h-classifying" resource="#h-classifying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.2 </span>classifying</span></h4>
+<section property="bibo:hasPart" resource="#classifying" typeof="bibo:Chapter" id="classifying" class="term">
+  <h4 resource="#h-classifying" id="h-classifying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.2 </span>classifying</span></h4>
   <p>The motivation for when the user intends to that classify the Target as something.</p>
   <div class="tech">
     <ul>
@@ -1640,15 +1654,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 48</span><span style="text-transform: none">: oa:classifying</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno46</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 48</span><span style="text-transform: none">: oa:classifying</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno46</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">type1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:classifying .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="commenting" typeof="bibo:Chapter" resource="#commenting" property="bibo:hasPart">
-  <h4 id="h-commenting" resource="#h-commenting"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.3 </span>commenting</span></h4>
+<section property="bibo:hasPart" resource="#commenting" typeof="bibo:Chapter" id="commenting" class="term">
+  <h4 resource="#h-commenting" id="h-commenting"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.3 </span>commenting</span></h4>
   <p>The motivation for when the user intends to comment about the Target.</p>
   <div class="tech">
     <ul>
@@ -1656,15 +1670,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 49</span><span style="text-transform: none">: oa:commenting</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno47</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 49</span><span style="text-transform: none">: oa:commenting</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno47</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "A comment about the page" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:commenting .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="describing" typeof="bibo:Chapter" resource="#describing" property="bibo:hasPart">
-  <h4 id="h-describing" resource="#h-describing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.4 </span>describing</span></h4>
+<section property="bibo:hasPart" resource="#describing" typeof="bibo:Chapter" id="describing" class="term">
+  <h4 resource="#h-describing" id="h-describing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.4 </span>describing</span></h4>
   <p>The motivation for when the user intends to describe the Target, as opposed to a comment about them.</p>
   <div class="tech">
     <ul>
@@ -1672,15 +1686,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 50</span><span style="text-transform: none">: oa:describing</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno48</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 50</span><span style="text-transform: none">: oa:describing</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno48</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "A description of the image" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:describing .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="editing" typeof="bibo:Chapter" resource="#editing" property="bibo:hasPart">
-  <h4 id="h-editing" resource="#h-editing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.5 </span>editing</span></h4>
+<section property="bibo:hasPart" resource="#editing" typeof="bibo:Chapter" id="editing" class="term">
+  <h4 resource="#h-editing" id="h-editing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.5 </span>editing</span></h4>
   <p>The motivation for when the user intends to request a change or edit to the Target resource.</p>
   <div class="tech">
     <ul>
@@ -1688,15 +1702,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 51</span><span style="text-transform: none">: oa:editing</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno49</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 51</span><span style="text-transform: none">: oa:editing</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno49</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "Editorial suggestion" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">text1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:editing .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="highlighting" typeof="bibo:Chapter" resource="#highlighting" property="bibo:hasPart">
-  <h4 id="h-highlighting" resource="#h-highlighting"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.6 </span>highlighting</span></h4>
+<section property="bibo:hasPart" resource="#highlighting" typeof="bibo:Chapter" id="highlighting" class="term">
+  <h4 resource="#h-highlighting" id="h-highlighting"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.6 </span>highlighting</span></h4>
   <p>The motivation for when the user intends to highlight the Target resource or segment of it.</p>
   <div class="tech">
     <ul>
@@ -1704,14 +1718,14 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 52</span><span style="text-transform: none">: oa:highlighting</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno50</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 52</span><span style="text-transform: none">: oa:highlighting</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno50</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:highlighting .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="identifying" typeof="bibo:Chapter" resource="#identifying" property="bibo:hasPart">
-  <h4 id="h-identifying" resource="#h-identifying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.7 </span>identifying</span></h4>
+<section property="bibo:hasPart" resource="#identifying" typeof="bibo:Chapter" id="identifying" class="term">
+  <h4 resource="#h-identifying" id="h-identifying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.7 </span>identifying</span></h4>
   <p>The motivation for when the user intends to assign an identity to the Target or identify what is being depicted or described in the Target.</p>
   <div class="tech">
     <ul>
@@ -1719,15 +1733,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 53</span><span style="text-transform: none">: oa:identifying</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno51</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 53</span><span style="text-transform: none">: oa:identifying</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno51</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">identities</span><span class="pun">/</span><span class="atn">object1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">image-of-object1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:identifying .      </span></pre></div>
+    oa:motivatedBy oa:identifying .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="linking" typeof="bibo:Chapter" resource="#linking" property="bibo:hasPart">
-  <h4 id="h-linking" resource="#h-linking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.8 </span>linking</span></h4>
+<section property="bibo:hasPart" resource="#linking" typeof="bibo:Chapter" id="linking" class="term">
+  <h4 resource="#h-linking" id="h-linking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.8 </span>linking</span></h4>
   <p>The motivation for when the user intends to link to a resource related to the Target.</p>
   <div class="tech">
     <ul>
@@ -1735,15 +1749,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 54</span><span style="text-transform: none">: oa:linking</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno52</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 54</span><span style="text-transform: none">: oa:linking</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno52</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">from1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">to1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:linking .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="moderating" typeof="bibo:Chapter" resource="#moderating" property="bibo:hasPart">
-  <h4 id="h-moderating" resource="#h-moderating"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.9 </span>moderating</span></h4>
+<section property="bibo:hasPart" resource="#moderating" typeof="bibo:Chapter" id="moderating" class="term">
+  <h4 resource="#h-moderating" id="h-moderating"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.9 </span>moderating</span></h4>
   <p>The motivation for when the user intends to assign some value or quality to the Target.</p>
   <div class="tech">
     <ul>
@@ -1751,15 +1765,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 55</span><span style="text-transform: none">: oa:moderating</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno53</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 55</span><span style="text-transform: none">: oa:moderating</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno53</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">tags</span><span class="pun">/</span><span class="atn">approved1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:moderating .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="questioning" typeof="bibo:Chapter" resource="#questioning" property="bibo:hasPart">
-  <h4 id="h-questioning" resource="#h-questioning"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.10 </span>questioning</span></h4>
+<section property="bibo:hasPart" resource="#questioning" typeof="bibo:Chapter" id="questioning" class="term">
+  <h4 resource="#h-questioning" id="h-questioning"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.10 </span>questioning</span></h4>
   <p>The motivation for when the user intends to ask a question about the Target.</p>
   <div class="tech">
     <ul>
@@ -1767,15 +1781,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 56</span><span style="text-transform: none">: oa:questioning</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno54</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 56</span><span style="text-transform: none">: oa:questioning</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno54</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "A question about the resource" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:questioning .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="replying" typeof="bibo:Chapter" resource="#replying" property="bibo:hasPart">
-  <h4 id="h-replying" resource="#h-replying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.11 </span>replying</span></h4>
+<section property="bibo:hasPart" resource="#replying" typeof="bibo:Chapter" id="replying" class="term">
+  <h4 resource="#h-replying" id="h-replying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.11 </span>replying</span></h4>
   <p>The motivation for when the user intends to reply to a previous statement, either an Annotation or another resource.</p>
   <div class="tech">
     <ul>
@@ -1783,15 +1797,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 57</span><span style="text-transform: none">: oa:replying</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno55</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 57</span><span style="text-transform: none">: oa:replying</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno55</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "A reply to a question" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:replying .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="reviewing" typeof="bibo:Chapter" resource="#reviewing" property="bibo:hasPart">
-  <h4 id="h-reviewing" resource="#h-reviewing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.12 </span>reviewing</span></h4>
+<section property="bibo:hasPart" resource="#reviewing" typeof="bibo:Chapter" id="reviewing" class="term">
+  <h4 resource="#h-reviewing" id="h-reviewing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.12 </span>reviewing</span></h4>
   <p>The motivation for when the user intends to review the Target in some assessing fashion, rather than simply make a comment about it.</p>
   <div class="tech">
     <ul>
@@ -1799,15 +1813,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 58</span><span style="text-transform: none">: oa:reviewing</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno56</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 58</span><span style="text-transform: none">: oa:reviewing</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno56</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "A review of the resource" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:reviewing .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="tagging" typeof="bibo:Chapter" resource="#tagging" property="bibo:hasPart">
-  <h4 id="h-tagging" resource="#h-tagging"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.13 </span>tagging</span></h4>
+<section property="bibo:hasPart" resource="#tagging" typeof="bibo:Chapter" id="tagging" class="term">
+  <h4 resource="#h-tagging" id="h-tagging"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.13 </span>tagging</span></h4>
   <p>The motivation for when the user intends to associate a tag with the Target.</p>
   <div class="tech">
     <ul>
@@ -1815,7 +1829,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 59</span><span style="text-transform: none">: oa:tagging</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno57</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 59</span><span style="text-transform: none">: oa:tagging</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno57</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "tag" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">thing1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:tagging .</span></pre></div>
@@ -1824,18 +1838,18 @@ The namespace used for the Web Annotation Ontology is:
 </section>
 </section>
 
-<section id="recommended-ontologies" typeof="bibo:Chapter" resource="#recommended-ontologies" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-recommended-ontologies" resource="#h-recommended-ontologies"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Recommended Ontologies</span></h2>
+<section property="bibo:hasPart" resource="#recommended-ontologies" typeof="bibo:Chapter" id="recommended-ontologies">
+<!--OddPage--><h2 resource="#h-recommended-ontologies" id="h-recommended-ontologies"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Recommended Ontologies</span></h2>
 
-<section id="classes-1" typeof="bibo:Chapter" resource="#classes-1" property="bibo:hasPart">
-<h3 id="h-classes-1" resource="#h-classes-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1 </span>Classes</span></h3>
+<section property="bibo:hasPart" resource="#classes-1" typeof="bibo:Chapter" id="classes-1">
+<h3 resource="#h-classes-1" id="h-classes-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1 </span>Classes</span></h3>
 
 <div class="termtoc">
 <a href="#as-application">as:Application</a> | <a href="#as-orderedcollection">as:OrderedCollection</a> | <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a> | <a href="#dctypes-dataset">dctypes:Dataset</a> | <a href="#dctypes-movingimage">dctypes:MovingImage</a> | <a href="#dctypes-stillimage">dctypes:StillImage</a> | <a href="#dctypes-sound">dctypes:Sound</a> | <a href="#dctypes-text">dctypes:Text</a> | <a href="#foaf-organization">foaf:Organization</a> | <a href="#foaf-person">foaf:Person</a> | <a href="#schema-audience">schema:Audience</a>
 </div>
 
-<section class="term" id="as-application" typeof="bibo:Chapter" resource="#as-application" property="bibo:hasPart">
-  <h4 id="h-as-application" resource="#h-as-application"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.1 </span>as:Application</span></h4>
+<section property="bibo:hasPart" resource="#as-application" typeof="bibo:Chapter" id="as-application" class="term">
+  <h4 resource="#h-as-application" id="h-as-application"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.1 </span>as:Application</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -1845,7 +1859,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 60</span><span style="text-transform: none">: as:Application</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno58</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 60</span><span style="text-transform: none">: as:Application</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno58</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     as:generator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> .
@@ -1856,8 +1870,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="as-orderedcollection" typeof="bibo:Chapter" resource="#as-orderedcollection" property="bibo:hasPart">
-  <h4 id="h-as-orderedcollection" resource="#h-as-orderedcollection"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.2 </span>as:OrderedCollection</span></h4>
+<section property="bibo:hasPart" resource="#as-orderedcollection" typeof="bibo:Chapter" id="as-orderedcollection" class="term">
+  <h4 resource="#h-as-orderedcollection" id="h-as-orderedcollection"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.2 </span>as:OrderedCollection</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -1868,16 +1882,16 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 61</span><span style="text-transform: none">: as:OrderedCollection</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
+    <div class="example"><div class="example-title marker"><span>Example 61</span><span style="text-transform: none">: as:OrderedCollection</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
   rdfs:label "Example Collection" ;
   as:totalItems 42023 ;
   as:first </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .      </span></pre></div>
+  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="as-orderedcollectionpage" typeof="bibo:Chapter" resource="#as-orderedcollectionpage" property="bibo:hasPart">
-  <h4 id="h-as-orderedcollectionpage" resource="#h-as-orderedcollectionpage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.3 </span>as:OrderedCollectionPage</span></h4>
+<section property="bibo:hasPart" resource="#as-orderedcollectionpage" typeof="bibo:Chapter" id="as-orderedcollectionpage" class="term">
+  <h4 resource="#h-as-orderedcollectionpage" id="h-as-orderedcollectionpage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.3 </span>as:OrderedCollectionPage</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -1888,7 +1902,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 62</span><span style="text-transform: none">: as:OrderedCollectionPage</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
+    <div class="example"><div class="example-title marker"><span>Example 62</span><span style="text-transform: none">: as:OrderedCollectionPage</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
   as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
   as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln"> ;
   as:startIndex 0 ;
@@ -1899,8 +1913,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="dctypes-dataset" typeof="bibo:Chapter" resource="#dctypes-dataset" property="bibo:hasPart">
-  <h4 id="h-dctypes-dataset" resource="#h-dctypes-dataset"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.4 </span>dctypes:Dataset</span></h4>
+<section property="bibo:hasPart" resource="#dctypes-dataset" typeof="bibo:Chapter" id="dctypes-dataset" class="term">
+  <h4 resource="#h-dctypes-dataset" id="h-dctypes-dataset"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.4 </span>dctypes:Dataset</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -1909,18 +1923,18 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 63</span><span style="text-transform: none">: dctypes:Dataset</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno59</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 63</span><span style="text-transform: none">: dctypes:Dataset</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno59</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:motivatedBy oa:commenting ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">dataset1</span><span class="tag">&gt;</span><span class="pln"> .
 
 </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">dataset1</span><span class="tag">&gt;</span><span class="pln"> a dctypes:Dataset ;
-  dc:format "text/csv" .    </span></pre></div>
+  dc:format "text/csv" .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="dctypes-movingimage" typeof="bibo:Chapter" resource="#dctypes-movingimage" property="bibo:hasPart">
-  <h4 id="h-dctypes-movingimage" resource="#h-dctypes-movingimage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.5 </span>dctypes:MovingImage</span></h4>
+<section property="bibo:hasPart" resource="#dctypes-movingimage" typeof="bibo:Chapter" id="dctypes-movingimage" class="term">
+  <h4 resource="#h-dctypes-movingimage" id="h-dctypes-movingimage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.5 </span>dctypes:MovingImage</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -1929,7 +1943,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 64</span><span style="text-transform: none">: dctypes:MovingImage</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno60</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 64</span><span style="text-transform: none">: dctypes:MovingImage</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno60</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "tag" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">video1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:tagging .
@@ -1938,8 +1952,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="dctypes-stillimage" typeof="bibo:Chapter" resource="#dctypes-stillimage" property="bibo:hasPart">
-  <h4 id="h-dctypes-stillimage" resource="#h-dctypes-stillimage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.6 </span>dctypes:StillImage</span></h4>
+<section property="bibo:hasPart" resource="#dctypes-stillimage" typeof="bibo:Chapter" id="dctypes-stillimage" class="term">
+  <h4 resource="#h-dctypes-stillimage" id="h-dctypes-stillimage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.6 </span>dctypes:StillImage</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -1948,7 +1962,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 65</span><span style="text-transform: none">: dctypes:StillImage</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno61</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 65</span><span style="text-transform: none">: dctypes:StillImage</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno61</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "tag" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:tagging .
@@ -1957,8 +1971,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="dctypes-sound" typeof="bibo:Chapter" resource="#dctypes-sound" property="bibo:hasPart">
-  <h4 id="h-dctypes-sound" resource="#h-dctypes-sound"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.7 </span>dctypes:Sound</span></h4>
+<section property="bibo:hasPart" resource="#dctypes-sound" typeof="bibo:Chapter" id="dctypes-sound" class="term">
+  <h4 resource="#h-dctypes-sound" id="h-dctypes-sound"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.7 </span>dctypes:Sound</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -1967,7 +1981,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 66</span><span style="text-transform: none">: dctypes:Sound</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno62</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 66</span><span style="text-transform: none">: dctypes:Sound</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno62</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "tag" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">audio1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:tagging .
@@ -1976,8 +1990,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="dctypes-text" typeof="bibo:Chapter" resource="#dctypes-text" property="bibo:hasPart">
-  <h4 id="h-dctypes-text" resource="#h-dctypes-text"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.8 </span>dctypes:Text</span></h4>
+<section property="bibo:hasPart" resource="#dctypes-text" typeof="bibo:Chapter" id="dctypes-text" class="term">
+  <h4 resource="#h-dctypes-text" id="h-dctypes-text"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.8 </span>dctypes:Text</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -1985,7 +1999,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 67</span><span style="text-transform: none">: dctypes:Text</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno63</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 67</span><span style="text-transform: none">: dctypes:Text</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno63</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody [ oa:text "tag" ] ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">document1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:motivatedBy oa:tagging .
@@ -1994,8 +2008,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="foaf-organization" typeof="bibo:Chapter" resource="#foaf-organization" property="bibo:hasPart">
-  <h4 id="h-foaf-organization" resource="#h-foaf-organization"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.9 </span>foaf:Organization</span></h4>
+<section property="bibo:hasPart" resource="#foaf-organization" typeof="bibo:Chapter" id="foaf-organization" class="term">
+  <h4 resource="#h-foaf-organization" id="h-foaf-organization"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.9 </span>foaf:Organization</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2004,7 +2018,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 68</span><span style="text-transform: none">: foaf:Organization</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno64</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 68</span><span style="text-transform: none">: foaf:Organization</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno64</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:motivatedBy oa:commenting ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -2015,8 +2029,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="foaf-person" typeof="bibo:Chapter" resource="#foaf-person" property="bibo:hasPart">
-  <h4 id="h-foaf-person" resource="#h-foaf-person"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.10 </span>foaf:Person</span></h4>
+<section property="bibo:hasPart" resource="#foaf-person" typeof="bibo:Chapter" id="foaf-person" class="term">
+  <h4 resource="#h-foaf-person" id="h-foaf-person"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.10 </span>foaf:Person</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2025,7 +2039,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 69</span><span style="text-transform: none">: foaf:Person</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno65</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 69</span><span style="text-transform: none">: foaf:Person</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno65</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> .
@@ -2036,8 +2050,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="schema-audience" typeof="bibo:Chapter" resource="#schema-audience" property="bibo:hasPart">
-  <h4 id="h-schema-audience" resource="#h-schema-audience"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.11 </span>schema:Audience</span></h4>
+<section property="bibo:hasPart" resource="#schema-audience" typeof="bibo:Chapter" id="schema-audience" class="term">
+  <h4 resource="#h-schema-audience" id="h-schema-audience"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.11 </span>schema:Audience</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2046,7 +2060,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 70</span><span style="text-transform: none">: schema:Audience</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno66</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 70</span><span style="text-transform: none">: schema:Audience</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno66</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     schema:audience </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">roles</span><span class="pun">/</span><span class="atn">musician</span><span class="tag">&gt;</span><span class="pln"> .
@@ -2058,16 +2072,16 @@ The namespace used for the Web Annotation Ontology is:
 
 </section>
 
-<section id="properties-1" typeof="bibo:Chapter" resource="#properties-1" property="bibo:hasPart">
-  <h3 id="h-properties-1" resource="#h-properties-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2 </span>Properties</span></h3>
+<section property="bibo:hasPart" resource="#properties-1" typeof="bibo:Chapter" id="properties-1">
+  <h3 resource="#h-properties-1" id="h-properties-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2 </span>Properties</span></h3>
 
 <div class="termtoc">
 <a href="#as-first">as:first</a> | <a href="#as-generator">as:generator</a> | <a href="#as-items">as:items</a> | <a href="#as-last">as:last</a> | <a href="#as-next">as:next</a> | <a href="#as-partof">as:partOf</a> | <a href="#as-prev">as:prev</a> | <a href="#as-startindex">as:startIndex</a> | <a href="#as-totalitems">as:totalItems</a> | <a href="#dc-format">dc:format</a> | <a href="#dc-language">dc:language</a> | <a href="#dcterms-conformsto">dcterms:conformsTo</a> | <a href="#dcterms-created">dcterms:created</a> | <a href="#dcterms-creator">dcterms:creator</a> | <a href="#dcterms-issued">dcterms:issued</a> | <a href="#dcterms-modified">dcterms:modified</a> | <a href="#dcterms-rights">dcterms:rights</a> | <a href="#foaf-homepage">foaf:homepage</a> | <a href="#foaf-mbox">foaf:mbox</a> | <a href="#foaf-mbox_sha1sum">foaf:mbox_sha1sum</a> | <a href="#foaf-name">foaf:name</a> | <a href="#foaf-nick">foaf:nick</a> | <a href="#rdf-type">rdf:type</a> | <a href="#rdf-value">rdf:value</a> | <a href="#rdfs-label">rdfs:label</a> | <a href="#schema-audience">schema:audience</a>
 </div>
 
 
-<section class="term" id="as-first" typeof="bibo:Chapter" resource="#as-first" property="bibo:hasPart">
-  <h4 id="h-as-first" resource="#h-as-first"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.1 </span>as:first</span></h4>
+<section property="bibo:hasPart" resource="#as-first" typeof="bibo:Chapter" id="as-first" class="term">
+  <h4 resource="#h-as-first" id="h-as-first"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.1 </span>as:first</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2077,16 +2091,16 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 71</span><span style="text-transform: none">: as:first</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
+    <div class="example"><div class="example-title marker"><span>Example 71</span><span style="text-transform: none">: as:first</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
   rdfs:label "Example Collection" ;
   as:totalItems 42023 ;
   as:first </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> . </span></pre></div>
+  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="as-generator" typeof="bibo:Chapter" resource="#as-generator" property="bibo:hasPart">
-  <h4 id="h-as-generator" resource="#h-as-generator"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.2 </span>as:generator</span></h4>
+<section property="bibo:hasPart" resource="#as-generator" typeof="bibo:Chapter" id="as-generator" class="term">
+  <h4 resource="#h-as-generator" id="h-as-generator"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.2 </span>as:generator</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2094,7 +2108,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 72</span><span style="text-transform: none">: as:generator</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno67</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 72</span><span style="text-transform: none">: as:generator</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno67</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     as:generator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> .
@@ -2105,8 +2119,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="as-items" typeof="bibo:Chapter" resource="#as-items" property="bibo:hasPart">
-  <h4 id="h-as-items" resource="#h-as-items"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.3 </span>as:items</span></h4>
+<section property="bibo:hasPart" resource="#as-items" typeof="bibo:Chapter" id="as-items" class="term">
+  <h4 resource="#h-as-items" id="h-as-items"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.3 </span>as:items</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2116,7 +2130,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 73</span><span style="text-transform: none">: as:items</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
+    <div class="example"><div class="example-title marker"><span>Example 73</span><span style="text-transform: none">: as:items</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
   as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
   as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln"> ;
   as:startIndex 0 ;
@@ -2127,8 +2141,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="as-last" typeof="bibo:Chapter" resource="#as-last" property="bibo:hasPart">
-  <h4 id="h-as-last" resource="#h-as-last"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.4 </span>as:last</span></h4>
+<section property="bibo:hasPart" resource="#as-last" typeof="bibo:Chapter" id="as-last" class="term">
+  <h4 resource="#h-as-last" id="h-as-last"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.4 </span>as:last</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2138,16 +2152,16 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 74</span><span style="text-transform: none">: as:last</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
+    <div class="example"><div class="example-title marker"><span>Example 74</span><span style="text-transform: none">: as:last</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
   rdfs:label "Example Collection" ;
   as:totalItems 42023 ;
   as:first </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> . </span></pre></div>
+  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="as-next" typeof="bibo:Chapter" resource="#as-next" property="bibo:hasPart">
-  <h4 id="h-as-next" resource="#h-as-next"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.5 </span>as:next</span></h4>
+<section property="bibo:hasPart" resource="#as-next" typeof="bibo:Chapter" id="as-next" class="term">
+  <h4 resource="#h-as-next" id="h-as-next"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.5 </span>as:next</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2157,7 +2171,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 75</span><span style="text-transform: none">: as:next</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
+    <div class="example"><div class="example-title marker"><span>Example 75</span><span style="text-transform: none">: as:next</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
   as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
   as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln"> ;
   as:startIndex 0 ;
@@ -2168,8 +2182,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="as-partof" typeof="bibo:Chapter" resource="#as-partof" property="bibo:hasPart">
-  <h4 id="h-as-partof" resource="#h-as-partof"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.6 </span>as:partOf</span></h4>
+<section property="bibo:hasPart" resource="#as-partof" typeof="bibo:Chapter" id="as-partof" class="term">
+  <h4 resource="#h-as-partof" id="h-as-partof"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.6 </span>as:partOf</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2179,7 +2193,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 76</span><span style="text-transform: none">: as:partOf</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
+    <div class="example"><div class="example-title marker"><span>Example 76</span><span style="text-transform: none">: as:partOf</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
   as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
   as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln"> ;
   as:startIndex 0 ;
@@ -2190,8 +2204,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="as-prev" typeof="bibo:Chapter" resource="#as-prev" property="bibo:hasPart">
-  <h4 id="h-as-prev" resource="#h-as-prev"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.7 </span>as:prev</span></h4>
+<section property="bibo:hasPart" resource="#as-prev" typeof="bibo:Chapter" id="as-prev" class="term">
+  <h4 resource="#h-as-prev" id="h-as-prev"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.7 </span>as:prev</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2201,7 +2215,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 77</span><span style="text-transform: none">: as:prev</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page2 a as:OrderedCollectionPage ;
+    <div class="example"><div class="example-title marker"><span>Example 77</span><span style="text-transform: none">: as:prev</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page2 a as:OrderedCollectionPage ;
   as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
   as:prev </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
   as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page3</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -2213,8 +2227,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="as-startindex" typeof="bibo:Chapter" resource="#as-startindex" property="bibo:hasPart">
-  <h4 id="h-as-startindex" resource="#h-as-startindex"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.8 </span>as:startIndex</span></h4>
+<section property="bibo:hasPart" resource="#as-startindex" typeof="bibo:Chapter" id="as-startindex" class="term">
+  <h4 resource="#h-as-startindex" id="h-as-startindex"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.8 </span>as:startIndex</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2224,7 +2238,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 78</span><span style="text-transform: none">: as:startIndex</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page2 a as:OrderedCollectionPage ;
+    <div class="example"><div class="example-title marker"><span>Example 78</span><span style="text-transform: none">: as:startIndex</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page2 a as:OrderedCollectionPage ;
   as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
   as:prev </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
   as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page3</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -2236,8 +2250,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="as-totalitems" typeof="bibo:Chapter" resource="#as-totalitems" property="bibo:hasPart">
-  <h4 id="h-as-totalitems" resource="#h-as-totalitems"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.9 </span>as:totalItems</span></h4>
+<section property="bibo:hasPart" resource="#as-totalitems" typeof="bibo:Chapter" id="as-totalitems" class="term">
+  <h4 resource="#h-as-totalitems" id="h-as-totalitems"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.9 </span>as:totalItems</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2247,16 +2261,16 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 79</span><span style="text-transform: none">: as:totalItems</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
+    <div class="example"><div class="example-title marker"><span>Example 79</span><span style="text-transform: none">: as:totalItems</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
   rdfs:label "Example Collection" ;
   as:totalItems 42023 ;
   as:first </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> . </span></pre></div>
+  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="dc-format" typeof="bibo:Chapter" resource="#dc-format" property="bibo:hasPart">
-  <h4 id="h-dc-format" resource="#h-dc-format"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.10 </span>dc:format</span></h4>
+<section property="bibo:hasPart" resource="#dc-format" typeof="bibo:Chapter" id="dc-format" class="term">
+  <h4 resource="#h-dc-format" id="h-dc-format"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.10 </span>dc:format</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2265,7 +2279,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 80</span><span style="text-transform: none">: dc:format</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno68</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 80</span><span style="text-transform: none">: dc:format</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno68</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">photo1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasBody [
         a oa:TextualBody;
@@ -2275,8 +2289,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="dc-language" typeof="bibo:Chapter" resource="#dc-language" property="bibo:hasPart">
-  <h4 id="h-dc-language" resource="#h-dc-language"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.11 </span>dc:language</span></h4>
+<section property="bibo:hasPart" resource="#dc-language" typeof="bibo:Chapter" id="dc-language" class="term">
+  <h4 resource="#h-dc-language" id="h-dc-language"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.11 </span>dc:language</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2285,7 +2299,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 81</span><span style="text-transform: none">: dc:language</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno69</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 81</span><span style="text-transform: none">: dc:language</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno69</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">photo1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasBody [
         a oa:TextualBody;
@@ -2295,8 +2309,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="dcterms-conformsto" typeof="bibo:Chapter" resource="#dcterms-conformsto" property="bibo:hasPart">
-  <h4 id="h-dcterms-conformsto" resource="#h-dcterms-conformsto"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.12 </span>dcterms:conformsTo</span></h4>
+<section property="bibo:hasPart" resource="#dcterms-conformsto" typeof="bibo:Chapter" id="dcterms-conformsto" class="term">
+  <h4 resource="#h-dcterms-conformsto" id="h-dcterms-conformsto"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.12 </span>dcterms:conformsTo</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2309,12 +2323,12 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 82</span><span style="text-transform: none">: dcterms:conformsTo</span></div><pre class="highlight prettyprint prettyprinted"></pre></div>
+    <div class="example"><div class="example-title marker"><span>Example 82</span><span style="text-transform: none">: dcterms:conformsTo</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
   </div>
 </section>
 
-<section class="term" id="dcterms-created" typeof="bibo:Chapter" resource="#dcterms-created" property="bibo:hasPart">
-  <h4 id="h-dcterms-created" resource="#h-dcterms-created"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.13 </span>dcterms:created</span></h4>
+<section property="bibo:hasPart" resource="#dcterms-created" typeof="bibo:Chapter" id="dcterms-created" class="term">
+  <h4 resource="#h-dcterms-created" id="h-dcterms-created"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.13 </span>dcterms:created</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2324,15 +2338,15 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 83</span><span style="text-transform: none">: dcterms:created</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno70</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 83</span><span style="text-transform: none">: dcterms:created</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno70</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     dcterms:created "2015-10-13T13:00:00Z" .</span></pre></div>
   </div>
 </section>
 
-<section class="term" id="dcterms-creator" typeof="bibo:Chapter" resource="#dcterms-creator" property="bibo:hasPart">
-  <h4 id="h-dcterms-creator" resource="#h-dcterms-creator"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.14 </span>dcterms:creator</span></h4>
+<section property="bibo:hasPart" resource="#dcterms-creator" typeof="bibo:Chapter" id="dcterms-creator" class="term">
+  <h4 resource="#h-dcterms-creator" id="h-dcterms-creator"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.14 </span>dcterms:creator</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2341,7 +2355,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 84</span><span style="text-transform: none">: dcterms:creator</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno71</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 84</span><span style="text-transform: none">: dcterms:creator</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno71</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> ;
@@ -2353,8 +2367,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="dcterms-issued" typeof="bibo:Chapter" resource="#dcterms-issued" property="bibo:hasPart">
-  <h4 id="h-dcterms-issued" resource="#h-dcterms-issued"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.15 </span>dcterms:issued</span></h4>
+<section property="bibo:hasPart" resource="#dcterms-issued" typeof="bibo:Chapter" id="dcterms-issued" class="term">
+  <h4 resource="#h-dcterms-issued" id="h-dcterms-issued"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.15 </span>dcterms:issued</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2363,7 +2377,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 85</span><span style="text-transform: none">: dcterms:issued</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno72</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 85</span><span style="text-transform: none">: dcterms:issued</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno72</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     dcterms:issued "2015-10-14T15:13:28Z" ;
@@ -2375,8 +2389,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="dcterms-modified" typeof="bibo:Chapter" resource="#dcterms-modified" property="bibo:hasPart">
-  <h4 id="h-dcterms-modified" resource="#h-dcterms-modified"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.16 </span>dcterms:modified</span></h4>
+<section property="bibo:hasPart" resource="#dcterms-modified" typeof="bibo:Chapter" id="dcterms-modified" class="term">
+  <h4 resource="#h-dcterms-modified" id="h-dcterms-modified"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.16 </span>dcterms:modified</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2385,12 +2399,12 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 86</span><span style="text-transform: none">: dcterms:modified</span></div><pre class="highlight prettyprint prettyprinted"></pre></div>
+    <div class="example"><div class="example-title marker"><span>Example 86</span><span style="text-transform: none">: dcterms:modified</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
   </div>
 </section>
 
-<section class="term" id="dcterms-rights" typeof="bibo:Chapter" resource="#dcterms-rights" property="bibo:hasPart">
-  <h4 id="h-dcterms-rights" resource="#h-dcterms-rights"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.17 </span>dcterms:rights</span></h4>
+<section property="bibo:hasPart" resource="#dcterms-rights" typeof="bibo:Chapter" id="dcterms-rights" class="term">
+  <h4 resource="#h-dcterms-rights" id="h-dcterms-rights"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.17 </span>dcterms:rights</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2403,12 +2417,12 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 87</span><span style="text-transform: none">: dcterms:rights</span></div><pre class="highlight prettyprint prettyprinted"></pre></div>
+    <div class="example"><div class="example-title marker"><span>Example 87</span><span style="text-transform: none">: dcterms:rights</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
   </div>
 </section>
 
-<section class="term" id="foaf-homepage" typeof="bibo:Chapter" resource="#foaf-homepage" property="bibo:hasPart">
-  <h4 id="h-foaf-homepage" resource="#h-foaf-homepage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.18 </span>foaf:homepage</span></h4>
+<section property="bibo:hasPart" resource="#foaf-homepage" typeof="bibo:Chapter" id="foaf-homepage" class="term">
+  <h4 resource="#h-foaf-homepage" id="h-foaf-homepage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.18 </span>foaf:homepage</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2416,7 +2430,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 88</span><span style="text-transform: none">: foaf:homepage</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno73</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 88</span><span style="text-transform: none">: foaf:homepage</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno73</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     as:generator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> .
@@ -2427,8 +2441,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="foaf-mbox" typeof="bibo:Chapter" resource="#foaf-mbox" property="bibo:hasPart">
-  <h4 id="h-foaf-mbox" resource="#h-foaf-mbox"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.19 </span>foaf:mbox</span></h4>
+<section property="bibo:hasPart" resource="#foaf-mbox" typeof="bibo:Chapter" id="foaf-mbox" class="term">
+  <h4 resource="#h-foaf-mbox" id="h-foaf-mbox"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.19 </span>foaf:mbox</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2436,12 +2450,12 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 89</span><span style="text-transform: none">: foaf:mbox</span></div><pre class="highlight prettyprint prettyprinted"></pre></div>
+    <div class="example"><div class="example-title marker"><span>Example 89</span><span style="text-transform: none">: foaf:mbox</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
   </div>
 </section>
 
-<section class="term" id="foaf-mbox_sha1sum" typeof="bibo:Chapter" resource="#foaf-mbox_sha1sum" property="bibo:hasPart">
-  <h4 id="h-foaf-mbox_sha1sum" resource="#h-foaf-mbox_sha1sum"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.20 </span>foaf:mbox_sha1sum</span></h4>
+<section property="bibo:hasPart" resource="#foaf-mbox_sha1sum" typeof="bibo:Chapter" id="foaf-mbox_sha1sum" class="term">
+  <h4 resource="#h-foaf-mbox_sha1sum" id="h-foaf-mbox_sha1sum"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.20 </span>foaf:mbox_sha1sum</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2449,12 +2463,12 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 90</span><span style="text-transform: none">: foaf:mbox_sha1sum</span></div><pre class="highlight prettyprint prettyprinted"></pre></div>
+    <div class="example"><div class="example-title marker"><span>Example 90</span><span style="text-transform: none">: foaf:mbox_sha1sum</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
   </div>
 </section>
 
-<section class="term" id="foaf-name" typeof="bibo:Chapter" resource="#foaf-name" property="bibo:hasPart">
-  <h4 id="h-foaf-name" resource="#h-foaf-name"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.21 </span>foaf:name</span></h4>
+<section property="bibo:hasPart" resource="#foaf-name" typeof="bibo:Chapter" id="foaf-name" class="term">
+  <h4 resource="#h-foaf-name" id="h-foaf-name"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.21 </span>foaf:name</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2462,7 +2476,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 91</span><span style="text-transform: none">: foaf:name</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno74</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 91</span><span style="text-transform: none">: foaf:name</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno74</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> .
@@ -2473,8 +2487,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="foaf-nick" typeof="bibo:Chapter" resource="#foaf-nick" property="bibo:hasPart">
-  <h4 id="h-foaf-nick" resource="#h-foaf-nick"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.22 </span>foaf:nick</span></h4>
+<section property="bibo:hasPart" resource="#foaf-nick" typeof="bibo:Chapter" id="foaf-nick" class="term">
+  <h4 resource="#h-foaf-nick" id="h-foaf-nick"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.22 </span>foaf:nick</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2482,7 +2496,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 92</span><span style="text-transform: none">: foaf:nick</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno75</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 92</span><span style="text-transform: none">: foaf:nick</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno75</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> .
@@ -2493,8 +2507,8 @@ The namespace used for the Web Annotation Ontology is:
   </div>
 </section>
 
-<section class="term" id="rdf-type" typeof="bibo:Chapter" resource="#rdf-type" property="bibo:hasPart">
-  <h4 id="h-rdf-type" resource="#h-rdf-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.23 </span>rdf:type</span></h4>
+<section property="bibo:hasPart" resource="#rdf-type" typeof="bibo:Chapter" id="rdf-type" class="term">
+  <h4 resource="#h-rdf-type" id="h-rdf-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.23 </span>rdf:type</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2502,12 +2516,12 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 93</span><span style="text-transform: none">: rdf:type</span></div><pre class="highlight prettyprint prettyprinted"></pre></div>
+    <div class="example"><div class="example-title marker"><span>Example 93</span><span style="text-transform: none">: rdf:type</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
   </div>
 </section>
 
-<section class="term" id="rdf-value" typeof="bibo:Chapter" resource="#rdf-value" property="bibo:hasPart">
-  <h4 id="h-rdf-value" resource="#h-rdf-value"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.24 </span>rdf:value</span></h4>
+<section property="bibo:hasPart" resource="#rdf-value" typeof="bibo:Chapter" id="rdf-value" class="term">
+  <h4 resource="#h-rdf-value" id="h-rdf-value"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.24 </span>rdf:value</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2515,12 +2529,12 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 94</span><span style="text-transform: none">: rdf:value</span></div><pre class="highlight prettyprint prettyprinted"></pre></div>
+    <div class="example"><div class="example-title marker"><span>Example 94</span><span style="text-transform: none">: rdf:value</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
   </div>
 </section>
 
-<section class="term" id="rdfs-label" typeof="bibo:Chapter" resource="#rdfs-label" property="bibo:hasPart">
-  <h4 id="h-rdfs-label" resource="#h-rdfs-label"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.25 </span>rdfs:label</span></h4>
+<section property="bibo:hasPart" resource="#rdfs-label" typeof="bibo:Chapter" id="rdfs-label" class="term">
+  <h4 resource="#h-rdfs-label" id="h-rdfs-label"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.25 </span>rdfs:label</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2529,12 +2543,12 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 95</span><span style="text-transform: none">: rdfs:label</span></div><pre class="highlight prettyprint prettyprinted"></pre></div>
+    <div class="example"><div class="example-title marker"><span>Example 95</span><span style="text-transform: none">: rdfs:label</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
   </div>
 </section>
 
-<section class="term" id="schema-audience-1" typeof="bibo:Chapter" resource="#schema-audience-1" property="bibo:hasPart">
-  <h4 id="h-schema-audience-1" resource="#h-schema-audience-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.26 </span>schema:audience</span></h4>
+<section property="bibo:hasPart" resource="#schema-audience-1" typeof="bibo:Chapter" id="schema-audience-1" class="term">
+  <h4 resource="#h-schema-audience-1" id="h-schema-audience-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.26 </span>schema:audience</span></h4>
   <p></p>
   <div class="tech">
     <ul>
@@ -2542,7 +2556,7 @@ The namespace used for the Web Annotation Ontology is:
     </ul>
   </div>
   <div>
-    <div class="example"><div class="example-title marker"><span>Example 96</span><span style="text-transform: none">: schema:Audience</span></div><pre class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno76</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
+    <div class="example"><div class="example-title marker"><span>Example 96</span><span style="text-transform: none">: schema:Audience</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno76</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
     oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
     oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
     schema:audience </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">roles</span><span class="pun">/</span><span class="atn">musician</span><span class="tag">&gt;</span><span class="pln"> .
@@ -2555,14 +2569,14 @@ The namespace used for the Web Annotation Ontology is:
 </section> <!-- /Recommended Properties -->
 </section> <!-- /Recommended Ontologies -->
 
-<section id="extensions" typeof="bibo:Chapter" resource="#extensions" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-extensions" resource="#h-extensions"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Extensions</span></h2>
+<section property="bibo:hasPart" resource="#extensions" typeof="bibo:Chapter" id="extensions">
+<!--OddPage--><h2 resource="#h-extensions" id="h-extensions"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Extensions</span></h2>
 
-<p>This vocabulary may be extended in the regular way, by creating new or importing existing predicates and classes from other RDF based ontologies. Extensions may be made to any resource, including adding new objects as well as properties. If there is a property in one of the ontologies that are already included in the context, then it is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to use a CURIE, the namespace and property name separated by a <code>:</code> character, as the JSON-LD key rather than creating a new context.</p>
+<p>This vocabulary may be extended in the regular way, by creating new or importing existing predicates and classes from other RDF based ontologies. Extensions may be made to any resource, including adding new objects as well as properties. If there is a property in one of the ontologies that are already included in the context, then it is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> to use a CURIE, the namespace and property name separated by a <code>:</code> character, as the JSON-LD key rather than creating a new context.</p>
 
 <p>For example, it is easier to add <code>skos:prefLabel</code> to the Annotation rather than requiring clients to download a new context document to discover the mapping.</p>
 
-  <div class="example"><div class="example-title marker"><span>Example 97</span><span style="text-transform: none">: Extension Example 1</span></div><pre class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
+  <div class="example"><div class="example-title marker"><span>Example 97</span><span style="text-transform: none">: Extension Example 1</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno77"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
@@ -2578,11 +2592,11 @@ The namespace used for the Web Annotation Ontology is:
 </span><span class="pun">}</span></pre></div>
 
 
-<p>In order to ensure a lack of collision between key names, a JSON-LD context document <em class="rfc2119" title="SHOULD">SHOULD</em> be made available when the term is not from an ontology that is already in the Web Annotation context. Extension contexts <em class="rfc2119" title="MUST NOT">MUST NOT</em> redefine existing JSON-LD keys from the Web Annotation context.  Implementations <em class="rfc2119" title="MUST">MUST</em> ignore unfamiliar properties when processing the data, but servers <em class="rfc2119" title="SHOULD">SHOULD</em> preserve them if they are part of a valid and included context.</p>
+<p>In order to ensure a lack of collision between key names, a JSON-LD context document <em title="SHOULD" class="rfc2119">SHOULD</em> be made available when the term is not from an ontology that is already in the Web Annotation context. Extension contexts <em title="MUST NOT" class="rfc2119">MUST NOT</em> redefine existing JSON-LD keys from the Web Annotation context.  Implementations <em title="MUST" class="rfc2119">MUST</em> ignore unfamiliar properties when processing the data, but servers <em title="SHOULD" class="rfc2119">SHOULD</em> preserve them if they are part of a valid and included context.</p>
 
-<p>For example, adding height and width for images from the EXIF vocabulary [<cite><a class="bibref" href="#bib-exif">exif</a></cite>] could be done by defining a JSON-LD context, and including the <code>height</code> and <code>width</code> properties and linking to the newly defined context in the Annotation's serialization.</p>
+<p>For example, adding height and width for images from the EXIF vocabulary [<cite><a href="#bib-exif" class="bibref">exif</a></cite>] could be done by defining a JSON-LD context, and including the <code>height</code> and <code>width</code> properties and linking to the newly defined context in the Annotation's serialization.</p>
 
-  <div class="example"><div class="example-title marker"><span>Example 98</span><span style="text-transform: none">: Extension Example 2</span></div><pre class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
+  <div class="example"><div class="example-title marker"><span>Example 98</span><span style="text-transform: none">: Extension Example 2</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
     </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"http://example.org/images/ns/extension.jsonld"</span><span class="pln">
@@ -2602,19 +2616,19 @@ The namespace used for the Web Annotation Ontology is:
   </span><span class="pun">}</span><span class="pln">
 </span><span class="pun">}</span></pre></div>
 
-<p>Note that the current JSON-LD [<cite><a class="bibref" href="#bib-JSON-LD">JSON-LD</a></cite>] specification does not allow arrays to contain other arrays directly.  As JSON-LD is the <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> serialization format, extensions <em class="rfc2119" title="SHOULD">SHOULD</em> avoid the use of this pattern.</p>
+<p>Note that the current JSON-LD [<cite><a href="#bib-JSON-LD" class="bibref">JSON-LD</a></cite>] specification does not allow arrays to contain other arrays directly.  As JSON-LD is the <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization format, extensions <em title="SHOULD" class="rfc2119">SHOULD</em> avoid the use of this pattern.</p>
 
 
 </section>
 
 
-<section class="appendix" id="json-ld-context" typeof="bibo:Chapter" resource="#json-ld-context" property="bibo:hasPart">
-  <!--OddPage--><h2 id="h-json-ld-context" resource="#h-json-ld-context"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>JSON-LD Context</span></h2>
+<section property="bibo:hasPart" resource="#json-ld-context" typeof="bibo:Chapter" id="json-ld-context" class="appendix">
+  <!--OddPage--><h2 resource="#h-json-ld-context" id="h-json-ld-context"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>JSON-LD Context</span></h2>
 
 <p>
-The <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> serialization format is [<cite><a class="bibref" href="#bib-JSON-LD">JSON-LD</a></cite>]. The JSON-LD context presented below is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to ensure consistency between implementations, and <em class="rfc2119" title="SHOULD">SHOULD</em> be referenced as <code>http://www.w3.org/ns/anno.jsonld</code>.  The same URI <em class="rfc2119" title="SHOULD">SHOULD</em> be used as the profile URI for representations that conform to the model and context.</p>
+The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization format is [<cite><a href="#bib-JSON-LD" class="bibref">JSON-LD</a></cite>]. The JSON-LD context presented below is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> to ensure consistency between implementations, and <em title="SHOULD" class="rfc2119">SHOULD</em> be referenced as <code>http://www.w3.org/ns/anno.jsonld</code>.  The same URI <em title="SHOULD" class="rfc2119">SHOULD</em> be used as the profile URI for representations that conform to the model and context.</p>
 
-<pre class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
+<pre style="" class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
     </span><span class="str">"oa"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"http://www.w3.org/ns/oa#"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"dc"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"http://purl.org/dc/elements/1.1/"</span><span class="pun">,</span><span class="pln">
@@ -2660,7 +2674,7 @@ The <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> serialization forma
     </span><span class="str">"Organization"</span><span class="pun">:</span><span class="pln">         </span><span class="str">"foaf:Organization"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"AnnotationCollection"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:OrderedCollection"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"AnnotationPage"</span><span class="pun">:</span><span class="pln">       </span><span class="str">"as:OrderedCollectionPage"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Audience"</span><span class="pun">:</span><span class="pln">             </span><span class="str">"schema:Audience"</span><span class="pun">,</span><span class="pln">
+    </span><span class="str">"Audience"</span><span class="pun">:</span><span class="pln">             </span><span class="str">"schema:Audience"</span><span class="pun">,</span><span class="pln"> 
 
     </span><span class="str">"Motivation"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"oa:Motivation"</span><span class="pun">,</span><span class="pln">
     </span><span class="str">"bookmarking"</span><span class="pun">:</span><span class="pln">   </span><span class="str">"oa:bookmarking"</span><span class="pun">,</span><span class="pln">
@@ -2735,17 +2749,17 @@ The <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> serialization forma
 </span></pre>
 </section>
 
-<section class="appendix" id="json-ld-frames" typeof="bibo:Chapter" resource="#json-ld-frames" property="bibo:hasPart">
-  <!--OddPage--><h2 id="h-json-ld-frames" resource="#h-json-ld-frames"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>JSON-LD Frames</span></h2>
+<section property="bibo:hasPart" resource="#json-ld-frames" typeof="bibo:Chapter" id="json-ld-frames" class="appendix">
+  <!--OddPage--><h2 resource="#h-json-ld-frames" id="h-json-ld-frames"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>JSON-LD Frames</span></h2>
 
-<p>There is an unofficial, yet well implemented, JSON-LD specification [<cite><a class="bibref" href="#bib-json-ld-framing">json-ld-framing</a></cite>] that describes a deterministic layout for serializing an RDF graph into a particular JSON-LD document layout.  Applying the following frames to the graph of information will generate JSON as close as possible to the serialization recommended by the Web Annotation Data Model.</p>
+<p>There is an unofficial, yet well implemented, JSON-LD specification [<cite><a href="#bib-json-ld-framing" class="bibref">json-ld-framing</a></cite>] that describes a deterministic layout for serializing an RDF graph into a particular JSON-LD document layout.  Applying the following frames to the graph of information will generate JSON as close as possible to the serialization recommended by the Web Annotation Data Model.</p>
 
-<section id="annotation-frame" typeof="bibo:Chapter" resource="#annotation-frame" property="bibo:hasPart">
-  <h3 id="h-annotation-frame" resource="#h-annotation-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.1 </span>Annotation Frame</span></h3>
+<section property="bibo:hasPart" resource="#annotation-frame" typeof="bibo:Chapter" id="annotation-frame">
+  <h3 resource="#h-annotation-frame" id="h-annotation-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.1 </span>Annotation Frame</span></h3>
 <p>
 A Frame for serializing a single Annotation.</p>
 
-<pre class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
+<pre style="" class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@omitDefault"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
@@ -2762,12 +2776,12 @@ A Frame for serializing a single Annotation.</p>
 </span></pre>
 </section>
 
-<section id="annotation-collection-frame" typeof="bibo:Chapter" resource="#annotation-collection-frame" property="bibo:hasPart">
-  <h3 id="h-annotation-collection-frame" resource="#h-annotation-collection-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.2 </span>Annotation Collection Frame</span></h3>
+<section property="bibo:hasPart" resource="#annotation-collection-frame" typeof="bibo:Chapter" id="annotation-collection-frame">
+  <h3 resource="#h-annotation-collection-frame" id="h-annotation-collection-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.2 </span>Annotation Collection Frame</span></h3>
 
 <p>A Frame for serializing a Collection of Annotations.</p>
 
-<pre class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
+<pre style="" class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
     </span><span class="str">"@context"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
     	</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
     	</span><span class="str">"http://www.w3.org/ns/ldp.jsonld"</span><span class="pln">
@@ -2778,15 +2792,15 @@ A Frame for serializing a single Annotation.</p>
 </span><span class="pun">}</span><span class="pln">
 </span></pre>
 
-<div class="note"><div class="note-title marker" aria-level="4" role="heading" id="h-note5"><span>Note</span></div><div class="">If it is instead desirable to embed the first page of the Collection, change the <code>false</code> for <code>first</code> to <code>true</code>.</div></div>
+<div class="note"><div id="h-note5" role="heading" aria-level="4" class="note-title marker"><span>Note</span></div><div class="">If it is instead desirable to embed the first page of the Collection, change the <code>false</code> for <code>first</code> to <code>true</code>.</div></div>
 
 </section>
-<section id="annotation-page-frame" typeof="bibo:Chapter" resource="#annotation-page-frame" property="bibo:hasPart">
-  <h3 id="h-annotation-page-frame" resource="#h-annotation-page-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.3 </span>Annotation Page Frame</span></h3>
+<section property="bibo:hasPart" resource="#annotation-page-frame" typeof="bibo:Chapter" id="annotation-page-frame">
+  <h3 resource="#h-annotation-page-frame" id="h-annotation-page-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.3 </span>Annotation Page Frame</span></h3>
 
 <p>A Frame for serializing a Page from a Collection of Annotations.</p>
 
-<pre class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
+<pre style="" class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
   </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"@omitDefault"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">,</span><span class="pln">
   </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"AnnotationPage"</span><span class="pun">,</span><span class="pln">
@@ -2799,13 +2813,13 @@ A Frame for serializing a single Annotation.</p>
 </section>
 </section>
 
-<section class="appendix" id="extending-motivations" typeof="bibo:Chapter" resource="#extending-motivations" property="bibo:hasPart">
-  <!--OddPage--><h2 id="h-extending-motivations" resource="#h-extending-motivations"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>Extending Motivations</span></h2>
+<section property="bibo:hasPart" resource="#extending-motivations" typeof="bibo:Chapter" id="extending-motivations" class="appendix">
+  <!--OddPage--><h2 resource="#h-extending-motivations" id="h-extending-motivations"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>Extending Motivations</span></h2>
 
-<p>Although the list of Motivations in the specification is derived from an extensive survey of the annotation landscape, there are many situations where more precise definitions are required or desirable. In these cases it is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to create a new Motivation resource and relate it to one or more that already exist.</p>
+<p>Although the list of Motivations in the specification is derived from an extensive survey of the annotation landscape, there are many situations where more precise definitions are required or desirable. In these cases it is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> to create a new Motivation resource and relate it to one or more that already exist.</p>
 
-<p>New Motivations <em class="rfc2119" title="MUST">MUST</em> be instances of <code>oa:Motivation</code>, which is a subClass of <code>skos:Concept</code>.
-The <code>skos:broader</code> relationship <em class="rfc2119" title="SHOULD">SHOULD</em> be asserted between the new Motivation and at least one existing Motivation, if there are any that are broader in scope.  Other relationships, such as <code>skos:relatedMatch</code>, <code>skos:exactMatch</code> and <code>skos:closeMatch</code>, <em class="rfc2119" title="SHOULD">SHOULD</em> also be asserted to concepts created by other communities.
+<p>New Motivations <em title="MUST" class="rfc2119">MUST</em> be instances of <code>oa:Motivation</code>, which is a subClass of <code>skos:Concept</code>.
+The <code>skos:broader</code> relationship <em title="SHOULD" class="rfc2119">SHOULD</em> be asserted between the new Motivation and at least one existing Motivation, if there are any that are broader in scope.  Other relationships, such as <code>skos:relatedMatch</code>, <code>skos:exactMatch</code> and <code>skos:closeMatch</code>, <em title="SHOULD" class="rfc2119">SHOULD</em> also be asserted to concepts created by other communities.
 </p>
 
 <h2 id="model">Model</h2>
@@ -2815,8 +2829,8 @@ The <code>skos:broader</code> relationship <em class="rfc2119" title="SHOULD">SH
     </figure>
 </section>
 
-<section class="appendix" id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">D. </span>Acknowledgements</span></h2>
+<section property="bibo:hasPart" resource="#acknowledgements" typeof="bibo:Chapter" id="acknowledgements" class="appendix">
+<!--OddPage--><h2 resource="#h-acknowledgements" id="h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">D. </span>Acknowledgements</span></h2>
 
 <p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>.  The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model.
 </p>
@@ -2832,19 +2846,19 @@ Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven
 
 
 
-<section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-DC-TERMS">[DC-TERMS]</dt><dd>Dublin Core Metadata Initiative. <a href="http://dublincore.org/documents/2010/10/11/dcmi-terms/" property="dc:requires"><cite>Dublin Core Metadata Initiative Terms, version 1.1.</cite></a> 11 October 2010. DCMI Recommendation. URL: <a href="http://dublincore.org/documents/2010/10/11/dcmi-terms/" property="dc:requires">http://dublincore.org/documents/2010/10/11/dcmi-terms/</a>.
-</dd><dt id="bib-DC11">[DC11]</dt><dd>Dublin Core metadata initiative. <a href="http://dublincore.org/documents/dcmi-terms/" property="dc:requires"><cite>Dublin Core metadata element set, version 1.1</cite></a>. July 1999. Dublin Core recommendation. URL: <a href="http://dublincore.org/documents/dcmi-terms/" property="dc:requires">http://dublincore.org/documents/dcmi-terms/</a>
-</dd><dt id="bib-FOAF">[FOAF]</dt><dd>Dan Brickley; Libby Miller. FOAF project. <a href="http://xmlns.com/foaf/spec" property="dc:requires"><cite>FOAF Vocabulary Specification 0.99 (Paddington Edition)</cite></a>. 14 January 2014. URL: <a href="http://xmlns.com/foaf/spec" property="dc:requires">http://xmlns.com/foaf/spec</a>
-</dd><dt id="bib-JSON-LD">[JSON-LD]</dt><dd>Manu Sporny; Gregg Kellogg; Markus Lanthaler. W3C. <a href="http://www.w3.org/TR/json-ld/" property="dc:requires"><cite>JSON-LD 1.0</cite></a>. 16 January 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/json-ld/" property="dc:requires">http://www.w3.org/TR/json-ld/</a>
-</dd><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
-</dd><dt id="bib-Turtle">[Turtle]</dt><dd>Eric Prud'hommeaux; Gavin Carothers. W3C. <a href="http://www.w3.org/TR/turtle/" property="dc:requires"><cite>RDF 1.1 Turtle</cite></a>. 25 February 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/turtle/" property="dc:requires">http://www.w3.org/TR/turtle/</a>
-</dd><dt id="bib-activitystreams-vocabulary">[activitystreams-vocabulary]</dt><dd>James Snell; Evan Prodromou. W3C. <a href="http://www.w3.org/TR/activitystreams-vocabulary/" property="dc:requires"><cite>Activity Vocabulary</cite></a>. 15 December 2015. W3C Working Draft. URL: <a href="http://www.w3.org/TR/activitystreams-vocabulary/" property="dc:requires">http://www.w3.org/TR/activitystreams-vocabulary/</a>
-</dd><dt id="bib-web-annotation">[web-annotation]</dt><dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires"><cite>Web Annotation Data Model</cite></a>. 31 March 2016. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
-</dd><dt id="bib-annotation-protocol">[annotation-protocol]</dt><dd>Robert Sanderson. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/" property="dc:requires"><cite>Web Annotation Protocol</cite></a>. 31 March 2016. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a>
-</dd><dt id="bib-rdf-schema">[rdf-schema]</dt><dd>Dan Brickley; Ramanathan Guha. W3C. <a href="http://www.w3.org/TR/rdf-schema/" property="dc:requires"><cite>RDF Schema 1.1</cite></a>. 25 February 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/rdf-schema/" property="dc:requires">http://www.w3.org/TR/rdf-schema/</a>
-</dd><dt id="bib-rfc5988">[rfc5988]</dt><dd>M. Nottingham. IETF. <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires">https://tools.ietf.org/html/rfc5988</a>
-</dd><dt id="bib-skos-reference">[skos-reference]</dt><dd>Alistair Miles; Sean Bechhofer. W3C. <a href="http://www.w3.org/TR/skos-reference" property="dc:requires"><cite>SKOS Simple Knowledge Organization System Reference</cite></a>. 18 August 2009. W3C Recommendation. URL: <a href="http://www.w3.org/TR/skos-reference" property="dc:requires">http://www.w3.org/TR/skos-reference</a>
-</dd><dt id="bib-xmlschema-2">[xmlschema-2]</dt><dd>Paul V. Biron; Ashok Malhotra. W3C. <a href="http://www.w3.org/TR/xmlschema-2/" property="dc:requires"><cite>XML Schema Part 2: Datatypes Second Edition</cite></a>. 28 October 2004. W3C Recommendation. URL: <a href="http://www.w3.org/TR/xmlschema-2/" property="dc:requires">http://www.w3.org/TR/xmlschema-2/</a>
-</dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-exif">[exif]</dt><dd>W3C. <a href="https://www.w3.org/2003/12/exif/" property="dc:references"><cite>Exif Vocabulary Workspace - RDF Schema</cite></a>. URL: <a href="https://www.w3.org/2003/12/exif/" property="dc:references">https://www.w3.org/2003/12/exif/</a>
-</dd><dt id="bib-json-ld-framing">[json-ld-framing]</dt><dd>W3C JSON-LD Community Group. <a href="http://json-ld.org/spec/latest/json-ld-framing/" property="dc:references"><cite>JSON-LD Framing 1.0</cite></a>. URL: <a href="http://json-ld.org/spec/latest/json-ld-framing/" property="dc:references">http://json-ld.org/spec/latest/json-ld-framing/</a>
-</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script async="" defer="" src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>
+<section property="bibo:hasPart" resource="#references" typeof="bibo:Chapter" id="references" class="appendix"><!--OddPage--><h2 resource="#h-references" id="h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E. </span>References</span></h2><section property="bibo:hasPart" resource="#normative-references" typeof="bibo:Chapter" id="normative-references"><h3 resource="#h-normative-references" id="h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E.1 </span>Normative references</span></h3><dl resource="" class="bibliography"><dt id="bib-DC-TERMS">[DC-TERMS]</dt><dd>Dublin Core Metadata Initiative. <a property="dc:requires" href="http://dublincore.org/documents/2010/10/11/dcmi-terms/"><cite>Dublin Core Metadata Initiative Terms, version 1.1.</cite></a> 11 October 2010. DCMI Recommendation. URL: <a property="dc:requires" href="http://dublincore.org/documents/2010/10/11/dcmi-terms/">http://dublincore.org/documents/2010/10/11/dcmi-terms/</a>.
+</dd><dt id="bib-DC11">[DC11]</dt><dd>Dublin Core metadata initiative. <a property="dc:requires" href="http://dublincore.org/documents/2012/06/14/dces/"><cite>Dublin Core Metadata Element Set, Version 1.1</cite></a>. 14 June 2012. DCMI recommendation. URL: <a property="dc:requires" href="http://dublincore.org/documents/2012/06/14/dces/">http://dublincore.org/documents/2012/06/14/dces/</a>
+</dd><dt id="bib-FOAF">[FOAF]</dt><dd>Dan Brickley; Libby Miller. FOAF project. <a property="dc:requires" href="http://xmlns.com/foaf/spec"><cite>FOAF Vocabulary Specification 0.99 (Paddington Edition)</cite></a>. 14 January 2014. URL: <a property="dc:requires" href="http://xmlns.com/foaf/spec">http://xmlns.com/foaf/spec</a>
+</dd><dt id="bib-JSON-LD">[JSON-LD]</dt><dd>Manu Sporny; Gregg Kellogg; Markus Lanthaler. W3C. <a property="dc:requires" href="http://www.w3.org/TR/json-ld/"><cite>JSON-LD 1.0</cite></a>. 16 January 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/json-ld/">http://www.w3.org/TR/json-ld/</a>
+</dd><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+</dd><dt id="bib-Turtle">[Turtle]</dt><dd>Eric Prud'hommeaux; Gavin Carothers. W3C. <a property="dc:requires" href="http://www.w3.org/TR/turtle/"><cite>RDF 1.1 Turtle</cite></a>. 25 February 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/turtle/">http://www.w3.org/TR/turtle/</a>
+</dd><dt id="bib-activitystreams-vocabulary">[activitystreams-vocabulary]</dt><dd>James Snell; Evan Prodromou. W3C. <a property="dc:requires" href="http://www.w3.org/TR/activitystreams-vocabulary/"><cite>Activity Vocabulary</cite></a>. 15 December 2015. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/activitystreams-vocabulary/">http://www.w3.org/TR/activitystreams-vocabulary/</a>
+</dd><dt id="bib-annotation-model">[annotation-model]</dt><dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/"><cite>Web Annotation Data Model</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
+</dd><dt id="bib-annotation-protocol">[annotation-protocol]</dt><dd>Robert Sanderson. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/"><cite>Web Annotation Protocol</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a>
+</dd><dt id="bib-rdf-schema">[rdf-schema]</dt><dd>Dan Brickley; Ramanathan Guha. W3C. <a property="dc:requires" href="http://www.w3.org/TR/rdf-schema/"><cite>RDF Schema 1.1</cite></a>. 25 February 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/rdf-schema/">http://www.w3.org/TR/rdf-schema/</a>
+</dd><dt id="bib-rfc5988">[rfc5988]</dt><dd>M. Nottingham. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988">https://tools.ietf.org/html/rfc5988</a>
+</dd><dt id="bib-skos-reference">[skos-reference]</dt><dd>Alistair Miles; Sean Bechhofer. W3C. <a property="dc:requires" href="http://www.w3.org/TR/skos-reference"><cite>SKOS Simple Knowledge Organization System Reference</cite></a>. 18 August 2009. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/skos-reference">http://www.w3.org/TR/skos-reference</a>
+</dd><dt id="bib-xmlschema-2">[xmlschema-2]</dt><dd>Paul V. Biron; Ashok Malhotra. W3C. <a property="dc:requires" href="http://www.w3.org/TR/xmlschema-2/"><cite>XML Schema Part 2: Datatypes Second Edition</cite></a>. 28 October 2004. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>
+</dd></dl></section><section property="bibo:hasPart" resource="#informative-references" typeof="bibo:Chapter" id="informative-references"><h3 resource="#h-informative-references" id="h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E.2 </span>Informative references</span></h3><dl resource="" class="bibliography"><dt id="bib-exif">[exif]</dt><dd>W3C. <a property="dc:references" href="https://www.w3.org/2003/12/exif/"><cite>Exif Vocabulary Workspace - RDF Schema</cite></a>. URL: <a property="dc:references" href="https://www.w3.org/2003/12/exif/">https://www.w3.org/2003/12/exif/</a>
+</dd><dt id="bib-json-ld-framing">[json-ld-framing]</dt><dd>W3C JSON-LD Community Group. <a property="dc:references" href="http://json-ld.org/spec/latest/json-ld-framing/"><cite>JSON-LD Framing 1.0</cite></a>. URL: <a property="dc:references" href="http://json-ld.org/spec/latest/json-ld-framing/">http://json-ld.org/spec/latest/json-ld-framing/</a>
+</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js" defer="" async=""></script></body></html>


### PR DESCRIPTION
This fixes #193 by adding explicit text to the 1.1 Namespaces section.

It also includes direct links to the OWL version of the ontology (depending on issue #66).
