### PR TITLE
Load ReSpec over HTTPS

### DIFF
--- a/model/fpwd/index.html
+++ b/model/fpwd/index.html
@@ -35,7 +35,7 @@
 
 </style>
 <script src="nanotabs.js" type="text/javascript"></script>
-        <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> 
+        <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> 
         <script class='remove'>
       var respecConfig = {
           specStatus: "FPWD", 

--- a/model/medias.html
+++ b/model/medias.html
@@ -31,7 +31,7 @@
             color: #005A9C;
         }
       </style>
-      <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
+      <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
       <script class='remove'>
       var respecConfig = {
           specStatus: "base",

--- a/model/wd/AnnoLevelMotive.html
+++ b/model/wd/AnnoLevelMotive.html
@@ -57,7 +57,7 @@
           color:#550;
       }</style>
     <script src="http://w3c.github.io/web-annotation/model/wd/nanotabs.js" type="text/javascript"></script>
-    <script src="http://www.w3.org/Tools/respec/respec-w3c-common" async="async" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" async="async" class="remove"></script>
     <script class="remove">
       var respecConfig = {
           specStatus: "base", 

--- a/model/wd/RequireSpecificResource.html
+++ b/model/wd/RequireSpecificResource.html
@@ -56,7 +56,7 @@
           color:#550;
       }</style>
     <script src="http://w3c.github.io/web-annotation/model/wd/nanotabs.js" type="text/javascript"></script>
-    <script src="http://www.w3.org/Tools/respec/respec-w3c-common" async="async" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" async="async" class="remove"></script>
     <script class="remove">
       var respecConfig = {
           specStatus: "base", 

--- a/model/wd/index-nametemplate.html
+++ b/model/wd/index-nametemplate.html
@@ -39,7 +39,7 @@
       </style>
       <script src="nanotabs.js" type="text/javascript"></script>
       <script src='respec-w3c-common.js' async='true' class='remove'></script>
-      <!-- <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> -->
+      <!-- <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> -->
       <script class='remove'>
       var respecConfig = {
           specStatus: "WD", 

--- a/model/wd/index-respec.html
+++ b/model/wd/index-respec.html
@@ -39,7 +39,7 @@
       </style>
       <script src="nanotabs.js" type="text/javascript"></script>
       <script src='respec-w3c-common.js' async='true' class='remove'></script>
-      <!-- <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> -->
+      <!-- <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> -->
       <script class='remove'>
       var respecConfig = {
           specStatus: "WD", 

--- a/model/wd/index.html
+++ b/model/wd/index.html
@@ -39,7 +39,7 @@
       </style>
       <script src="nanotabs.js" type="text/javascript"></script>
       
-      <!-- <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> -->
+      <!-- <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> -->
        
     <style>/*****************************************************************
  * ReSpec 3 CSS

--- a/model/wd/roles.html
+++ b/model/wd/roles.html
@@ -39,7 +39,7 @@ div.example {
 
 </style>
   <script src="nanotabs.js" type="text/javascript"></script>
-  <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> 
+  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> 
   <script class='remove'>
       var respecConfig = {
           specStatus: "base", 

--- a/model/wd2/index-nametemplate.html
+++ b/model/wd2/index-nametemplate.html
@@ -29,7 +29,7 @@
 }
 
       </style>
-      <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
+      <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
       <script class='remove'>
       var respecConfig = {
           specStatus: "WD",

--- a/model/wd2/index-respec.html
+++ b/model/wd2/index-respec.html
@@ -33,7 +33,7 @@
 }
 
       </style>
-      <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
+      <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
       <script class='remove'>
       var respecConfig = {
           specStatus: "WD",

--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -29,7 +29,7 @@
 
 
 </style>
-        <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
+        <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
         <script class='remove'>
       var respecConfig = {
           specStatus: "WD",

--- a/protocol/wd/paging.html
+++ b/protocol/wd/paging.html
@@ -35,7 +35,7 @@
 
 </style>
 <script src="nanotabs.js" type="text/javascript"></script>
-        <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> 
+        <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script> 
         <script class='remove'>
       var respecConfig = {
           specStatus: "ED", 

--- a/selector-note/index-respec.html
+++ b/selector-note/index-respec.html
@@ -31,7 +31,7 @@
             color: #005A9C;
         }
       </style>
-      <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
+      <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
       <script class='remove'>
       var respecConfig = {
           specStatus: "ED",

--- a/vocab/wd/index-linktemplate.html
+++ b/vocab/wd/index-linktemplate.html
@@ -86,7 +86,7 @@
 }
 
       </style>
-      <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
+      <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
       <script class='remove'>
       var respecConfig = {
           specStatus: "WD",

--- a/vocab/wd/index-respec.html
+++ b/vocab/wd/index-respec.html
@@ -86,7 +86,7 @@
 }
 
       </style>
-      <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
+      <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
       <script class='remove'>
       var respecConfig = {
           specStatus: "WD", 


### PR DESCRIPTION
This ensures that the drafts hosted on GitHub pages load correctly over HTTPS. The HTTPS URL is now the recommended URL for these scripts in the ReSpec documentation at https://www.w3.org/respec/guide.html.
