### PR TITLE
Rob Editor Actions

### DIFF
--- a/jsonld/anno.jsonld
+++ b/jsonld/anno.jsonld
@@ -63,6 +63,10 @@
     "reviewing":     "oa:reviewing",
     "tagging":       "oa:tagging",
 
+    "auto":          "oa:autoDirection",
+    "ltr":           "oa:ltrDirection",
+    "rtl":           "oa:rtlDirection",
+
     "body":          {"@type": "@id", "@id": "oa:hasBody"},
     "target":        {"@type": "@id", "@id": "oa:hasTarget"},
     "source":        {"@type": "@id", "@id": "oa:hasSource"},
@@ -91,6 +95,7 @@
     "audience":      {"@type": "@id", "@id": "schema:audience"},
     "motivation":    {"@type": "@vocab", "@id": "oa:motivatedBy"},
     "purpose":       {"@type": "@vocab", "@id": "oa:hasPurpose"},
+    "textDirection": {"@type": "@vocab", "@id": "oa:textDirection"},
 
     "accessibility": "schema:accessibilityFeature",
     "bodyValue":     "oa:bodyValue",

--- a/jsonld/anno.jsonld
+++ b/jsonld/anno.jsonld
@@ -92,6 +92,7 @@
     "motivation":    {"@type": "@vocab", "@id": "oa:motivatedBy"},
     "purpose":       {"@type": "@vocab", "@id": "oa:hasPurpose"},
 
+    "accessibility": "schema:accessibilityFeature",
     "bodyValue":     "oa:bodyValue",
     "format":        "dc:format",
     "language":      "dc:language",

--- a/model/wd2/examples/correct/anno15.json
+++ b/model/wd2/examples/correct/anno15.json
@@ -6,7 +6,7 @@
     "id": "http://example.org/user1",
     "type": "Person",
     "name": "My Pseudonym",
-    "nick": "pseudo",
+    "account": "pseudo",
     "email_sha1": "58bad08927902ff9307b621c54716dcc5083e339"
   },
   "generator": {

--- a/model/wd2/examples/correct/anno17.json
+++ b/model/wd2/examples/correct/anno17.json
@@ -2,16 +2,11 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno17",
   "type": "Annotation",
-  "motivation": "bookmarking",
-  "body": [
-    {
-      "value": "readme",
-      "purpose": "tagging"
-    },
-    {
-      "value": "A good description of the topic that bears further investigation",
-      "purpose": "describing"
-    }
-  ],
-  "target": "http://example.com/page1"
+  "motivation": "commenting",
+  "body": "http://example.net/comment1",
+  "target": {
+    "id": "http://example.com/video1",
+    "type": "Video",
+    "accessibility": "captions"
+  }
 }

--- a/model/wd2/examples/correct/anno18.json
+++ b/model/wd2/examples/correct/anno18.json
@@ -2,9 +2,16 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno18",
   "type": "Annotation",
-  "body": {
-    "id": "http://example.net/review1",
-    "rights": "http://creativecommons.org/licenses/by/4.0/"
-  },
-  "target": "http://example.com/product1"
+  "motivation": "bookmarking",
+  "body": [
+    {
+      "value": "readme",
+      "purpose": "tagging"
+    },
+    {
+      "value": "A good description of the topic that bears further investigation",
+      "purpose": "describing"
+    }
+  ],
+  "target": "http://example.com/page1"
 }

--- a/model/wd2/examples/correct/anno19.json
+++ b/model/wd2/examples/correct/anno19.json
@@ -2,8 +2,6 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno19",
   "type": "Annotation",
-  "canonical": "urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df",
-  "via": "http://other.example.org/anno1",
   "body": {
     "id": "http://example.net/review1",
     "rights": "http://creativecommons.org/licenses/by/4.0/"

--- a/model/wd2/examples/correct/anno2.json
+++ b/model/wd2/examples/correct/anno2.json
@@ -10,6 +10,7 @@
   "target": {
     "id": "http://example.gov/patent1.pdf",
     "format": "application/pdf",
-    "language": "en"
+    "language": "en",
+    "textDirection": "ltr"
   }
 }

--- a/model/wd2/examples/correct/anno20.json
+++ b/model/wd2/examples/correct/anno20.json
@@ -2,13 +2,11 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno20",
   "type": "Annotation",
+  "canonical": "urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df",
+  "via": "http://other.example.org/anno1",
   "body": {
-    "type": "SpecificResource",
-    "purpose": "tagging",
-    "source": "http://example.org/city1"
+    "id": "http://example.net/review1",
+    "rights": "http://creativecommons.org/licenses/by/4.0/"
   },
-  "target": {
-    "id": "http://example.org/photo1",
-    "type": "Image"
-  }
+  "target": "http://example.com/product1"
 }

--- a/model/wd2/examples/correct/anno21.json
+++ b/model/wd2/examples/correct/anno21.json
@@ -3,11 +3,12 @@
   "id": "http://example.org/anno21",
   "type": "Annotation",
   "body": {
-    "source": "http://example.org/page1",
-    "selector": "http://example.org/paraselector1"
+    "type": "SpecificResource",
+    "purpose": "tagging",
+    "source": "http://example.org/city1"
   },
   "target": {
-    "source": "http://example.com/dataset1",
-    "selector": "http://example.org/dataselector1"
+    "id": "http://example.org/photo1",
+    "type": "Image"
   }
 }

--- a/model/wd2/examples/correct/anno22.json
+++ b/model/wd2/examples/correct/anno22.json
@@ -3,13 +3,11 @@
   "id": "http://example.org/anno22",
   "type": "Annotation",
   "body": {
-    "source": "http://example.org/video1",
-    "role": "describing",
-    "selector": {
-      "type": "FragmentSelector",
-      "conformsTo": "http://www.w3.org/TR/media-frags/",
-      "value": "t=30,60"
-    }
+    "source": "http://example.org/page1",
+    "selector": "http://example.org/paraselector1"
   },
-  "target": "http://example.org/image1"
+  "target": {
+    "source": "http://example.com/dataset1",
+    "selector": "http://example.org/dataselector1"
+  }
 }

--- a/model/wd2/examples/correct/anno23.json
+++ b/model/wd2/examples/correct/anno23.json
@@ -2,12 +2,14 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno23",
   "type": "Annotation",
-  "body": "http://example.org/note1",
-  "target": {
-    "source": "http://example.org/page1.html",
+  "body": {
+    "source": "http://example.org/video1",
+    "purpose": "describing",
     "selector": {
-      "type": "CssSelector",
-      "value": "#elemid > .elemclass + p"
+      "type": "FragmentSelector",
+      "conformsTo": "http://www.w3.org/TR/media-frags/",
+      "value": "t=30,60"
     }
-  }
+  },
+  "target": "http://example.org/image1"
 }

--- a/model/wd2/examples/correct/anno24.json
+++ b/model/wd2/examples/correct/anno24.json
@@ -6,8 +6,8 @@
   "target": {
     "source": "http://example.org/page1.html",
     "selector": {
-      "type": "XPathSelector",
-      "value": "/html/body/p[2]/table/tr[2]/td[3]/span"
+      "type": "CssSelector",
+      "value": "#elemid > .elemclass + p"
     }
   }
 }

--- a/model/wd2/examples/correct/anno25.json
+++ b/model/wd2/examples/correct/anno25.json
@@ -2,14 +2,12 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno25",
   "type": "Annotation",
-  "body": "http://example.org/comment1",
+  "body": "http://example.org/note1",
   "target": {
-    "source": "http://example.org/page1",
+    "source": "http://example.org/page1.html",
     "selector": {
-      "type": "TextQuoteSelector",
-      "exact": "anotation",
-      "prefix": "this is an ",
-      "suffix": " that has some"
+      "type": "XPathSelector",
+      "value": "/html/body/p[2]/table/tr[2]/td[3]/span"
     }
   }
 }

--- a/model/wd2/examples/correct/anno26.json
+++ b/model/wd2/examples/correct/anno26.json
@@ -2,13 +2,14 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno26",
   "type": "Annotation",
-  "body": "http://example.org/review1",
+  "body": "http://example.org/comment1",
   "target": {
-    "source": "http://example.org/ebook1",
+    "source": "http://example.org/page1",
     "selector": {
-      "type": "TextPositionSelector",
-      "start": 412,
-      "end": 795
+      "type": "TextQuoteSelector",
+      "exact": "anotation",
+      "prefix": "this is an ",
+      "suffix": " that has some"
     }
   }
 }

--- a/model/wd2/examples/correct/anno27.json
+++ b/model/wd2/examples/correct/anno27.json
@@ -2,13 +2,13 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno27",
   "type": "Annotation",
-  "body": "http://example.org/note1",
+  "body": "http://example.org/review1",
   "target": {
-    "source": "http://example.org/diskimg1",
+    "source": "http://example.org/ebook1",
     "selector": {
-      "type": "DataPositionSelector",
-      "start": 4096,
-      "end": 4104
+      "type": "TextPositionSelector",
+      "start": 412,
+      "end": 795
     }
   }
 }

--- a/model/wd2/examples/correct/anno28.json
+++ b/model/wd2/examples/correct/anno28.json
@@ -2,12 +2,13 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno28",
   "type": "Annotation",
-  "body": "http://example.org/road1",
+  "body": "http://example.org/note1",
   "target": {
-    "source": "http://example.org/map1",
+    "source": "http://example.org/diskimg1",
     "selector": {
-      "id": "http://example.org/svg1",
-      "type": "SvgSelector"
+      "type": "DataPositionSelector",
+      "start": 4096,
+      "end": 4104
     }
   }
 }

--- a/model/wd2/examples/correct/anno29.json
+++ b/model/wd2/examples/correct/anno29.json
@@ -6,8 +6,8 @@
   "target": {
     "source": "http://example.org/map1",
     "selector": {
-      "type": "SvgSelector",
-      "value": "<svg:svg> ... </svg:svg>"
+      "id": "http://example.org/svg1",
+      "type": "SvgSelector"
     }
   }
 }

--- a/model/wd2/examples/correct/anno30.json
+++ b/model/wd2/examples/correct/anno30.json
@@ -2,19 +2,12 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno30",
   "type": "Annotation",
-  "body": "http://example.org/comment1",
+  "body": "http://example.org/road1",
   "target": {
-    "source": "http://example.org/page1.html",
+    "source": "http://example.org/map1",
     "selector": {
-      "type": "RangeSelector",
-      "startSelector": {
-        "type": "XPathSelector",
-        "value": "//table[1]/tr[1]/td[2]"
-      },
-      "endSelector": {
-        "type": "XPathSelector",
-        "value": "//table[1]/tr[1]/td[4]"
-      }
+      "type": "SvgSelector",
+      "value": "<svg:svg> ... </svg:svg>"
     }
   }
 }

--- a/model/wd2/examples/correct/anno31.json
+++ b/model/wd2/examples/correct/anno31.json
@@ -4,15 +4,16 @@
   "type": "Annotation",
   "body": "http://example.org/comment1",
   "target": {
-    "source": "http://example.org/page1",
+    "source": "http://example.org/page1.html",
     "selector": {
-      "type": "FragmentSelector",
-      "value": "para5",
-      "refinedBy": {
-        "type": "TextQuoteSelector",
-        "exact": "Selected Text",
-        "prefix": "text before the ",
-        "suffix": " and text after it"
+      "type": "RangeSelector",
+      "startSelector": {
+        "type": "XPathSelector",
+        "value": "//table[1]/tr[1]/td[2]"
+      },
+      "endSelector": {
+        "type": "XPathSelector",
+        "value": "//table[1]/tr[1]/td[4]"
       }
     }
   }

--- a/model/wd2/examples/correct/anno32.json
+++ b/model/wd2/examples/correct/anno32.json
@@ -2,11 +2,18 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno32",
   "type": "Annotation",
-  "body": "http://example.org/note1",
+  "body": "http://example.org/comment1",
   "target": {
     "source": "http://example.org/page1",
-    "state": {
-      "id": "http://example.org/state1"
+    "selector": {
+      "type": "FragmentSelector",
+      "value": "para5",
+      "refinedBy": {
+        "type": "TextQuoteSelector",
+        "exact": "Selected Text",
+        "prefix": "text before the ",
+        "suffix": " and text after it"
+      }
     }
   }
 }

--- a/model/wd2/examples/correct/anno33.json
+++ b/model/wd2/examples/correct/anno33.json
@@ -6,9 +6,7 @@
   "target": {
     "source": "http://example.org/page1",
     "state": {
-      "type": "TimeState",
-      "cached": "http://archive.example.org/copy1",
-      "sourceDate": "2015-07-20T13:30:00Z"
+      "id": "http://example.org/state1"
     }
   }
 }

--- a/model/wd2/examples/correct/anno34.json
+++ b/model/wd2/examples/correct/anno34.json
@@ -2,12 +2,13 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno34",
   "type": "Annotation",
-  "body": "http://example.org/description1",
+  "body": "http://example.org/note1",
   "target": {
-    "source": "http://example.org/resource1",
+    "source": "http://example.org/page1",
     "state": {
-      "type": "HttpRequestState",
-      "value": "Accept: application/pdf"
+      "type": "TimeState",
+      "cached": "http://archive.example.org/copy1",
+      "sourceDate": "2015-07-20T13:30:00Z"
     }
   }
 }

--- a/model/wd2/examples/correct/anno35.json
+++ b/model/wd2/examples/correct/anno35.json
@@ -2,21 +2,12 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno35",
   "type": "Annotation",
-  "body": "http://example.org/comment1",
+  "body": "http://example.org/description1",
   "target": {
-    "source": "http://example.org/ebook1",
+    "source": "http://example.org/resource1",
     "state": {
-      "type": "TimeState",
-      "sourceDate": "2016-02-01T12:05:23Z",
-      "refinedBy": {
-        "type": "HttpRequestState",
-        "value": "Accept: application/pdf",
-        "refinedBy": {
-          "type": "FragmentSelector",
-          "value": "page=10",
-          "conformsTo": "http://tools.ietf.org/rfc/rfc3778"
-        }
-      }
+      "type": "HttpRequestState",
+      "value": "Accept: application/pdf"
     }
   }
 }

--- a/model/wd2/examples/correct/anno36.json
+++ b/model/wd2/examples/correct/anno36.json
@@ -2,10 +2,21 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno36",
   "type": "Annotation",
-  "stylesheet": "http://example.org/style1",
   "body": "http://example.org/comment1",
   "target": {
-    "source": "http://example.org/document1",
-    "styleClass": "red"
+    "source": "http://example.org/ebook1",
+    "state": {
+      "type": "TimeState",
+      "sourceDate": "2016-02-01T12:05:23Z",
+      "refinedBy": {
+        "type": "HttpRequestState",
+        "value": "Accept: application/pdf",
+        "refinedBy": {
+          "type": "FragmentSelector",
+          "value": "page=10",
+          "conformsTo": "http://tools.ietf.org/rfc/rfc3778"
+        }
+      }
+    }
   }
 }

--- a/model/wd2/examples/correct/anno37.json
+++ b/model/wd2/examples/correct/anno37.json
@@ -2,13 +2,10 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno37",
   "type": "Annotation",
-  "stylesheet": {
-    "type": "CssStylesheet",
-    "value": ".red { color: red }"
-  },
-  "body": "http://example.org/body1",
+  "stylesheet": "http://example.org/style1",
+  "body": "http://example.org/comment1",
   "target": {
-    "source": "http://example.org/target1",
+    "source": "http://example.org/document1",
     "styleClass": "red"
   }
 }

--- a/model/wd2/examples/correct/anno38.json
+++ b/model/wd2/examples/correct/anno38.json
@@ -2,14 +2,13 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno38",
   "type": "Annotation",
-  "body": "http://example.org/comment1",
+  "stylesheet": {
+    "type": "CssStylesheet",
+    "value": ".red { color: red }"
+  },
+  "body": "http://example.org/body1",
   "target": {
-    "source": "http://example.edu/article.pdf",
-    "selector": "http://example.org/selectors/html-selector1",
-    "renderedVia": {
-      "id": "http://example.com/pdf-to-html-library",
-      "type": "Software",
-      "schema:softwareVersion": "2.5"
-    }
+    "source": "http://example.org/target1",
+    "styleClass": "red"
   }
 }

--- a/model/wd2/examples/correct/anno39.json
+++ b/model/wd2/examples/correct/anno39.json
@@ -2,9 +2,14 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno39",
   "type": "Annotation",
-  "body": "http://example.org/note1",
+  "body": "http://example.org/comment1",
   "target": {
-    "source": "http://example.org/image1",
-    "scope": "http://example.org/page1"
+    "source": "http://example.edu/article.pdf",
+    "selector": "http://example.org/selectors/html-selector1",
+    "renderedVia": {
+      "id": "http://example.com/pdf-to-html-library",
+      "type": "Software",
+      "schema:softwareVersion": "2.5"
+    }
   }
 }

--- a/model/wd2/examples/correct/anno40.json
+++ b/model/wd2/examples/correct/anno40.json
@@ -2,81 +2,9 @@
   "@context": "http://www.w3.org/ns/anno.jsonld",
   "id": "http://example.org/anno40",
   "type": "Annotation",
-  "motivation": "commenting",
-  "creator": {
-    "id": "http://example.org/user1",
-    "type": "Person",
-    "name": "A. Person",
-    "nick": "user1"
-  },
-  "created": "2015-10-13T13:00:00Z",
-  "generator": {
-    "id": "http://example.org/client1",
-    "type": "SoftwareAgent",
-    "name": "Code v2.1",
-    "homepage": "http://example.org/homepage1"
-  },
-  "generated": "2015-10-14T15:13:28Z",
-  "stylesheet": {
-    "id": "http://example.org/stylesheet1",
-    "type": "CssStylesheet"
-  },
-  "body": [
-    {
-      "type": "TextualBody",
-      "purpose": "tagging",
-      "value": "love"
-    },
-    {
-      "type": "Choice",
-      "items": [
-        {
-          "type": "TextualBody",
-          "purpose": "describing",
-          "value": "I really love this particular bit of text in this XML. No really.",
-          "format": "text/plain",
-          "language": "en",
-          "creator": "http://example.org/user1"
-        },
-        {
-          "type": "SpecificResource",
-          "purpose": "describing",
-          "source": {
-            "id": "http://example.org/comment1",
-            "type": "Audio",
-            "format": "audio/mpeg",
-            "language": "de",
-            "creator": {
-              "id": "http://example.org/user2",
-              "type": "Person"
-            }
-          }
-        }
-      ]
-    }
-  ],
+  "body": "http://example.org/note1",
   "target": {
-    "type": "SpecificResource",
-    "styleClass": "mystyle",
-    "source": "http://example.com/document1",
-    "state": [
-      {
-        "type": "HttpRequestState",
-        "value": "Accept: application/xml"
-      },
-      {
-        "type": "TimeState",
-        "sourceDate": "2015-09-25T12:00:00Z"
-      }
-    ],
-    "selector": {
-      "type": "FragmentSelector",
-      "value": "xpointer(/doc/body/section[2]/para[1])",
-      "refinedBy": {
-        "type": "TextPositionSelector",
-        "start": 6,
-        "end": 27
-      }
-    }
+    "source": "http://example.org/image1",
+    "scope": "http://example.org/page1"
   }
 }

--- a/model/wd2/examples/correct/anno41.json
+++ b/model/wd2/examples/correct/anno41.json
@@ -1,0 +1,82 @@
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "id": "http://example.org/anno41",
+  "type": "Annotation",
+  "motivation": "commenting",
+  "creator": {
+    "id": "http://example.org/user1",
+    "type": "Person",
+    "name": "A. Person",
+    "account": "user1"
+  },
+  "created": "2015-10-13T13:00:00Z",
+  "generator": {
+    "id": "http://example.org/client1",
+    "type": "SoftwareAgent",
+    "name": "Code v2.1",
+    "homepage": "http://example.org/homepage1"
+  },
+  "generated": "2015-10-14T15:13:28Z",
+  "stylesheet": {
+    "id": "http://example.org/stylesheet1",
+    "type": "CssStylesheet"
+  },
+  "body": [
+    {
+      "type": "TextualBody",
+      "purpose": "tagging",
+      "value": "love"
+    },
+    {
+      "type": "Choice",
+      "items": [
+        {
+          "type": "TextualBody",
+          "purpose": "describing",
+          "value": "I really love this particular bit of text in this XML. No really.",
+          "format": "text/plain",
+          "language": "en",
+          "creator": "http://example.org/user1"
+        },
+        {
+          "type": "SpecificResource",
+          "purpose": "describing",
+          "source": {
+            "id": "http://example.org/comment1",
+            "type": "Audio",
+            "format": "audio/mpeg",
+            "language": "de",
+            "creator": {
+              "id": "http://example.org/user2",
+              "type": "Person"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "target": {
+    "type": "SpecificResource",
+    "styleClass": "mystyle",
+    "source": "http://example.com/document1",
+    "state": [
+      {
+        "type": "HttpRequestState",
+        "value": "Accept: application/xml"
+      },
+      {
+        "type": "TimeState",
+        "sourceDate": "2015-09-25T12:00:00Z"
+      }
+    ],
+    "selector": {
+      "type": "FragmentSelector",
+      "value": "xpointer(/doc/body/section[2]/para[1])",
+      "refinedBy": {
+        "type": "TextPositionSelector",
+        "start": 6,
+        "end": 27
+      }
+    }
+  }
+}

--- a/model/wd2/examples/correct/collection1.json
+++ b/model/wd2/examples/correct/collection1.json
@@ -5,7 +5,7 @@
   "type": "AnnotationCollection",
   "creator": "http://www.w3.org/",
   "label": "Annotation Examples",
-  "total": 40,
+  "total": 41,
   "first": {
     "id": "http://example.org/collection1/page1",
     "type": "AnnotationPage",
@@ -28,7 +28,8 @@
         "target": {
           "id": "http://example.gov/patent1.pdf",
           "format": "application/pdf",
-          "language": "en"
+          "language": "en",
+          "textDirection": "ltr"
         }
       },
       {
@@ -191,7 +192,7 @@
           "id": "http://example.org/user1",
           "type": "Person",
           "name": "My Pseudonym",
-          "nick": "pseudo",
+          "account": "pseudo",
           "email_sha1": "58bad08927902ff9307b621c54716dcc5083e339"
         },
         "generator": {
@@ -217,6 +218,17 @@
       {
         "id": "http://example.org/anno17",
         "type": "Annotation",
+        "motivation": "commenting",
+        "body": "http://example.net/comment1",
+        "target": {
+          "id": "http://example.com/video1",
+          "type": "Video",
+          "accessibility": "captions"
+        }
+      },
+      {
+        "id": "http://example.org/anno18",
+        "type": "Annotation",
         "motivation": "bookmarking",
         "body": [
           {
@@ -231,7 +243,7 @@
         "target": "http://example.com/page1"
       },
       {
-        "id": "http://example.org/anno18",
+        "id": "http://example.org/anno19",
         "type": "Annotation",
         "body": {
           "id": "http://example.net/review1",
@@ -240,7 +252,7 @@
         "target": "http://example.com/product1"
       },
       {
-        "id": "http://example.org/anno19",
+        "id": "http://example.org/anno20",
         "type": "Annotation",
         "canonical": "urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df",
         "via": "http://other.example.org/anno1",
@@ -251,7 +263,7 @@
         "target": "http://example.com/product1"
       },
       {
-        "id": "http://example.org/anno20",
+        "id": "http://example.org/anno21",
         "type": "Annotation",
         "body": {
           "type": "SpecificResource",
@@ -264,7 +276,7 @@
         }
       },
       {
-        "id": "http://example.org/anno21",
+        "id": "http://example.org/anno22",
         "type": "Annotation",
         "body": {
           "source": "http://example.org/page1",
@@ -276,11 +288,11 @@
         }
       },
       {
-        "id": "http://example.org/anno22",
+        "id": "http://example.org/anno23",
         "type": "Annotation",
         "body": {
           "source": "http://example.org/video1",
-          "role": "describing",
+          "purpose": "describing",
           "selector": {
             "type": "FragmentSelector",
             "conformsTo": "http://www.w3.org/TR/media-frags/",
@@ -290,7 +302,7 @@
         "target": "http://example.org/image1"
       },
       {
-        "id": "http://example.org/anno23",
+        "id": "http://example.org/anno24",
         "type": "Annotation",
         "body": "http://example.org/note1",
         "target": {
@@ -302,7 +314,7 @@
         }
       },
       {
-        "id": "http://example.org/anno24",
+        "id": "http://example.org/anno25",
         "type": "Annotation",
         "body": "http://example.org/note1",
         "target": {
@@ -314,7 +326,7 @@
         }
       },
       {
-        "id": "http://example.org/anno25",
+        "id": "http://example.org/anno26",
         "type": "Annotation",
         "body": "http://example.org/comment1",
         "target": {
@@ -328,7 +340,7 @@
         }
       },
       {
-        "id": "http://example.org/anno26",
+        "id": "http://example.org/anno27",
         "type": "Annotation",
         "body": "http://example.org/review1",
         "target": {
@@ -341,7 +353,7 @@
         }
       },
       {
-        "id": "http://example.org/anno27",
+        "id": "http://example.org/anno28",
         "type": "Annotation",
         "body": "http://example.org/note1",
         "target": {
@@ -354,7 +366,7 @@
         }
       },
       {
-        "id": "http://example.org/anno28",
+        "id": "http://example.org/anno29",
         "type": "Annotation",
         "body": "http://example.org/road1",
         "target": {
@@ -366,7 +378,7 @@
         }
       },
       {
-        "id": "http://example.org/anno29",
+        "id": "http://example.org/anno30",
         "type": "Annotation",
         "body": "http://example.org/road1",
         "target": {
@@ -378,7 +390,7 @@
         }
       },
       {
-        "id": "http://example.org/anno30",
+        "id": "http://example.org/anno31",
         "type": "Annotation",
         "body": "http://example.org/comment1",
         "target": {
@@ -397,7 +409,7 @@
         }
       },
       {
-        "id": "http://example.org/anno31",
+        "id": "http://example.org/anno32",
         "type": "Annotation",
         "body": "http://example.org/comment1",
         "target": {
@@ -415,7 +427,7 @@
         }
       },
       {
-        "id": "http://example.org/anno32",
+        "id": "http://example.org/anno33",
         "type": "Annotation",
         "body": "http://example.org/note1",
         "target": {
@@ -426,7 +438,7 @@
         }
       },
       {
-        "id": "http://example.org/anno33",
+        "id": "http://example.org/anno34",
         "type": "Annotation",
         "body": "http://example.org/note1",
         "target": {
@@ -439,7 +451,7 @@
         }
       },
       {
-        "id": "http://example.org/anno34",
+        "id": "http://example.org/anno35",
         "type": "Annotation",
         "body": "http://example.org/description1",
         "target": {
@@ -451,7 +463,7 @@
         }
       },
       {
-        "id": "http://example.org/anno35",
+        "id": "http://example.org/anno36",
         "type": "Annotation",
         "body": "http://example.org/comment1",
         "target": {
@@ -472,7 +484,7 @@
         }
       },
       {
-        "id": "http://example.org/anno36",
+        "id": "http://example.org/anno37",
         "type": "Annotation",
         "stylesheet": "http://example.org/style1",
         "body": "http://example.org/comment1",
@@ -482,7 +494,7 @@
         }
       },
       {
-        "id": "http://example.org/anno37",
+        "id": "http://example.org/anno38",
         "type": "Annotation",
         "stylesheet": {
           "type": "CssStylesheet",
@@ -495,7 +507,7 @@
         }
       },
       {
-        "id": "http://example.org/anno38",
+        "id": "http://example.org/anno39",
         "type": "Annotation",
         "body": "http://example.org/comment1",
         "target": {
@@ -509,7 +521,7 @@
         }
       },
       {
-        "id": "http://example.org/anno39",
+        "id": "http://example.org/anno40",
         "type": "Annotation",
         "body": "http://example.org/note1",
         "target": {
@@ -518,14 +530,14 @@
         }
       },
       {
-        "id": "http://example.org/anno40",
+        "id": "http://example.org/anno41",
         "type": "Annotation",
         "motivation": "commenting",
         "creator": {
           "id": "http://example.org/user1",
           "type": "Person",
           "name": "A. Person",
-          "nick": "user1"
+          "account": "user1"
         },
         "created": "2015-10-13T13:00:00Z",
         "generator": {

--- a/model/wd2/index-nametemplate.html
+++ b/model/wd2/index-nametemplate.html
@@ -397,7 +397,7 @@ The Web is distributed, with different systems working together to provide acces
 </table>
 
 <div class="note">
-The [[iana-media-types]] document provides the official registry of media types that can be used with the <code>format</code> property.  The [[w3c-language-tags]] article provides a good overview of the values that implementers can expect to encounter in the <code>language</code> property.  The notion of text direction is taken explicity from <a href="https://www.w3.org/TR/html5/dom.html#the-dir-attribute">HTML5's</a> <code>dir</code> attribute.
+The [[iana-media-types]] document provides the official registry of media types that can be used with the <code>format</code> property.  The [[w3c-language-tags]] article provides a good overview of the values that implementers can expect to encounter in the <code>language</code> property.  The notion of text direction is taken explicity from the HTML5 [[html5]] <code>dir</code> attribute.
 </div>
 
 <h4>Example</h4>

--- a/model/wd2/index-nametemplate.html
+++ b/model/wd2/index-nametemplate.html
@@ -385,13 +385,19 @@ The Web is distributed, with different systems working together to provide acces
 <br/>Bodies or Targets which are External Web Resources MUST have exactly 1 <code>id</code> with the value of the resource's <a>IRI</a>.
   </td></tr>
   <tr><td>language</td><td>Property</td><td>The language of the Web Resource's content
-  <br/>The Body or Target SHOULD have exactly 1 language associated with it, but MAY have 0 or more.  The value of the property SHOULD be a language code following the [[!bcp47]] specifiction.</td></tr>
+  <br/>The Body or Target SHOULD have exactly 1 language associated with it, but MAY have 0 or more.  The value of the property SHOULD be a language code following the [[!bcp47]] specification.</td></tr>
 <tr><td>format</td><td>Property</td><td>The format of the Web Resource's content
   <br/>The Body or Target SHOULD have exactly 1 format associated with it, but MAY have 0 or more.  The value of the property SHOULD be the media-type of the format, following the [[!rfc6838]] specification.</td></tr>
+<tr><td>textDirection</td><td>Relationship</td><td>The direction of the text of the resource.  
+<br/>The Body or Target MAY have exactly 1 textDirection associated with it.  The value of the property MUST be one of the directions defined below (<code>ltr</code>, <code>rtl</code>, or <code>auto</code>).
+</td></tr>
+<tr><td>ltr</td><td>Instance</td><td>The direction that indicates the value of the resource is explicitly directionally isolated left-to-right text.</td></tr>
+<tr><td>rtl</td><td>Instance</td><td>The direction that indicates the value of the resource is explicitly directionally isolated right-to-left text.</td></tr>
+<tr><td>auto</td><td>Instance</td><td>The direction that indicates the value of the resource is explicitly directionally isolated text, and the direction is to be programmatically determined using the value.</td></tr>
 </table>
 
 <div class="note">
-The [[iana-media-types]] document provides the official registry of media types that can be used with the <code>format</code> property.  The [[w3c-language-tags]] article provides a good overview of the values that implementers can expect to encounter in the <code>language</code> property.
+The [[iana-media-types]] document provides the official registry of media types that can be used with the <code>format</code> property.  The [[w3c-language-tags]] article provides a good overview of the values that implementers can expect to encounter in the <code>language</code> property.  The notion of text direction is taken explicity from <a href="https://www.w3.org/TR/html5/dom.html#the-dir-attribute">HTML5's</a> <code>dir</code> attribute.
 </div>
 
 <h4>Example</h4>
@@ -409,7 +415,8 @@ The [[iana-media-types]] document provides the official registry of media types 
   "target": {
     "id": "http://example.gov/patent1.pdf",
     "format": "application/pdf",
-    "language": "en"
+    "language": "en",
+    "textDirection": "ltr"
   }
 }
 </pre>
@@ -577,14 +584,13 @@ There are several restrictions on when this form may be used and how it is to be
   <li>MUST NOT have a language associated with it.</li>
   <li>MUST be interpreted as if it were the value of the <code>value</code> property of a Textual Body.</li>
 	<li>MUST be interpreted as if the Textual Body resource had a <code>format</code> property with the value <code>text/plain</code>.</li>
-  <li>MUST be interpreted as if the Textual Body resource had a <a href="#motivation-and-purpose"><code>purpose</code> property</a> with the value of <code>commenting</code>.</li>
 	<li>MUST NOT have the value of other properties of the Textual Body inferred from similar properties on the Annotation resource.</li>
 </ul>
 </p>
 
 <p>If any of the interpretations above are not correct, then the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a> MUST be used instead.</p>
 
-<div class="note">Systems MAY rewrite Annotations to instead use the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a>, rather than maintaining the <code>bodyValue</code> form.</div>
+<div class="note">Systems MAY rewrite Annotations to instead use the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a>, rather than maintaining the <code>bodyValue</code> form.  The <code>TextualBody</code> construction is preferred, as language and format information are important for clients processing the Annotation.</div>
 
 <h4>Example</h4>
 
@@ -966,6 +972,43 @@ The use of <code>audience</code> does not imply nor enable any access restrictio
 </section>
 
 <section>
+  <h3>Accessibility of Content</h3>
+
+<p>Access to information is recognized as a basic human right by the United Nations. The Web is able to remove barriers to communication and interaction regardless of various physical impediments. This support social inclusion, but also increases the potential audience of the information.  For resources that are used as the body or target of an Annotation, it is valuable to record the features of that resource that provide easier access for users with various and diverse ranges of ability.</p>
+
+<p><b>Example Use Case:</b> %%name%% has very limited ability to hear sound, and prefers to read captions when interacting with videos. She uses her annotation client to make a comment on such a video, and to help others in the same situation, the client includes that the video has this accessibility feature.</p>
+
+<h4>Model</h4>
+
+<table class="model">
+<tr><th>Term</th><th>Type</th><th>Description</th></tr>
+<tr><td>accessibility</td><td>Property</td><td>One or more strings from an enumerated list of values that each describes an accessibility feature that the resource has.
+<br/>There MAY be 0 or more accessibility features listed for each Body or Target resource.</td></tr>
+</table>
+
+<p class="note">
+The current list of values is referenced from the <a href="http://schema.org/accessibilityFeature">schema.org description</a> of the <code>accessibilityFeature</code> property.
+</p>
+
+<h4>Example</h4>
+<pre class="example highlight" title="Accessibility">
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "id": "http://example.org/anno%%anno%%",
+  "type": "Annotation",
+  "motivation": "commenting",
+  "body": "http://example.net/comment1",
+  "target": {
+    "id": "http://example.com/video1",
+    "type": "Video",
+    "accessibility": "captions"
+  }
+}
+</pre>  
+</section>
+
+
+<section>
 <h3>Motivation and Purpose</h3>
 
 <p>In many cases it is important to understand the reasons why the Annotation was created, or why the Textual Body was included in the Annotation, not just the times and agents involved.  These reasons are provided by declaring the motivation for the Annotation's creation or the purpose for the inclusion of the Body in the Annotation; the "why" rather than the "who" and "when" described in the previous sections.</p>
@@ -989,7 +1032,7 @@ The use of <code>audience</code> does not imply nor enable any access restrictio
 <tr><td>describing</td><td>Instance </td><td> The motivation for when the user intends to describe the Target, as opposed to a comment about them.  For example describing the above PDF's contents, rather than commenting on their accuracy.</td></tr>
 <tr><td>editing</td><td>Instance </td><td> The motivation for when the user intends to request a change or edit to the Target resource. For example an Annotation that requests a typo to be corrected. </td></tr>
 <tr><td>highlighting</td><td>Instance </td><td> The motivation for when the user intends to highlight the Target resource or segment of it.  For example to draw attention to the selected text that the annotator disagrees with.</td></tr>
-<tr><td>identifying</td><td>Instance</td><td>The motivation for when the user intends to  assign an identity to the Target.  For example to associate the IRI that identifies a city with a mention of the city in a web page.</td></tr>
+<tr><td>identifying</td><td>Instance</td><td>The motivation for when the user intends to assign an identity to the Target.  For example to associate the IRI that identifies a city with a mention of the city in a web page.</td></tr>
 <tr><td>linking</td><td>Instance</td><td>The motivation for when the user intends to link to a resource related to the Target.</td></tr>
 <tr><td>moderating</td><td>Instance </td><td> The motivation for when the user intends to assign some value or quality to the Target. For example annotating an Annotation to moderate it up in a trust network or threaded discussion.</td></tr>
 <tr><td>questioning</td><td>Instance </td><td> The motivation for when the user intends to ask a question about the Target. For example to ask for assistance with a particular section of text, or question its veracity.</td></tr>
@@ -1389,7 +1432,7 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 <br/>Each TextQuoteSelector SHOULD have exactly 1 <code>suffix</code> property, and MUST NOT have more than 1.</td></tr>
 </table>
 
-<p>The text MUST be normalized before recording.  Thus HTML/XML tags should be removed, character entities should be replaced with the character that they encode, unnecessary whitespace should be normalized, character encoding should be turned into UTF-8, and so forth. The normalization routine may be performed automatically by a browser, and other applications should implement the <a href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-5DFED1F0">DOM String Comparisons</a> method. This allows the Selector to be used with different encodings and user agents and still have the same semantics and utility.
+<p>The text MUST be normalized before recording.  Thus HTML/XML tags should be removed, character entities should be replaced with the character that they encode, and unnecessary whitespace should be normalized. The normalization routine may be performed automatically by a browser, and other applications should implement the <a href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-5DFED1F0">DOM String Comparisons</a> method. This allows the Selector to be used with different encodings and user agents and still have the same semantics and utility. The selection MUST be based on the <a href="https://www.w3.org/International/questions/qa-visual-vs-logical">logical order</a> of the text, rather than the visual order, especially for bidirectional text. The normalized value MUST be recorded as UTF-8 in the JSON serialization of the Annotation.  
 </p>
 
 <p>When generating the Text Position Selector values, it is recommended that implementations built for an environment that supports DOM Level 3 APIs use the <code>textContent</code> property of top level, user visible Node object [[!DOM-Level-3-Core]] of the resource. This content would be located at <code>document.body.textContent</code> in an HTML5 document being accessed via a JavaScript DOM implementation.</p>
@@ -1993,7 +2036,7 @@ The relationship between the Specific Resource that represents the target in the
 <tr><td>type</td><td>Property</td><td>The type of the Collection.<br/>The Collection MUST have 1 or more types, and the <code>AnnotationCollection</code> class MUST be one of them.</td></tr>
 <tr><td>AnnotationCollection</td><td>Class</td><td>The class for ordered Collections of Annotations.<br/>This class MUST be associated with the Collection using <code>type</code></td></tr>
 <tr><td>label</td><td>Property</td><td>A human readable label intended as the name of the Collection.<br/>Collections SHOULD have 1 or more <code>label</code>, and the value MUST be a string.</td></tr>
-<tr><td>total</td><td>Property</td><td>The total number of Annotations in the Collection.<br/>Collections SHOULD have exactly 1 <code>total</code>, and if present it MUST be an <code>xsd:nonNegaiveInteger</code>. </td></tr>
+<tr><td>total</td><td>Property</td><td>The total number of Annotations in the Collection.<br/>Collections SHOULD have exactly 1 <code>total</code>, and if present it MUST be an <code>xsd:nonNegativeInteger</code>. </td></tr>
 <tr><td>first</td><td>Relationship</td><td>The first page of Annotations that are included within the Collection.<br/>A Collection that has a total number of Annotations greater than 0 MUST have exactly 1 <code>first</code> page of Annotations. The first Page MAY be embedded within the representation of the Collection, or it MAY be given as an IRI.</td></tr>
 <tr><td>last</td><td>Relationship</td><td>The last page of Annotations that are included within the Collection.</br>A Collection that has a total number of Annotations greater than 0 SHOULD have a reference to the IRI of the <code>last</code> page of Annotations.</td></tr>
 </table>
@@ -2408,6 +2451,7 @@ The relationship between the Specific Resource that represents the target in the
 
 <table class="model">
   <tr><th>Key</th><th>Usage</th></tr>
+<tr><td>accessibility</td><td><a href="#accessibility-of-content">Body, Target</a></td></tr>
 <tr><td>account</td><td><a href="#agents">Agent</a></td></tr>
 <tr><td>audience</td><td><a href="#intended-audience">Audience</a></td></tr>
 <tr><td>body</td><td><a href="#annotations">Annotation</a></td></tr>
@@ -2457,6 +2501,7 @@ The relationship between the Specific Resource that represents the target in the
 <tr><td>stylesheet</td><td><a href="#styles">Annotation</a></td></tr>
 <tr><td>suffix</td><td><a href="#text-quote-selector">Text Quote Selector</a></td></tr>
 <tr><td>target</td><td><a href="#annotations">Annotation</a></td></tr>
+<tr><td>textDirection</td><td><a href="#external-web-resources">Body, Target</a></td></tr>
 <tr><td>total</td><td><a href="#annotation-collection">Annotation Collection</a></td></tr>
 <tr><td class="top_cell">type</td><td>Note: Every object MAY have a <code>type</code>.<br/> <a href="#annotations">Annotation</a>, <a href="#classes">Body, Target</a>, <a href="#embedded-textual-body">Embedded Textual Body</a>, <a href="#agents">Agent</a>, <a href="#intended-audience">Audience</a>, <a href="#specific-resources">Specific Resource</a>, <a href="#fragment-selector">Fragment Selector</a>, <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a>, <a href="#text-quote-selector">Text Quote Selector</a>, <a href="#text-position-selector">Text Position Selector</a>, <a href="#data-position-selector">Data Position Selector</a>, <a href="#svg-selector">SVG Selector</a>, <a href="#time-state">Time State</a>, <a href="#request-header-state">Request Header State</a>, <a href="#styles">CSS Stylesheet</a></td></tr>
 <tr><td>value</td><td> <a href="#embedded-textual-body">Textual Body</a>, <a href="#fragment-selector">Fragment Selector</a>, <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a>, <a href="#svg-selector">SVG Selector</a>, <a href="#request-header-state">Request Header State</a>, <a href="#styles">CSS Stylesheet</a></td></tr>

--- a/model/wd2/index-respec.html
+++ b/model/wd2/index-respec.html
@@ -385,13 +385,19 @@ The Web is distributed, with different systems working together to provide acces
 <br/>Bodies or Targets which are External Web Resources MUST have exactly 1 <code>id</code> with the value of the resource's <a>IRI</a>.
   </td></tr>
   <tr><td>language</td><td>Property</td><td>The language of the Web Resource's content
-  <br/>The Body or Target SHOULD have exactly 1 language associated with it, but MAY have 0 or more.  The value of the property SHOULD be a language code following the [[!bcp47]] specifiction.</td></tr>
+  <br/>The Body or Target SHOULD have exactly 1 language associated with it, but MAY have 0 or more.  The value of the property SHOULD be a language code following the [[!bcp47]] specification.</td></tr>
 <tr><td>format</td><td>Property</td><td>The format of the Web Resource's content
   <br/>The Body or Target SHOULD have exactly 1 format associated with it, but MAY have 0 or more.  The value of the property SHOULD be the media-type of the format, following the [[!rfc6838]] specification.</td></tr>
+<tr><td>textDirection</td><td>Relationship</td><td>The direction of the text of the resource.  
+<br/>The Body or Target MAY have exactly 1 textDirection associated with it.  The value of the property MUST be one of the directions defined below (<code>ltr</code>, <code>rtl</code>, or <code>auto</code>).
+</td></tr>
+<tr><td>ltr</td><td>Instance</td><td>The direction that indicates the value of the resource is explicitly directionally isolated left-to-right text.</td></tr>
+<tr><td>rtl</td><td>Instance</td><td>The direction that indicates the value of the resource is explicitly directionally isolated right-to-left text.</td></tr>
+<tr><td>auto</td><td>Instance</td><td>The direction that indicates the value of the resource is explicitly directionally isolated text, and the direction is to be programmatically determined using the value.</td></tr>
 </table>
 
 <div class="note">
-The [[iana-media-types]] document provides the official registry of media types that can be used with the <code>format</code> property.  The [[w3c-language-tags]] article provides a good overview of the values that implementers can expect to encounter in the <code>language</code> property.
+The [[iana-media-types]] document provides the official registry of media types that can be used with the <code>format</code> property.  The [[w3c-language-tags]] article provides a good overview of the values that implementers can expect to encounter in the <code>language</code> property.  The notion of text direction is taken explicity from <a href="https://www.w3.org/TR/html5/dom.html#the-dir-attribute">HTML5's</a> <code>dir</code> attribute.
 </div>
 
 <h4>Example</h4>
@@ -409,7 +415,8 @@ The [[iana-media-types]] document provides the official registry of media types 
   "target": {
     "id": "http://example.gov/patent1.pdf",
     "format": "application/pdf",
-    "language": "en"
+    "language": "en",
+    "textDirection": "ltr"
   }
 }
 </pre>
@@ -577,14 +584,13 @@ There are several restrictions on when this form may be used and how it is to be
   <li>MUST NOT have a language associated with it.</li>
   <li>MUST be interpreted as if it were the value of the <code>value</code> property of a Textual Body.</li>
 	<li>MUST be interpreted as if the Textual Body resource had a <code>format</code> property with the value <code>text/plain</code>.</li>
-  <li>MUST be interpreted as if the Textual Body resource had a <a href="#motivation-and-purpose"><code>purpose</code> property</a> with the value of <code>commenting</code>.</li>
 	<li>MUST NOT have the value of other properties of the Textual Body inferred from similar properties on the Annotation resource.</li>
 </ul>
 </p>
 
 <p>If any of the interpretations above are not correct, then the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a> MUST be used instead.</p>
 
-<div class="note">Systems MAY rewrite Annotations to instead use the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a>, rather than maintaining the <code>bodyValue</code> form.</div>
+<div class="note">Systems MAY rewrite Annotations to instead use the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a>, rather than maintaining the <code>bodyValue</code> form.  The <code>TextualBody</code> construction is preferred, as language and format information are important for clients processing the Annotation.</div>
 
 <h4>Example</h4>
 
@@ -908,7 +914,7 @@ Each agent MAY have 1 or more values in the <code>email_sha1</code> property.</t
     "id": "http://example.org/user1",
     "type": "Person",
     "name": "My Pseudonym",
-    "nick": "pseudo",
+    "account": "pseudo",
     "email_sha1": "58bad08927902ff9307b621c54716dcc5083e339"
   },
   "generator": {
@@ -966,11 +972,48 @@ The use of <code>audience</code> does not imply nor enable any access restrictio
 </section>
 
 <section>
+  <h3>Accessibility of Content</h3>
+
+<p>Access to information is recognized as a basic human right by the United Nations. The Web is able to remove barriers to communication and interaction regardless of various physical impediments. This support social inclusion, but also increases the potential audience of the information.  For resources that are used as the body or target of an Annotation, it is valuable to record the features of that resource that provide easier access for users with various and diverse ranges of ability.</p>
+
+<p><b>Example Use Case:</b> Petra has very limited ability to hear sound, and prefers to read captions when interacting with videos. She uses her annotation client to make a comment on such a video, and to help others in the same situation, the client includes that the video has this accessibility feature.</p>
+
+<h4>Model</h4>
+
+<table class="model">
+<tr><th>Term</th><th>Type</th><th>Description</th></tr>
+<tr><td>accessibility</td><td>Property</td><td>One or more strings from an enumerated list of values that each describes an accessibility feature that the resource has.
+<br/>There MAY be 0 or more accessibility features listed for each Body or Target resource.</td></tr>
+</table>
+
+<p class="note">
+The current list of values is referenced from the <a href="http://schema.org/accessibilityFeature">schema.org description</a> of the <code>accessibilityFeature</code> property.
+</p>
+
+<h4>Example</h4>
+<pre class="example highlight" title="Accessibility">
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "id": "http://example.org/anno17",
+  "type": "Annotation",
+  "motivation": "commenting",
+  "body": "http://example.net/comment1",
+  "target": {
+    "id": "http://example.com/video1",
+    "type": "Video",
+    "accessibility": "captions"
+  }
+}
+</pre>  
+</section>
+
+
+<section>
 <h3>Motivation and Purpose</h3>
 
 <p>In many cases it is important to understand the reasons why the Annotation was created, or why the Textual Body was included in the Annotation, not just the times and agents involved.  These reasons are provided by declaring the motivation for the Annotation's creation or the purpose for the inclusion of the Body in the Annotation; the "why" rather than the "who" and "when" described in the previous sections.</p>
 
-<p><b>Example Use Case:</b> Petra annotates a resource intending to bookmark it for future reference, and provides a description and a tag to make it easier to find again. Her client adds the right motivations to the Annotation and the Body resources to capture this.</p>
+<p><b>Example Use Case:</b> Qitara annotates a resource intending to bookmark it for future reference, and provides a description and a tag to make it easier to find again. Her client adds the right motivations to the Annotation and the Body resources to capture this.</p>
 
 <h4>Model</h4>
 
@@ -989,7 +1032,7 @@ The use of <code>audience</code> does not imply nor enable any access restrictio
 <tr><td>describing</td><td>Instance </td><td> The motivation for when the user intends to describe the Target, as opposed to a comment about them.  For example describing the above PDF's contents, rather than commenting on their accuracy.</td></tr>
 <tr><td>editing</td><td>Instance </td><td> The motivation for when the user intends to request a change or edit to the Target resource. For example an Annotation that requests a typo to be corrected. </td></tr>
 <tr><td>highlighting</td><td>Instance </td><td> The motivation for when the user intends to highlight the Target resource or segment of it.  For example to draw attention to the selected text that the annotator disagrees with.</td></tr>
-<tr><td>identifying</td><td>Instance</td><td>The motivation for when the user intends to  assign an identity to the Target.  For example to associate the IRI that identifies a city with a mention of the city in a web page.</td></tr>
+<tr><td>identifying</td><td>Instance</td><td>The motivation for when the user intends to assign an identity to the Target.  For example to associate the IRI that identifies a city with a mention of the city in a web page.</td></tr>
 <tr><td>linking</td><td>Instance</td><td>The motivation for when the user intends to link to a resource related to the Target.</td></tr>
 <tr><td>moderating</td><td>Instance </td><td> The motivation for when the user intends to assign some value or quality to the Target. For example annotating an Annotation to moderate it up in a trust network or threaded discussion.</td></tr>
 <tr><td>questioning</td><td>Instance </td><td> The motivation for when the user intends to ask a question about the Target. For example to ask for assistance with a particular section of text, or question its veracity.</td></tr>
@@ -1008,7 +1051,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <pre class="example highlight" title="Motivation and Purpose">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno17",
+  "id": "http://example.org/anno18",
   "type": "Annotation",
   "motivation": "bookmarking",
   "body": [
@@ -1031,7 +1074,7 @@ For more information about how Motivations can be inter-related and new Motivati
 
 <p>It is common practice to associate a licence or rights statement with a resource, in order to describe the conditions under which it may be used.  This allows the user to make appropriate use of the resource, as well as allowing some automated systems to confirm that the usage is permitted.</p>
 
-<p><b>Example Use Case:</b> Qitara writes a review of a product and wishes to be known as the author of the review, however does not mind how the Annotation that relates the review and the product together is used.  She asserts these two separate rights statements with the Annotation and Body individually.</p>
+<p><b>Example Use Case:</b> Ramona writes a review of a product and wishes to be known as the author of the review, however does not mind how the Annotation that relates the review and the product together is used.  She asserts these two separate rights statements with the Annotation and Body individually.</p>
 
 <h4>Model</h4>
 
@@ -1047,7 +1090,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <pre class="example highlight" title="Rights">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno18",
+  "id": "http://example.org/anno19",
   "type": "Annotation",
   "body": {
     "id": "http://example.net/review1",
@@ -1063,7 +1106,7 @@ For more information about how Motivations can be inter-related and new Motivati
 
 <p>In a massively distributed system such as the Web, information is often copied.  In order to track the provenance of the Annotation and other related resources, it is possible to record additional IRIs that also identify the resource.  These may be dereferencable "permalinks", identities assigned by a client offline without any knowledge of the web, or simply the location where the current harvesting system discovered the resource.</p>
 
-<p><b>Example Use Case:</b> Ramona creates an Annotation and sends it to multiple systems to maintain, one personal and one public.  She wants to ensure that the copies can be aligned, and so she sets a UUID as the canonical IRI, allowing the service to assign an HTTP IRI for it.  A subsequent system then harvests the public copy, maintaining the canonical UUID and moves the assigned HTTP IRI to <code>via</code>, replacing the <code>id</code> field with its own IRI. </p>
+<p><b>Example Use Case:</b> Sally creates an Annotation and sends it to multiple systems to maintain, one personal and one public.  She wants to ensure that the copies can be aligned, and so she sets a UUID as the canonical IRI, allowing the service to assign an HTTP IRI for it.  A subsequent system then harvests the public copy, maintaining the canonical UUID and moves the assigned HTTP IRI to <code>via</code>, replacing the <code>id</code> field with its own IRI. </p>
 
 <h4>Model</h4>
 
@@ -1080,7 +1123,7 @@ For more information about how Motivations can be inter-related and new Motivati
 <pre class="example highlight" title="Other Identities">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno19",
+  "id": "http://example.org/anno20",
   "type": "Annotation",
   "canonical": "urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df",
   "via": "http://other.example.org/anno1",
@@ -1145,7 +1188,7 @@ The types of additional specificity that are defined by this document:
 
 <p>As well as Textual Bodies, External Web Resources may also be given a Motivation as to their inclusion within the Annotation.  This is done using the Specific Resource pattern, as the purpose specifies the way in which the resource is used in the context of the Annotation in the same way as a Selector describes the segment or a State describes the representation.</p>
 
-<p><b>Example Use Case:</b> Sally wants to tag a photo with an identifier for a city, rather than just type the city's name which could be ambiguous. Her client uses a well-known IRI for the city having done a search for it, and creates a Specific Resource to manage that purpose assignment.</p>
+<p><b>Example Use Case:</b> Teynika wants to tag a photo with an identifier for a city, rather than just type the city's name which could be ambiguous. Her client uses a well-known IRI for the city having done a search for it, and creates a Specific Resource to manage that purpose assignment.</p>
 
 
 <h4>Model</h4>
@@ -1162,7 +1205,7 @@ The types of additional specificity that are defined by this document:
 <pre class="example highlight" title="Resource with Purpose">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno20",
+  "id": "http://example.org/anno21",
   "type": "Annotation",
   "body": {
     "type": "SpecificResource",
@@ -1182,7 +1225,7 @@ The types of additional specificity that are defined by this document:
 
 <p>Many Annotations refer to part of a resource, rather than all of it, as the Target. We call that part of the resource a Segment (of Interest). A Selector is used to describe how to determine the Segment from within the Source resource.  The nature of the Selector will be dependent on the type of resource, as the methods to describe Segments from various media-types will differ.</p>
 
-<p><b>Example Use Case:</b> Teynika wants to associate a selection of text in a web page, with a slice of a dataset.  She selects both using her client, and creates the Annotation with a SpecificResource that has a Selector for each of the Body and the Target.</p>
+<p><b>Example Use Case:</b> Ulrika wants to associate a selection of text in a web page, with a slice of a dataset.  She selects both using her client, and creates the Annotation with a SpecificResource that has a Selector for each of the Body and the Target.</p>
 
 <h4>Model</h4>
 
@@ -1198,7 +1241,7 @@ The types of additional specificity that are defined by this document:
 <pre class="example highlight" title="Selectors">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno21",
+  "id": "http://example.org/anno22",
   "type": "Annotation",
   "body": {
     "source": "http://example.org/page1",
@@ -1216,7 +1259,7 @@ The types of additional specificity that are defined by this document:
 
 <p>As the most well understood mechanism for selecting a Segment is to use the fragment part of an IRI defined by the representation's media type, it is useful to allow this as a description mechanism via a Selector.  This allows existing and future fragment specifications to be used with Specific Resources in a consistent way.  To be clear about which fragment type is being used, the Selector may refer to the specification that defines it.</p>
 
-<p><b>Example Use Case:</b> Ulrika wants to associate part of a video as the description of an image.  She selects the time range within the video and clicks that it is describing the target.  Her client then creates the Annotation using a SpecificResource with a FragmentSelector and the <code>describing</code> Motivation. </p>
+<p><b>Example Use Case:</b> Valeria wants to associate part of a video as the description of an image.  She selects the time range within the video and clicks that it is describing the target.  Her client then creates the Annotation using a SpecificResource with a FragmentSelector and the <code>describing</code> Motivation. </p>
 
 
 <h4>Model</h4>
@@ -1258,11 +1301,11 @@ The IRI that uses the fragment may be reconstructed by concatenating the <code>s
 <pre class="example highlight" title="Fragment Selector">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno22",
+  "id": "http://example.org/anno23",
   "type": "Annotation",
   "body": {
     "source": "http://example.org/video1",
-    "role": "describing",
+    "purpose": "describing",
     "selector": {
       "type": "FragmentSelector",
       "conformsTo": "http://www.w3.org/TR/media-frags/",
@@ -1282,7 +1325,7 @@ The IRI that uses the fragment may be reconstructed by concatenating the <code>s
 
 <p>Note that CSS may also be used for <a href="#styles">styling</a> a resource within an annotation. This class is specifically to re-use the CSS Selector mechanism to select a segment of a resource that conforms to the Document Object Model.</p>
 
-<p><b>Example Use Case:</b> Valeria selects a paragraph in a web page that she wishes to write a note about.  Her client calculates a CSS path that cleanly identifies that element and adds it to the annotation.</p>
+<p><b>Example Use Case:</b> Wendy selects a paragraph in a web page that she wishes to write a note about.  Her client calculates a CSS path that cleanly identifies that element and adds it to the annotation.</p>
 
 <h4>Model</h4>
 
@@ -1304,7 +1347,7 @@ Implementers SHOULD use only commonly supported features of CSS that directly co
 <pre class="example highlight" title="CSS Selector">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno23",
+  "id": "http://example.org/anno24",
   "type": "Annotation",
   "body": "http://example.org/note1",
   "target": {
@@ -1327,7 +1370,7 @@ Implementers SHOULD use only commonly supported features of CSS that directly co
 Implementers should note that the <a href="https://www.w3.org/TR/html5/syntax.html#optional-tags">HTML5 specification</a> allows parsers to add elements into the DOM that are considered to be missing. XPaths SHOULD be constructed to include these elements, rather than from the element structure in the document.
 </div>
 
-<p><b>Example Use Case:</b> Wendy selects a span within a table in an HTML page and writes a note about the content.  To refer explicitly to this element, her client carefully constructs an XPath to identify it as the target of the Annotation.</p>
+<p><b>Example Use Case:</b> Xena selects a span within a table in an HTML page and writes a note about the content.  To refer explicitly to this element, her client carefully constructs an XPath to identify it as the target of the Annotation.</p>
 
 <h4>Model</h4>
 
@@ -1349,7 +1392,7 @@ Implementers SHOULD use only commonly supported features of XPath that directly 
 <pre class="example highlight" title="XPath Selector">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno24",
+  "id": "http://example.org/anno25",
   "type": "Annotation",
   "body": "http://example.org/note1",
   "target": {
@@ -1372,7 +1415,7 @@ Implementers SHOULD use only commonly supported features of XPath that directly 
 For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could select "efg" by a prefix of "abcd", the match of "efg" and a suffix of "hijk".
 </p>
 
-<p><b>Example Use Case:</b> Xena selects a typo ('anotation') in a web page and adds a comment that it should be replaced with the correct spelling ('annotation').</p>
+<p><b>Example Use Case:</b> Yadira selects a typo ('anotation') in a web page and adds a comment that it should be replaced with the correct spelling ('annotation').</p>
 
 <h4>Model</h4>
 
@@ -1389,7 +1432,7 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 <br/>Each TextQuoteSelector SHOULD have exactly 1 <code>suffix</code> property, and MUST NOT have more than 1.</td></tr>
 </table>
 
-<p>The text MUST be normalized before recording.  Thus HTML/XML tags should be removed, character entities should be replaced with the character that they encode, unnecessary whitespace should be normalized, character encoding should be turned into UTF-8, and so forth. The normalization routine may be performed automatically by a browser, and other applications should implement the <a href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-5DFED1F0">DOM String Comparisons</a> method. This allows the Selector to be used with different encodings and user agents and still have the same semantics and utility.
+<p>The text MUST be normalized before recording.  Thus HTML/XML tags should be removed, character entities should be replaced with the character that they encode, and unnecessary whitespace should be normalized. The normalization routine may be performed automatically by a browser, and other applications should implement the <a href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-5DFED1F0">DOM String Comparisons</a> method. This allows the Selector to be used with different encodings and user agents and still have the same semantics and utility. The selection MUST be based on the <a href="https://www.w3.org/International/questions/qa-visual-vs-logical">logical order</a> of the text, rather than the visual order, especially for bidirectional text. The normalized value MUST be recorded as UTF-8 in the JSON serialization of the Annotation.  
 </p>
 
 <p>When generating the Text Position Selector values, it is recommended that implementations built for an environment that supports DOM Level 3 APIs use the <code>textContent</code> property of top level, user visible Node object [[!DOM-Level-3-Core]] of the resource. This content would be located at <code>document.body.textContent</code> in an HTML5 document being accessed via a JavaScript DOM implementation.</p>
@@ -1404,7 +1447,7 @@ For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could 
 <pre class="example highlight" title="Text Quote Selector">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno25",
+  "id": "http://example.org/anno26",
   "type": "Annotation",
   "body": "http://example.org/comment1",
   "target": {
@@ -1429,7 +1472,7 @@ This Selector describes a range of text by recording the start and end positions
 For example, if the document was "abcdefghijklmnopqrstuvwxyz", the start was 4, and the end was 7, then the selection would be "efg".
 </p>
 
-<p><b>Example Use Case:</b> Yadira writes a review of an ebook that does not allow its content to be extracted and copied.  Her client describes the selection using its start and end position in the content.</p>
+<p><b>Example Use Case:</b> Zara writes a review of an ebook that does not allow its content to be extracted and copied.  Her client describes the selection using its start and end position in the content.</p>
 
 <h4>Model</h4>
 
@@ -1456,7 +1499,7 @@ The use of this Selector does not require text to be copied from the Source docu
 <pre class="example highlight" title="Text Position Selector">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno26",
+  "id": "http://example.org/anno27",
   "type": "Annotation",
   "body": "http://example.org/review1",
   "target": {
@@ -1477,7 +1520,7 @@ The use of this Selector does not require text to be copied from the Source docu
 <p>
 Similar to the Text Position Selector, the Data Position Selector uses the same properties but works at the byte in bitstream level rather than the character in text level.</p>
 
-<p><b>Example Use Case:</b> Zara writes comments about regions of online disk images for forensic purposes and describing emulation requirements.  Her client generates the start and end positions from the binary stream, rather than the more human readable display she is using.</p>
+<p><b>Example Use Case:</b> Alexandra writes comments about regions of online disk images for forensic purposes and describing emulation requirements.  Her client generates the start and end positions from the binary stream, rather than the more human readable display she is using.</p>
 
 
 <h4>Model</h4>
@@ -1498,7 +1541,7 @@ Similar to the Text Position Selector, the Data Position Selector uses the same 
 <pre class="example highlight" title="Data Position Selector">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno27",
+  "id": "http://example.org/anno28",
   "type": "Annotation",
   "body": "http://example.org/note1",
   "target": {
@@ -1520,7 +1563,7 @@ Similar to the Text Position Selector, the Data Position Selector uses the same 
 
 <p>Note that the SvgSelector uses SVG to select an area of a resource. Segments of an SVG representation may also be selected using selectors, including the FragmentSelector or even an SvgSelector.</p>
 
-<p><b>Example Use Case:</b> Alexandra is tagging an old map online with a diagonal region for a historical road.  Her client creates SVG polygon to describe the region, relative to the image content.</p>
+<p><b>Example Use Case:</b> Britney is tagging an old map online with a diagonal region for a historical road.  Her client creates SVG polygon to describe the region, relative to the image content.</p>
 
 <h4>Model</h4>
 
@@ -1545,7 +1588,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
 <pre class="example highlight" title="SVG Selector">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno28",
+  "id": "http://example.org/anno29",
   "type": "Annotation",
   "body": "http://example.org/road1",
   "target": {
@@ -1561,7 +1604,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
 <pre class="example highlight" title="SVG Selector, embedded">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno29",
+  "id": "http://example.org/anno30",
   "type": "Annotation",
   "body": "http://example.org/road1",
   "target": {
@@ -1580,7 +1623,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
 
 <p>Selections made by users may be extensive and/or cross over internal boundaries in the representation, making it difficult to construct a single selector that robustly describes the correct content.  A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors.  In this way, two points can be accurately identified using the most appropriate selection mechanisms, and then linked together to form the selection.  The selection consists of everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it.</p>
 
-<p><b>Example Use Case:</b> Britney wants to comment on two adjacent cells in a table that is part of a web page.  She selects the two cells and her client constructs XPaths to the the first cell, and the cell that immediately follows the second. Her client then creates a Range Selector with the first XPath Selector as the start, and the second XPath selector as the end.</p>
+<p><b>Example Use Case:</b> Carla wants to comment on two adjacent cells in a table that is part of a web page.  She selects the two cells and her client constructs XPaths to the the first cell, and the cell that immediately follows the second. Her client then creates a Range Selector with the first XPath Selector as the start, and the second XPath selector as the end.</p>
 
 <h4>Model</h4>
 
@@ -1600,7 +1643,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
 <pre class="example highlight" title="Range Selector">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno30",
+  "id": "http://example.org/anno31",
   "type": "Annotation",
   "body": "http://example.org/comment1",
   "target": {
@@ -1626,7 +1669,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
 
   <p>It may be easier, more reliable or more accurate to specify the segment of interest of a resource as a selection of a selection, rather than as a selection of the complete resource.  Particularly for resources that contain other resources, such as various packaging formats, this also allows decomposition of the selection mechanisms when the components do not have unique identifiers.  This is accomplished by having selectors chained together, where each refines the results of the previous one.</p>
 
-  <p><b>Example Use Case:</b> Carla selects a paragraph of text and then a short phrase within it to comment on.  Her client records the phrase as a TextQuoteSelector that further modifies a FragmentSelector used to identify the paragraph that the phrase is part of.</p>
+  <p><b>Example Use Case:</b> Devina selects a paragraph of text and then a short phrase within it to comment on.  Her client records the phrase as a TextQuoteSelector that further modifies a FragmentSelector used to identify the paragraph that the phrase is part of.</p>
 
   <h4>Model</h4>
 
@@ -1641,7 +1684,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
   <pre class="example highlight" title="Refinement of Selection">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno31",
+  "id": "http://example.org/anno32",
   "type": "Annotation",
   "body": "http://example.org/comment1",
   "target": {
@@ -1669,7 +1712,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
 <p>A State describes the intended state of a resource as applied to the particular Annotation, and thus provides
  the information needed to retrieve the correct representation of that resource. Web resources change over time, and a State might be used to describe how to recover the intended previous version.  Web resources also have multiple formats, and a State might equally be used to describe how to retrieve that particular format.</p>
 
-<p><b>Example Use Case:</b> Devina makes a comment about a web page that changes frequently. Her client records information to allow other clients to hopefully reconstruct the original target of the annotation.</p>
+<p><b>Example Use Case:</b> Erin makes a comment about a web page that changes frequently. Her client records information to allow other clients to hopefully reconstruct the original target of the annotation.</p>
 
 <h4>Model</h4>
 
@@ -1686,7 +1729,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
 <pre class="example highlight" title="State">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno32",
+  "id": "http://example.org/anno33",
   "type": "Annotation",
   "body": "http://example.org/note1",
   "target": {
@@ -1703,7 +1746,7 @@ Implementers SHOULD use only commonly supported features of SVG that directly co
 
 <p>A Time State resource records the time at which the resource is appropriate for the Annotation, typically the time that the Annotation was created and/or a link to a persistent copy of the current version.  The timestamp for the resource could be resolved via the Memento protocol, described in RFC 7089 [[!rfc7089]].</p>
 
-<p><b>Example Use Case:</b> Erin makes a note about the current state of the front page of a news website, and flags that the page is likely to change often.  Her client adds in a State with the current time to describe the version of the page being annotated.</p>
+<p><b>Example Use Case:</b> Felicity makes a note about the current state of the front page of a news website, and flags that the page is likely to change often.  Her client adds in a State with the current time to describe the version of the page being annotated.</p>
 
 
 <h4>Model</h4>
@@ -1733,7 +1776,7 @@ representation, appropriate for the Annotation.
 <pre class="example highlight" title="Time State">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno33",
+  "id": "http://example.org/anno34",
   "type": "Annotation",
   "body": "http://example.org/note1",
   "target": {
@@ -1756,7 +1799,7 @@ Specific Resource may only apply to one of them, it is important to be able to r
 that need to be sent to retrieve the correct representation.  The HttpRequestState resource maintains a copy
 of the headers to be replayed when obtaining the representation. </p>
 
-<p><b>Example Use Case:</b> Felicity retrieves a PDF representation of a web resource that can deliver HTML, PDF or plain text and then writes a description about it.  She signals that her description is only about the PDF representation.  Her client then includes a State to describe how to retrieve the target representation.</p>
+<p><b>Example Use Case:</b> Gabrielle retrieves a PDF representation of a web resource that can deliver HTML, PDF or plain text and then writes a description about it.  She signals that her description is only about the PDF representation.  Her client then includes a State to describe how to retrieve the target representation.</p>
 
 <h4>Model</h4>
 
@@ -1774,7 +1817,7 @@ of the headers to be replayed when obtaining the representation. </p>
 <pre class="example highlight" title="HTTP Request State">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno34",
+  "id": "http://example.org/anno35",
   "type": "Annotation",
   "body": "http://example.org/description1",
   "target": {
@@ -1795,7 +1838,7 @@ of the headers to be replayed when obtaining the representation. </p>
 
 <p>Further, given that the State(s) will likely result in a specific representation, there may be specific Selectors that are appropriate for describing the segment of the representation.  In order to accomodate this, States may also be refined by Selectors.</p> 
 
-  <p><b>Example Use Case:</b> Gabrielle writes a comment about a travel e-book which has many versions available over time, and is available in different formats.  She is particularly commenting on a specific version and format, so her client adds both a TimeState to capture the time and an HttpRequestState to capture the format, and then a particular FragmentSelector that is appropriate to that format.</p>
+  <p><b>Example Use Case:</b> Heather writes a comment about a travel e-book which has many versions available over time, and is available in different formats.  She is particularly commenting on a specific version and format, so her client adds both a TimeState to capture the time and an HttpRequestState to capture the format, and then a particular FragmentSelector that is appropriate to that format.</p>
 
   <h4>Model</h4>
 
@@ -1810,7 +1853,7 @@ of the headers to be replayed when obtaining the representation. </p>
   <pre class="example highlight" title="Refinement of States">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno35",
+  "id": "http://example.org/anno36",
   "type": "Annotation",
   "body": "http://example.org/comment1",
   "target": {
@@ -1840,7 +1883,7 @@ of the headers to be replayed when obtaining the representation. </p>
 
 <p>The interpretation of a particular Annotation, or the Annotation's body, may rely on the rendering style of the Annotation being consistent across implementations.  For Annotations on binary content such as Images or Video, the background color of the target may not be accessible to the annotation client, and the default coloring may be difficult to perceive, such as a black rectangle rendered as the target area on an image of the night sky. Rendering information is recorded using CSS stylesheets and references to classes defined in those stylesheets.</p>
 
-<p><b>Example Use Case:</b> Heather highlights two paragraphs in a document, and selects in her client that one should be highlighted in red and the other in yellow.  She then makes a comment that the yellow part contradicts the red part. Her client records that she selected the red and yellow coloration of the targets. </p>
+<p><b>Example Use Case:</b> Ingeborg highlights two paragraphs in a document, and selects in her client that one should be highlighted in red and the other in yellow.  She then makes a comment that the yellow part contradicts the red part. Her client records that she selected the red and yellow coloration of the targets. </p>
 
 <h4>Model</h4>
 
@@ -1866,7 +1909,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="CSS Style">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno36",
+  "id": "http://example.org/anno37",
   "type": "Annotation",
   "stylesheet": "http://example.org/style1",
   "body": "http://example.org/comment1",
@@ -1880,7 +1923,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
 <pre class="example highlight" title="CSS Style, embedded">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno37",
+  "id": "http://example.org/anno38",
   "type": "Annotation",
   "stylesheet": {
     "type": "CssStylesheet",
@@ -1899,7 +1942,7 @@ There MAY be 0 or more <code>styleClass</code> properties on a Specific Resource
   <h3>Rendering Software</h3>
   <p>It may be valuable to know the software that was used to process and/or render the target resource when the annotation was created. This information can be used by later systems to potentially recreate the environment to ensure that the annotation can be more easily and more accurately reconnected with the appropriate part of the target's representation. This life cycle information is associated with the Specific Resource, as it is very likely to change between Annotations for the same target, and thus cannot be associated with the target resource directly.</p>
 
-<p><b>Example Use Case:</b> Ingeborg is using a browser based client to render a PDF of a scholarly article.  Her browser uses a particular library to render the PDF as HTML.  She annotates a paragraph in the view that she sees, the HTML rendering, and her client records that the library that was used for rendering in the annotation, along with her comment and the target PDF.</p>
+<p><b>Example Use Case:</b> Juliet is using a browser based client to render a PDF of a scholarly article.  Her browser uses a particular library to render the PDF as HTML.  She annotates a paragraph in the view that she sees, the HTML rendering, and her client records that the library that was used for rendering in the annotation, along with her comment and the target PDF.</p>
 
 <h4>Model</h4>
 
@@ -1918,7 +1961,7 @@ The relationship between the Specific Resource that represents the target in the
 <pre class="example highlight" title="Rendering Software">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno38",
+  "id": "http://example.org/anno39",
   "type": "Annotation",
   "body": "http://example.org/comment1",
   "target": {
@@ -1939,7 +1982,7 @@ The relationship between the Specific Resource that represents the target in the
 	<h3>Scope of a Resource</h3>
 	<p>It is sometimes important for an Annotation to capture the context in which it was made, in terms of the resources that the annotator was viewing or using at the time.  This does not imply an assertion that the annotation is only valid for the image in the context of that page, it just records that the page was being viewed.</p>
 
-<p><b>Example Use Case:</b> Juliet makes a comment about an image in a particular web page to say that it is not the right organization's logo.  Her client includes the page that the image is being rendered in, however the annotation is associated with the image resource itself.</p>
+<p><b>Example Use Case:</b> Karin makes a comment about an image in a particular web page to say that it is not the right organization's logo.  Her client includes the page that the image is being rendered in, however the annotation is associated with the image resource itself.</p>
 
 <h4>Model</h4>
 
@@ -1955,7 +1998,7 @@ The relationship between the Specific Resource that represents the target in the
 <pre class="example highlight" title="Scope">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno39",
+  "id": "http://example.org/anno40",
   "type": "Annotation",
   "body": "http://example.org/note1",
   "target": {
@@ -1974,7 +2017,7 @@ The relationship between the Specific Resource that represents the target in the
 
   <p>The Collection model is divided into two sections: the Annotation Collection that manages the identity of the list and its description, and Annotation Pages that list the Annotations which are members of the Collection.</p>
 
-  <p><b>Example Use Case:</b> Karin works for a publishing house and has transformed the author's commentary on their steampunk novel into a set of annotations for sale. The company wishes to have them available as an add-on for customers that have already bought the novel, and also in a bundle for new sales.</p>
+  <p><b>Example Use Case:</b> Lana works for a publishing house and has transformed the author's commentary on their steampunk novel into a set of annotations for sale. The company wishes to have them available as an add-on for customers that have already bought the novel, and also in a bundle for new sales.</p>
 
 <section>
 	<h3>Annotation Collection</h3>
@@ -1993,7 +2036,7 @@ The relationship between the Specific Resource that represents the target in the
 <tr><td>type</td><td>Property</td><td>The type of the Collection.<br/>The Collection MUST have 1 or more types, and the <code>AnnotationCollection</code> class MUST be one of them.</td></tr>
 <tr><td>AnnotationCollection</td><td>Class</td><td>The class for ordered Collections of Annotations.<br/>This class MUST be associated with the Collection using <code>type</code></td></tr>
 <tr><td>label</td><td>Property</td><td>A human readable label intended as the name of the Collection.<br/>Collections SHOULD have 1 or more <code>label</code>, and the value MUST be a string.</td></tr>
-<tr><td>total</td><td>Property</td><td>The total number of Annotations in the Collection.<br/>Collections SHOULD have exactly 1 <code>total</code>, and if present it MUST be an <code>xsd:nonNegaiveInteger</code>. </td></tr>
+<tr><td>total</td><td>Property</td><td>The total number of Annotations in the Collection.<br/>Collections SHOULD have exactly 1 <code>total</code>, and if present it MUST be an <code>xsd:nonNegativeInteger</code>. </td></tr>
 <tr><td>first</td><td>Relationship</td><td>The first page of Annotations that are included within the Collection.<br/>A Collection that has a total number of Annotations greater than 0 MUST have exactly 1 <code>first</code> page of Annotations. The first Page MAY be embedded within the representation of the Collection, or it MAY be given as an IRI.</td></tr>
 <tr><td>last</td><td>Relationship</td><td>The last page of Annotations that are included within the Collection.</br>A Collection that has a total number of Annotations greater than 0 SHOULD have a reference to the IRI of the <code>last</code> page of Annotations.</td></tr>
 </table>
@@ -2315,19 +2358,19 @@ The relationship between the Specific Resource that represents the target in the
 <section class="appendix informative">
   <h3>Complete Example</h3>
 
-<p><b>Entirely Contrived Example Use Case:</b> Lana wants to associate a comment that she wrote in English within the annotation or a external mp3 of the same content in German by someone else, plus a tag, with a range of characters from a particular element in an XML representation of a document as it was at a certain point in time, and for it to be displayed in a particular way.</p>
+<p><b>Entirely Contrived Example Use Case:</b> Melanie wants to associate a comment that she wrote in English within the annotation or a external mp3 of the same content in German by someone else, plus a tag, with a range of characters from a particular element in an XML representation of a document as it was at a certain point in time, and for it to be displayed in a particular way.</p>
 
 <pre class="example highlight" title="Complete Example">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno40",
+  "id": "http://example.org/anno41",
   "type": "Annotation",
   "motivation": "commenting",
   "creator": {
     "id": "http://example.org/user1",
     "type": "Person",
     "name": "A. Person",
-    "nick": "user1"
+    "account": "user1"
   },
   "created": "2015-10-13T13:00:00Z",
   "generator": {
@@ -2408,6 +2451,7 @@ The relationship between the Specific Resource that represents the target in the
 
 <table class="model">
   <tr><th>Key</th><th>Usage</th></tr>
+<tr><td>accessibility</td><td><a href="#accessibility-of-content">Body, Target</a></td></tr>
 <tr><td>account</td><td><a href="#agents">Agent</a></td></tr>
 <tr><td>audience</td><td><a href="#intended-audience">Audience</a></td></tr>
 <tr><td>body</td><td><a href="#annotations">Annotation</a></td></tr>
@@ -2457,6 +2501,7 @@ The relationship between the Specific Resource that represents the target in the
 <tr><td>stylesheet</td><td><a href="#styles">Annotation</a></td></tr>
 <tr><td>suffix</td><td><a href="#text-quote-selector">Text Quote Selector</a></td></tr>
 <tr><td>target</td><td><a href="#annotations">Annotation</a></td></tr>
+<tr><td>textDirection</td><td><a href="#external-web-resources">Body, Target</a></td></tr>
 <tr><td>total</td><td><a href="#annotation-collection">Annotation Collection</a></td></tr>
 <tr><td class="top_cell">type</td><td>Note: Every object MAY have a <code>type</code>.<br/> <a href="#annotations">Annotation</a>, <a href="#classes">Body, Target</a>, <a href="#embedded-textual-body">Embedded Textual Body</a>, <a href="#agents">Agent</a>, <a href="#intended-audience">Audience</a>, <a href="#specific-resources">Specific Resource</a>, <a href="#fragment-selector">Fragment Selector</a>, <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a>, <a href="#text-quote-selector">Text Quote Selector</a>, <a href="#text-position-selector">Text Position Selector</a>, <a href="#data-position-selector">Data Position Selector</a>, <a href="#svg-selector">SVG Selector</a>, <a href="#time-state">Time State</a>, <a href="#request-header-state">Request Header State</a>, <a href="#styles">CSS Stylesheet</a></td></tr>
 <tr><td>value</td><td> <a href="#embedded-textual-body">Textual Body</a>, <a href="#fragment-selector">Fragment Selector</a>, <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a>, <a href="#svg-selector">SVG Selector</a>, <a href="#request-header-state">Request Header State</a>, <a href="#styles">CSS Stylesheet</a></td></tr>

--- a/model/wd2/index.html
+++ b/model/wd2/index.html
@@ -1,367 +1,575 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr" typeof="bibo:Document w3p:WD" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
-<head><meta property="dc:language" content="en" lang="">
-    <title>Web Annotation Data Model</title>
-    <meta charset="utf-8">
-    <style>
+<head>
+  <meta lang="" property="dc:language" content="en">
+  <style>
+    /*
 
-.model {
- empty-cells: show;
- border-collapse: collapse;
- margin-bottom: .5ex;
- border: 1px solid black;
- width: 100%;
-}
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
-.model th {
- padding: 3px;
- border: 1px solid #404040;
- text-align: center;
- font-weight: bold;
- font-family: sans-serif;
-}
-
-.model td {
- padding: 5px;
- border: 1px solid #404040;
- text-align: left;
- font-family: sans-serif;
-}
-
-      </style>
-      
-      
-    <style>/*****************************************************************
+*/
+    
+    .hljs {
+      display: block;
+      overflow-x: auto;
+      padding: 0.5em;
+      color: #333;
+      background: #f8f8f8;
+      -webkit-text-size-adjust: none;
+    }
+    
+    .hljs-comment,
+    .diff .hljs-header {
+      color: #998;
+      font-style: italic;
+    }
+    
+    .hljs-keyword,
+    .css .rule .hljs-keyword,
+    .hljs-winutils,
+    .nginx .hljs-title,
+    .hljs-subst,
+    .hljs-request,
+    .hljs-status {
+      color: #333;
+      font-weight: bold;
+    }
+    
+    .hljs-number,
+    .hljs-hexcolor,
+    .ruby .hljs-constant {
+      color: #008080;
+    }
+    
+    .hljs-string,
+    .hljs-tag .hljs-value,
+    .hljs-doctag,
+    .tex .hljs-formula {
+      color: #d14;
+    }
+    
+    .hljs-title,
+    .hljs-id,
+    .scss .hljs-preprocessor {
+      color: #900;
+      font-weight: bold;
+    }
+    
+    .hljs-list .hljs-keyword,
+    .hljs-subst {
+      font-weight: normal;
+    }
+    
+    .hljs-class .hljs-title,
+    .hljs-type,
+    .vhdl .hljs-literal,
+    .tex .hljs-command {
+      color: #458;
+      font-weight: bold;
+    }
+    
+    .hljs-tag,
+    .hljs-tag .hljs-title,
+    .hljs-rule .hljs-property,
+    .django .hljs-tag .hljs-keyword {
+      color: #000080;
+      font-weight: normal;
+    }
+    
+    .hljs-attribute,
+    .hljs-variable,
+    .lisp .hljs-body,
+    .hljs-name {
+      color: #008080;
+    }
+    
+    .hljs-regexp {
+      color: #009926;
+    }
+    
+    .hljs-symbol,
+    .ruby .hljs-symbol .hljs-string,
+    .lisp .hljs-keyword,
+    .clojure .hljs-keyword,
+    .scheme .hljs-keyword,
+    .tex .hljs-special,
+    .hljs-prompt {
+      color: #990073;
+    }
+    
+    .hljs-built_in {
+      color: #0086b3;
+    }
+    
+    .hljs-preprocessor,
+    .hljs-pragma,
+    .hljs-pi,
+    .hljs-doctype,
+    .hljs-shebang,
+    .hljs-cdata {
+      color: #999;
+      font-weight: bold;
+    }
+    
+    .hljs-deletion {
+      background: #fdd;
+    }
+    
+    .hljs-addition {
+      background: #dfd;
+    }
+    
+    .diff .hljs-change {
+      background: #0086b3;
+    }
+    
+    .hljs-chunk {
+      color: #aaa;
+    }
+  </style>
+  <style id="respec-mainstyle">
+    /*****************************************************************
  * ReSpec 3 CSS
  * Robin Berjon - http://berjon.com/
  *****************************************************************/
-
-/* Override code highlighter background */
-.hljs {
-    background: transparent !important;
-}
-
-/* --- INLINES --- */
-em.rfc2119 {
-    text-transform:     lowercase;
-    font-variant:       small-caps;
-    font-style:         normal;
-    color:              #900;
-}
-
-h1 acronym, h2 acronym, h3 acronym, h4 acronym, h5 acronym, h6 acronym, a acronym,
-h1 abbr, h2 abbr, h3 abbr, h4 abbr, h5 abbr, h6 abbr, a abbr {
-    border: none;
-}
-
-dfn {
-    font-weight:    bold;
-}
-
-a.internalDFN {
-    color:  inherit;
-    border-bottom:  1px solid #99c;
-    text-decoration:    none;
-}
-
-a.externalDFN {
-    color:  inherit;
-    border-bottom:  1px dotted #ccc;
-    text-decoration:    none;
-}
-
-a.bibref {
-    text-decoration:    none;
-}
-
-cite .bibref {
-    font-style: normal;
-}
-
-code {
-    color:  #C83500;
-}
-
-/* --- TOC --- */
-.toc a, .tof a {
-    text-decoration:    none;
-}
-
-a .secno, a .figno {
-    color:  #000;
-}
-
-ul.tof, ol.tof {
-    list-style: none outside none;
-}
-
-.caption {
-    margin-top: 0.5em;
-    font-style:   italic;
-}
-
-/* --- TABLE --- */
-table.simple {
-    border-spacing: 0;
-    border-collapse:    collapse;
-    border-bottom:  3px solid #005a9c;
-}
-
-.simple th {
-    background: #005a9c;
-    color:  #fff;
-    padding:    3px 5px;
-    text-align: left;
-}
-
-.simple th[scope="row"] {
-    background: inherit;
-    color:  inherit;
-    border-top: 1px solid #ddd;
-}
-
-.simple td {
-    padding:    3px 10px;
-    border-top: 1px solid #ddd;
-}
-
-.simple tr:nth-child(even) {
-    background: #f0f6ff;
-}
-
-/* --- DL --- */
-.section dd > p:first-child {
-    margin-top: 0;
-}
-
-.section dd > p:last-child {
-    margin-bottom: 0;
-}
-
-.section dd {
-    margin-bottom:  1em;
-}
-
-.section dl.attrs dd, .section dl.eldef dd {
-    margin-bottom:  0;
-}
-
-.respec-hidden {
-    display: none;
-}
-
-@media print {
-    .removeOnSave {
+    /* Override code highlighter background */
+    
+    .hljs {
+      background: transparent !important;
+    }
+    /* --- INLINES --- */
+    
+    em.rfc2119 {
+      text-transform: lowercase;
+      font-variant: small-caps;
+      font-style: normal;
+      color: #900;
+    }
+    
+    h1 acronym,
+    h2 acronym,
+    h3 acronym,
+    h4 acronym,
+    h5 acronym,
+    h6 acronym,
+    a acronym,
+    h1 abbr,
+    h2 abbr,
+    h3 abbr,
+    h4 abbr,
+    h5 abbr,
+    h6 abbr,
+    a abbr {
+      border: none;
+    }
+    
+    dfn {
+      font-weight: bold;
+    }
+    
+    a.internalDFN {
+      color: inherit;
+      border-bottom: 1px solid #99c;
+      text-decoration: none;
+    }
+    
+    a.externalDFN {
+      color: inherit;
+      border-bottom: 1px dotted #ccc;
+      text-decoration: none;
+    }
+    
+    a.bibref {
+      text-decoration: none;
+    }
+    
+    cite .bibref {
+      font-style: normal;
+    }
+    
+    code {
+      color: #C83500;
+    }
+    /* --- TOC --- */
+    
+    .toc a,
+    .tof a {
+      text-decoration: none;
+    }
+    
+    a .secno,
+    a .figno {
+      color: #000;
+    }
+    
+    ul.tof,
+    ol.tof {
+      list-style: none outside none;
+    }
+    
+    .caption {
+      margin-top: 0.5em;
+      font-style: italic;
+    }
+    /* --- TABLE --- */
+    
+    table.simple {
+      border-spacing: 0;
+      border-collapse: collapse;
+      border-bottom: 3px solid #005a9c;
+    }
+    
+    .simple th {
+      background: #005a9c;
+      color: #fff;
+      padding: 3px 5px;
+      text-align: left;
+    }
+    
+    .simple th[scope="row"] {
+      background: inherit;
+      color: inherit;
+      border-top: 1px solid #ddd;
+    }
+    
+    .simple td {
+      padding: 3px 10px;
+      border-top: 1px solid #ddd;
+    }
+    
+    .simple tr:nth-child(even) {
+      background: #f0f6ff;
+    }
+    /* --- DL --- */
+    
+    .section dd > p:first-child {
+      margin-top: 0;
+    }
+    
+    .section dd > p:last-child {
+      margin-bottom: 0;
+    }
+    
+    .section dd {
+      margin-bottom: 1em;
+    }
+    
+    .section dl.attrs dd,
+    .section dl.eldef dd {
+      margin-bottom: 0;
+    }
+    
+    .respec-hidden {
+      display: none;
+    }
+    
+    @media print {
+      .removeOnSave {
         display: none;
+      }
     }
-}
-</style><meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"><style>/* --- EXAMPLES --- */
-div.example-title {
-    min-width: 7.5em;
-    color: #b9ab2d;
-}
-div.example-title span {
-    text-transform: uppercase;
-}
-aside.example, div.example, div.illegal-example {
-    padding: 0.5em;
-    margin: 1em 0;
-    position: relative;
-    clear: both;
-}
-div.illegal-example { color: red }
-div.illegal-example p { color: black }
-aside.example, div.example {
-    padding: .5em;
-    border-left-width: .5em;
-    border-left-style: solid;
-    border-color: #e0cb52;
-    background: #fcfaee;
-}
-
-aside.example div.example {
-    border-left-width: .1em;
-    border-color: #999;
-    background: #fff;
-}
-aside.example div.example div.example-title {
-    color: #999;
-}
-</style><style>/* --- ISSUES/NOTES --- */
-div.issue-title, div.note-title , div.ednote-title, div.warning-title {
-    padding-right:  1em;
-    min-width: 7.5em;
-    color: #b9ab2d;
-}
-div.issue-title { color: #e05252; }
-div.note-title, div.ednote-title { color: #2b2; }
-div.warning-title { color: #f22; }
-div.issue-title span, div.note-title span, div.ednote-title span, div.warning-title span {
-    text-transform: uppercase;
-}
-div.note, div.issue, div.ednote, div.warning {
-    margin-top: 1em;
-    margin-bottom: 1em;
-}
-.note > p:first-child, .ednote > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
-.issue, .note, .ednote, .warning {
-    padding: .5em;
-    border-left-width: .5em;
-    border-left-style: solid;
-}
-div.issue, div.note , div.ednote,  div.warning {
-    padding: 1em 1.2em 0.5em;
-    margin: 1em 0;
-    position: relative;
-    clear: both;
-}
-span.note, span.ednote, span.issue, span.warning { padding: .1em .5em .15em; }
-
-.issue {
-    border-color: #e05252;
-    background: #fbe9e9;
-}
-.note, .ednote {
-    border-color: #52e052;
-    background: #e9fbe9;
-}
-
-.warning {
-    border-color: #f11;
-    border-width: .2em;
-    border-style: solid;
-    background: #fbe9e9;
-}
-
-.warning-title:before{
-    content: "⚠"; /*U+26A0 WARNING SIGN*/
-    font-size: 3em;
-    float: left;
-    height: 100%;
-    padding-right: .3em;
-    vertical-align: top;
-    margin-top: -0.5em;
-}
-
-li.task-list-item {
-    list-style: none;
-}
-
-input.task-list-item-checkbox {
-    margin: 0 0.35em 0.25em -1.6em;
-    vertical-align: middle;
-}
-</style><style>/* HIGHLIGHTS */
-code.prettyprint {
-    color:  inherit;
-}
-
-/* this from google-code-prettify */
-.pln{color:#000}@media screen{.str{color:#080}.kwd{color:#008}.com{color:#800}.typ{color:#606}.lit{color:#066}.pun,.opn,.clo{color:#660}.tag{color:#008}.atn{color:#606}.atv{color:#080}.dec,.var{color:#606}.fun{color:red}}@media print,projection{.str{color:#060}.kwd{color:#006;font-weight:bold}.com{color:#600;font-style:italic}.typ{color:#404;font-weight:bold}.lit{color:#044}.pun,.opn,.clo{color:#440}.tag{color:#006;font-weight:bold}.atn{color:#404}.atv{color:#060}}ol.linenums{margin-top:0;margin-bottom:0}li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8{list-style-type:none}li.L1,li.L3,li.L5,li.L7,li.L9{background:#eee}
-</style><link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script type="application/json" id="initialUserConfig">{
-  "specStatus": "WD",
-  "shortName": "annotation-model",
-  "editors": [
-    {
-      "name": "Robert Sanderson",
-      "company": "Stanford University",
-      "companyURL": "http://www.stanford.edu/",
-      "mailto": "azaroth42@gmail.com"
-    },
-    {
-      "name": "Paolo Ciccarese",
-      "url": "http://www.paolociccarese.info",
-      "company": "Massachusetts General Hospital",
-      "companyUrl": "",
-      "mailto": "paolo.ciccarese@gmail.com "
-    },
-    {
-      "name": "Benjamin Young",
-      "url": "http://bigbluehat.com/",
-      "company": "Wiley",
-      "companyURL": "http://www.wiley.com/",
-      "mailto": "byoung@bigbluehat.com"
+  </style>
+  <title>Web Annotation Data Model</title>
+  <meta charset="utf-8">
+  <style>
+    .model {
+      empty-cells: show;
+      border-collapse: collapse;
+      margin-bottom: .5ex;
+      border: 1px solid black;
+      width: 100%;
     }
-  ],
-  "previousMaturity": "WD",
-  "previousPublishDate": "2016-03-31",
-  "previousURI": "http://www.w3.org/TR/2015/WD-annotation-model-20160331/",
-  "publishDate": "2016-05-20",
-  "edDraftURI": "http://w3c.github.io/web-annotation/",
-  "wg": "Web Annotation Working Group",
-  "wgURI": "http://www.w3.org/annotation/",
-  "wgPublicList": "public-annotation",
-  "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/73180/status",
-  "localBiblio": {
-    "iana-media-types": {
-      "title": "Media Types",
-      "href": "http://www.iana.org/assignments/media-types/",
-      "publisher": "IANA (Internet Assigned Numbers Authority)"
-    },
-    "w3c-language-tags": {
-      "title": "Language Tags in HTML and XML",
-      "href": "https://www.w3.org/International/articles/language-tags/",
-      "publisher": "W3C"
-    },
-    "cfi": {
-      "authors": [
-        "Peter Sorotokin",
-        "Garth Conboy",
-        "Brady Duga",
-        "John Rivlin",
-        "Don Beaver",
-        "Kevin Ballard",
-        "Alastair Fettes",
-        "Daniel Weck"
-      ],
-      "title": "EPUB Canonical Fragment Identifiers",
-      "href": "http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html",
-      "publisher": "IDPF",
-      "rawDate": "2014-06-26",
-      "status": "Recommended Specification"
-    },
-    "annotation-vocab": {
-      "authors": [
-        "Robert Sanderson",
-        "Paolo Ciccarese",
-        "Benjamin Young"
-      ],
-      "title": "Web Annotation Vocabulary",
-      "href": "http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/",
-      "publisher": "W3C",
-      "rawDate": "2016-03-31",
-      "status": "WD"
-    },
-    "annotation-protocol": {
-      "authors": [
-        "Robert Sanderson"
-      ],
-      "title": "Web Annotation Protocol",
-      "href": "http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/",
-      "publisher": "W3C",
-      "rawDate": "2016-03-31",
-      "status": "WD"
+    
+    .model th {
+      padding: 3px;
+      border: 1px solid #404040;
+      text-align: center;
+      font-weight: bold;
+      font-family: sans-serif;
     }
-  },
-  "otherLinks": [
+    
+    .model td {
+      padding: 5px;
+      border: 1px solid #404040;
+      text-align: left;
+      font-family: sans-serif;
+    }
+  </style>
+
+
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style>
+    /* --- EXAMPLES --- */
+    
+    div.example-title {
+      min-width: 7.5em;
+      color: #b9ab2d;
+    }
+    
+    div.example-title span {
+      text-transform: uppercase;
+    }
+    
+    aside.example,
+    div.example,
+    div.illegal-example {
+      padding: 0.5em;
+      margin: 1em 0;
+      position: relative;
+      clear: both;
+    }
+    
+    div.illegal-example {
+      color: red
+    }
+    
+    div.illegal-example p {
+      color: black
+    }
+    
+    aside.example,
+    div.example {
+      padding: .5em;
+      border-left-width: .5em;
+      border-left-style: solid;
+      border-color: #e0cb52;
+      background: #fcfaee;
+    }
+    
+    aside.example div.example {
+      border-left-width: .1em;
+      border-color: #999;
+      background: #fff;
+    }
+    
+    aside.example div.example div.example-title {
+      color: #999;
+    }
+  </style>
+  <style>
+    /* --- ISSUES/NOTES --- */
+    
+    div.issue-title,
+    div.note-title,
+    div.ednote-title,
+    div.warning-title {
+      padding-right: 1em;
+      min-width: 7.5em;
+      color: #b9ab2d;
+    }
+    
+    div.issue-title {
+      color: #e05252;
+    }
+    
+    div.note-title,
+    div.ednote-title {
+      color: #2b2;
+    }
+    
+    div.warning-title {
+      color: #f22;
+    }
+    
+    div.issue-title span,
+    div.note-title span,
+    div.ednote-title span,
+    div.warning-title span {
+      text-transform: uppercase;
+    }
+    
+    div.note,
+    div.issue,
+    div.ednote,
+    div.warning {
+      margin-top: 1em;
+      margin-bottom: 1em;
+    }
+    
+    .note > p:first-child,
+    .ednote > p:first-child,
+    .issue > p:first-child,
+    .warning > p:first-child {
+      margin-top: 0
+    }
+    
+    .issue,
+    .note,
+    .ednote,
+    .warning {
+      padding: .5em;
+      border-left-width: .5em;
+      border-left-style: solid;
+    }
+    
+    div.issue,
+    div.note,
+    div.ednote,
+    div.warning {
+      padding: 1em 1.2em 0.5em;
+      margin: 1em 0;
+      position: relative;
+      clear: both;
+    }
+    
+    span.note,
+    span.ednote,
+    span.issue,
+    span.warning {
+      padding: .1em .5em .15em;
+    }
+    
+    .issue {
+      border-color: #e05252;
+      background: #fbe9e9;
+    }
+    
+    .note,
+    .ednote {
+      border-color: #52e052;
+      background: #e9fbe9;
+    }
+    
+    .warning {
+      border-color: #f11;
+      border-width: .2em;
+      border-style: solid;
+      background: #fbe9e9;
+    }
+    
+    .warning-title:before {
+      content: "⚠";
+      /*U+26A0 WARNING SIGN*/
+      font-size: 3em;
+      float: left;
+      height: 100%;
+      padding-right: .3em;
+      vertical-align: top;
+      margin-top: -0.5em;
+    }
+    
+    li.task-list-item {
+      list-style: none;
+    }
+    
+    input.task-list-item-checkbox {
+      margin: 0 0.35em 0.25em -1.6em;
+      vertical-align: middle;
+    }
+  </style>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD">
+  <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
+  <script id="initialUserConfig" type="application/json">
     {
-      "key": "Repository",
-      "data": [
+      "specStatus": "WD",
+      "shortName": "annotation-model",
+      "editors": [
+      {
+        "name": "Robert Sanderson",
+        "company": "Stanford University",
+        "companyURL": "http://www.stanford.edu/",
+        "mailto": "azaroth42@gmail.com"
+      },
+      {
+        "name": "Paolo Ciccarese",
+        "url": "http://www.paolociccarese.info",
+        "company": "Massachusetts General Hospital",
+        "companyUrl": "",
+        "mailto": "paolo.ciccarese@gmail.com "
+      },
+      {
+        "name": "Benjamin Young",
+        "url": "http://bigbluehat.com/",
+        "company": "Wiley",
+        "companyURL": "http://www.wiley.com/",
+        "mailto": "byoung@bigbluehat.com"
+      }],
+      "previousMaturity": "WD",
+      "previousPublishDate": "2016-03-31",
+      "previousURI": "http://www.w3.org/TR/2015/WD-annotation-model-20160331/",
+      "publishDate": "2016-05-20",
+      "edDraftURI": "http://w3c.github.io/web-annotation/",
+      "wg": "Web Annotation Working Group",
+      "wgURI": "http://www.w3.org/annotation/",
+      "wgPublicList": "public-annotation",
+      "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/73180/status",
+      "localBiblio":
+      {
+        "iana-media-types":
+        {
+          "title": "Media Types",
+          "href": "http://www.iana.org/assignments/media-types/",
+          "publisher": "IANA (Internet Assigned Numbers Authority)"
+        },
+        "w3c-language-tags":
+        {
+          "title": "Language Tags in HTML and XML",
+          "href": "https://www.w3.org/International/articles/language-tags/",
+          "publisher": "W3C"
+        },
+        "cfi":
+        {
+          "authors": [
+            "Peter Sorotokin",
+            "Garth Conboy",
+            "Brady Duga",
+            "John Rivlin",
+            "Don Beaver",
+            "Kevin Ballard",
+            "Alastair Fettes",
+            "Daniel Weck"
+          ],
+          "title": "EPUB Canonical Fragment Identifiers",
+          "href": "http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html",
+          "publisher": "IDPF",
+          "rawDate": "2014-06-26",
+          "status": "Recommended Specification"
+        },
+        "annotation-vocab":
+        {
+          "authors": [
+            "Robert Sanderson",
+            "Paolo Ciccarese",
+            "Benjamin Young"
+          ],
+          "title": "Web Annotation Vocabulary",
+          "href": "http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/",
+          "publisher": "W3C",
+          "rawDate": "2016-03-31",
+          "status": "WD"
+        },
+        "annotation-protocol":
+        {
+          "authors": [
+            "Robert Sanderson"
+          ],
+          "title": "Web Annotation Protocol",
+          "href": "http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/",
+          "publisher": "W3C",
+          "rawDate": "2016-03-31",
+          "status": "WD"
+        }
+      },
+      "otherLinks": [
+      {
+        "key": "Repository",
+        "data": [
         {
           "value": "Github Repository",
           "href": "https://github.com/w3c/web-annotation"
-        }
-      ]
+        }]
+      }]
     }
-  ]
-}</script></head>
-    <body id="respecDocument" role="document" class="h-entry toc-inline"><div id="respecHeader" role="contentinfo" class="head">
-  <p>
-            <a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C" height="48" width="72"></a>
-  </p>
-  <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Data Model</h1>
-  <h2 id="w3c-working-draft-20-may-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-05-20">20 May 2016</time></h2>
-  <dl>
+  </script>
+</head>
+<body class="h-entry" role="document" id="respecDocument">
+  <div class="head" role="contentinfo" id="respecHeader">
+    <p>
+      <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
+    </p>
+    <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Data Model</h1>
+    <h2 id="w3c-working-draft-20-may-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-05-20">20 May 2016</time></h2>
+    <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="http://www.w3.org/TR/2016/WD-annotation-model-20160520/">http://www.w3.org/TR/2016/WD-annotation-model-20160520/</a></dd>
       <dt>Latest published version:</dt>
@@ -370,2416 +578,3654 @@ code.prettyprint {
       <dd><a href="http://w3c.github.io/web-annotation/">http://w3c.github.io/web-annotation/</a></dd>
       <dt>Previous version:</dt>
       <dd><a rel="dcterms:replaces" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a></dd>
-    <dt>Editors:</dt>
-    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Robert Sanderson</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
-<span property="rdf:rest" resource="_:editor1"></span>
-</dd>
-<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Paolo Ciccarese"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.paolociccarese.info">Paolo Ciccarese</a>, Massachusetts General Hospital, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:paolo.ciccarese@gmail.com ">paolo.ciccarese@gmail.com </a></span></span>
-<span property="rdf:rest" resource="_:editor2"></span>
-</dd>
-<dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Benjamin Young"><a class="u-url url p-name fn" property="foaf:homepage" href="http://bigbluehat.com/">Benjamin Young</a>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.wiley.com/">Wiley</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:byoung@bigbluehat.com">byoung@bigbluehat.com</a></span></span>
-<span property="rdf:rest" resource="rdf:nil"></span>
-</dd>
+      <dt>Editors:</dt>
+      <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Robert Sanderson</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
+        <span property="rdf:rest" resource="_:editor1"></span>
+      </dd>
+      <dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Paolo Ciccarese"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.paolociccarese.info">Paolo Ciccarese</a>, Massachusetts General Hospital, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:paolo.ciccarese@gmail.com ">paolo.ciccarese@gmail.com </a></span></span>
+        <span property="rdf:rest" resource="_:editor2"></span>
+      </dd>
+      <dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Benjamin Young"><a class="u-url url p-name fn" property="foaf:homepage" href="http://bigbluehat.com/">Benjamin Young</a>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.wiley.com/">Wiley</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:byoung@bigbluehat.com">byoung@bigbluehat.com</a></span></span>
+        <span property="rdf:rest" resource="rdf:nil"></span>
+      </dd>
 
-          <dt>Repository:</dt>
-                  <dd>
-                    <a href="https://github.com/w3c/web-annotation">
+      <dt>Repository:</dt>
+      <dd>
+        <a href="https://github.com/w3c/web-annotation">
                       Github Repository
                     </a>
-                  </dd>
-  </dl>
-      <p class="copyright">
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2016
-        
-        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
-        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). 
-        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
-        rules apply.
-      </p>
-  <hr title="Separator for header">
-</div>
+      </dd>
+    </dl>
+    <p class="copyright">
+      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016
 
+      <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (
+      <a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+      <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+      <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+      <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+    </p>
+    <hr title="Separator for header">
+  </div>
 
-<section property="dc:abstract" class="introductory" id="abstract"><h2 resource="#h-abstract" id="h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
 
-<p>Annotations are typically used to convey information about a resource or associations between resources. Simple examples include a comment or tag on a single web page or image, or a blog post about a news article.</p>
+  <section id="abstract" class="introductory" property="dc:abstract">
+    <h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
 
-<p>The Web Annotation Data Model specification describes a structured model and format to enable annotations to be shared and reused across different hardware and software platforms. Common use cases can be modeled in a manner that is simple and convenient, while at the same time enabling more complex requirements, including linking arbitrary content to a particular data point or to segments of timed multimedia resources.</p>
+    <p>Annotations are typically used to convey information about a resource or associations between resources. Simple examples include a comment or tag on a single web page or image, or a blog post about a news article.</p>
 
-<p>The specification provides a specific JSON format for ease of creation and consumption of annotations based on the conceptual model that accommodates these use cases, and the vocabulary of terms that represents it.</p>
+    <p>The Web Annotation Data Model specification describes a structured model and format to enable annotations to be shared and reused across different hardware and software platforms. Common use cases can be modeled in a manner that is simple and convenient, while at the same time enabling more complex requirements, including linking arbitrary content to a particular data point or to segments of timed multimedia resources.</p>
 
-</section><section id="sotd" class="introductory"><h2 resource="#h-sotd" id="h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
-        <p>
-          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
-        </p>
-          
-<p>
-  <b>This is a work in progress. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future. If you feel something should be covered, please <a href="mailto:public-annotation@w3.org">tell us!</a></b>
-</p>
+    <p>The specification provides a specific JSON format for ease of creation and consumption of annotations based on the conceptual model that accommodates these use cases, and the vocabulary of terms that represents it.</p>
 
-<p>
-This specification was derived from the Open Annotation Community Group's outcomes, and details of the differences between the two are maintained in the <a href="#acknowledgements">Acknowledgement</a> appendix.
-</p>
+  </section>
 
-
-          <p>
-            This document was published by the <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> as a Working Draft.
-              This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
-              If you wish to make comments regarding this document, please send them to
-              <a href="mailto:public-annotation@w3.org">public-annotation@w3.org</a>
-              (<a href="mailto:public-annotation-request@w3.org?subject=subscribe">subscribe</a>,
-              <a href="http://lists.w3.org/Archives/Public/public-annotation/">archives</a>).
-            
-              All comments are welcome.
-          </p>
-            <p>
-              Publication as a Working Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
-              Membership. This is a draft document and may be updated, replaced or obsoleted by other
-              documents at any time. It is inappropriate to cite this document as other than work in
-              progress.
-            </p>
-          <p>
-              This document was produced by
-              a group
-               operating under the
-              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-              Policy</a>.
-                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/73180/status" rel="disclosure">public list of any patent
-                disclosures</a>
-              made in connection with the deliverables of
-              the group; that page also includes
-              instructions for disclosing a patent. An individual who has actual knowledge of a patent
-              which the individual believes contains
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-              Claim(s)</a> must disclose the information in accordance with
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-          </p>
-            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
-            </p>
-          
-</section><nav id="toc"><h2 resource="#table-of-contents" id="table-of-contents" class="introductory"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul role="directory" class="toc"><li class="tocline"><a class="tocxref" href="#introduction"><span class="secno">1. </span>Introduction</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#aims-of-the-model"><span class="secno">1.1 </span>Aims of the Model</a></li><li class="tocline"><a class="tocxref" href="#serialization-of-the-model"><span class="secno">1.2 </span>Serialization of the Model</a></li><li class="tocline"><a class="tocxref" href="#conformance"><span class="secno">1.3 </span>Conformance</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#conformance-requirements-related-to-selectors"><span class="secno">1.3.1 </span>Conformance Requirements Related to Selectors</a></li></ul></li><li class="tocline"><a class="tocxref" href="#terminology"><span class="secno">1.4 </span>Terminology</a></li></ul></li><li class="tocline"><a class="tocxref" href="#web-annotation-principles"><span class="secno">2. </span>Web Annotation Principles</a></li><li class="tocline"><a class="tocxref" href="#web-annotation-framework"><span class="secno">3. </span>Web Annotation Framework</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#annotations"><span class="secno">3.1 </span>Annotations</a></li><li class="tocline"><a class="tocxref" href="#bodies-and-targets"><span class="secno">3.2 </span>Bodies and Targets</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#external-web-resources"><span class="secno">3.2.1 </span>External Web Resources</a></li><li class="tocline"><a class="tocxref" href="#classes"><span class="secno">3.2.2 </span>Classes</a></li><li class="tocline"><a class="tocxref" href="#segments-of-external-resources"><span class="secno">3.2.3 </span>Segments of External Resources</a></li><li class="tocline"><a class="tocxref" href="#embedded-textual-body"><span class="secno">3.2.4 </span>Embedded Textual Body</a></li><li class="tocline"><a class="tocxref" href="#string-body"><span class="secno">3.2.5 </span>String Body</a></li><li class="tocline"><a class="tocxref" href="#cardinality-of-bodies-and-targets"><span class="secno">3.2.6 </span>Cardinality of Bodies and Targets</a></li><li class="tocline"><a class="tocxref" href="#choice-of-bodies-and-targets"><span class="secno">3.2.7 </span>Choice of Bodies and Targets </a></li><li class="tocline"><a class="tocxref" href="#sets-of-bodies-and-targets"><span class="secno">3.2.8 </span>Sets of Bodies and Targets</a></li></ul></li><li class="tocline"><a class="tocxref" href="#other-properties"><span class="secno">3.3 </span>Other Properties</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#lifecycle-information"><span class="secno">3.3.1 </span>Lifecycle Information</a></li><li class="tocline"><a class="tocxref" href="#agents"><span class="secno">3.3.2 </span>Agents</a></li><li class="tocline"><a class="tocxref" href="#intended-audience"><span class="secno">3.3.3 </span>Intended Audience</a></li><li class="tocline"><a class="tocxref" href="#motivation-and-purpose"><span class="secno">3.3.4 </span>Motivation and Purpose</a></li><li class="tocline"><a class="tocxref" href="#rights-information"><span class="secno">3.3.5 </span>Rights Information</a></li><li class="tocline"><a class="tocxref" href="#other-identities"><span class="secno">3.3.6 </span>Other Identities</a></li></ul></li></ul></li><li class="tocline"><a class="tocxref" href="#specific-resources"><span class="secno">4. </span>Specific Resources</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#purpose-for-external-web-resources"><span class="secno">4.1 </span>Purpose for External Web Resources</a></li><li class="tocline"><a class="tocxref" href="#selectors"><span class="secno">4.2 </span>Selectors</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#fragment-selector"><span class="secno">4.2.1 </span>Fragment Selector</a></li><li class="tocline"><a class="tocxref" href="#css-selector"><span class="secno">4.2.2 </span>CSS Selector</a></li><li class="tocline"><a class="tocxref" href="#xpath-selector"><span class="secno">4.2.3 </span>XPath Selector</a></li><li class="tocline"><a class="tocxref" href="#text-quote-selector"><span class="secno">4.2.4 </span>Text Quote Selector</a></li><li class="tocline"><a class="tocxref" href="#text-position-selector"><span class="secno">4.2.5 </span>Text Position Selector</a></li><li class="tocline"><a class="tocxref" href="#data-position-selector"><span class="secno">4.2.6 </span>Data Position Selector</a></li><li class="tocline"><a class="tocxref" href="#svg-selector"><span class="secno">4.2.7 </span>SVG Selector</a></li><li class="tocline"><a class="tocxref" href="#range-selector"><span class="secno">4.2.8 </span>Range Selector</a></li><li class="tocline"><a class="tocxref" href="#refinement-of-selection"><span class="secno">4.2.9 </span>Refinement of Selection</a></li></ul></li><li class="tocline"><a class="tocxref" href="#states"><span class="secno">4.3 </span>States</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#time-state"><span class="secno">4.3.1 </span>Time State</a></li><li class="tocline"><a class="tocxref" href="#request-header-state"><span class="secno">4.3.2 </span>Request Header State</a></li><li class="tocline"><a class="tocxref" href="#refinement-of-state"><span class="secno">4.3.3 </span>Refinement of State</a></li></ul></li><li class="tocline"><a class="tocxref" href="#styles"><span class="secno">4.4 </span>Styles</a></li><li class="tocline"><a class="tocxref" href="#rendering-software"><span class="secno">4.5 </span>Rendering Software</a></li><li class="tocline"><a class="tocxref" href="#scope-of-a-resource"><span class="secno">4.6 </span>Scope of a Resource</a></li></ul></li><li class="tocline"><a class="tocxref" href="#collections"><span class="secno">5. </span>Collections</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#annotation-collection"><span class="secno">5.1 </span>Annotation Collection</a></li><li class="tocline"><a class="tocxref" href="#annotation-page"><span class="secno">5.2 </span>Annotation Page</a></li></ul></li><li class="tocline"><a class="tocxref" href="#media_selector"><span class="secno">A. </span>Correspondance Among Media Types and Selectors</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#additional-media-types-selector-combination"><span class="secno">A.1 </span>Additional Media Types/Selector Combination</a></li></ul></li><li class="tocline"><a class="tocxref" href="#complete-example"><span class="secno">B. </span>Complete Example</a></li><li class="tocline"><a class="tocxref" href="#index-of-json-keys"><span class="secno">C. </span>Index of JSON Keys</a></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><span class="secno">D. </span>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#changes-from-previous-draft"><span class="secno">E. </span>Changes from Previous Draft</a></li><li class="tocline"><a class="tocxref" href="#references"><span class="secno">F. </span>References</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><span class="secno">F.1 </span>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><span class="secno">F.2 </span>Informative references</a></li></ul></li></ul></nav>
-
-
-
-<section property="bibo:hasPart" resource="#introduction" typeof="bibo:Chapter" id="introduction" class="informative">
-<!--OddPage--><h2 resource="#h-introduction" id="h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2><p><em>This section is non-normative.</em></p>
-
-<p>Annotating, the act of creating associations between distinct pieces
-of information, is a pervasive activity online in many guises.
-Web citizens make comments about online resources using either tools built
-in to the hosting website, external web services, or the functionality
-of an annotation client. Comments about shared photos or videos, reviews of products, or even social network mentions of web resources could all be considered as annotations. In addition, there are a plethora of "sticky note" systems and stand-alone multimedia annotation systems. This specification describes a common approach to expressing these annotations, and more.
-</p>
-
-<p>The Web Annotation Data Model provides an extensible, interoperable framework for
-expressing annotations such that they can easily be shared between
-platforms, with sufficient richness of expression to satisfy complex
-requirements while remaining simple enough to also allow for the most common use cases,
-such as attaching a piece of text to a single web resource.</p>
-
-<p>An annotation is considered to be a set of connected resources,
-typically including a body and target, and conveys that the body is related to the target.
-The exact nature of this relationship changes according to the intention of the annotation, but the body is most frequently somehow "about" the target.  This perspective results in a basic model with three parts, depicted below.
-The full model supports additional functionality, enabling content to be embedded within the annotation,
-selecting arbitrary segments of resources, choosing the appropriate representation of a
-resource and providing styling hints to help clients render the annotation appropriately.
-Annotations created by or intended for machines are also possible, ensuring that the Data Web is not ignored in favor of only considering the human-oriented Document Web.</p>
-
-<img src="images/intro_model.png" alt="Basic Model: Annotation, Body and Target" width="400">
-
-<p>The Web Annotation Data Model does not prescribe a transport protocol for creating, managing and retrieving annotations. Instead it describes a resource oriented structure and serialization of that structure that could be carried over many different protocols.  The related [<cite><a href="#bib-annotation-protocol" class="bibref">annotation-protocol</a></cite>] specification describes a recommended transport layer, which may be adopted separately.</p>
-
-
-<section property="bibo:hasPart" resource="#aims-of-the-model" typeof="bibo:Chapter" id="aims-of-the-model">
-	<h3 resource="#h-aims-of-the-model" id="h-aims-of-the-model"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Aims of the Model</span></h3>
-
-	<p>
-The primary aim of the Web Annotation Data Model is to provide a
-standard description model and format to enable annotations to be shared between
-systems.  This interoperability may be either for sharing with others,
-or the migration of private annotations between devices or platforms.  The shared
-annotations must be able to be integrated into existing collections
-and reused without loss of significant information.  The model should
-cover as many annotation use cases as possible, while keeping the simple
-annotations easy and expanding from that baseline to make complex uses possible.
-</p>
-
-<p>
-The Web Annotation Data Model is a single, consistent model that can be used by all interested parties.
-All efforts have been made to keep the implementation costs for both producers
-and consumers to a minimum.  A single method of fulfilling a use case
-is strongly preferred over multiple methods, unless there are existing
-standards that need to be accommodated or there is a significant cost
-associated with using only a single method.  While the Data Model is built using Linked Data
-fundamentals, the design is intended to allow rich and performant non-graph-based implementations.
-As such, inferencing and other graph-based queries are explicitly not a priority for optimization in the
-design of the model.
-
-</p>
-</section>
-
-<section property="bibo:hasPart" resource="#serialization-of-the-model" typeof="bibo:Chapter" id="serialization-of-the-model">
-<h3 resource="#h-serialization-of-the-model" id="h-serialization-of-the-model"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Serialization of the Model</span></h3>
-
-<p>
-The examples throughout the document are serialized as [<cite><a href="#bib-JSON-LD" class="bibref">JSON-LD</a></cite>] using the Context given in Appendix A of the Annotation Vocabulary [<cite><a href="#bib-annotation-vocab" class="bibref">annotation-vocab</a></cite>], which is the preferred serialization format.
-</p>
-
-<p>When the only information that is recorded in the annotation is the <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a> of a resource, then that IRI is used as the value of the relationship, as in <a href="#annotations">Example 1</a>.  When there is more information about the resource, the IRI is the value of the <code>id</code> property of the object which is the value of the relationship, as in <a href="#external-web-resources">Example 2</a>.</p>
-
-
-</section>
-
-<section property="bibo:hasPart" resource="#conformance" typeof="bibo:Chapter" id="conformance"><h3 resource="#h-conformance" id="h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
-<p>
-  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
-  and notes in this specification are non-normative. Everything else in this specification is
-  normative.
-</p>
-<p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="NOT RECOMMENDED">NOT RECOMMENDED</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are 
-  to be interpreted as described in [<cite><a href="#bib-RFC2119" class="bibref">RFC2119</a></cite>].
-</p>
-
-    <section property="bibo:hasPart" resource="#conformance-requirements-related-to-selectors" typeof="bibo:Chapter" id="conformance-requirements-related-to-selectors">
-        <h4 resource="#h-conformance-requirements-related-to-selectors" id="h-conformance-requirements-related-to-selectors"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3.1 </span>Conformance Requirements Related to Selectors</span></h4>
-        <p>Not all <a href="#selectors">Selectors</a> are relevant for all media types; some combinations are meaningless or not formally defined. An implementation may therefore ignore certain types of Selectors in case the corresponding media types are not handled by that particular implementation.</p>
-
-        <p>The table in <a class="sec-ref" href="#media_selector"><span class="secno">A.</span> <span class="sec-title">Correspondance Among Media Types and Selectors</span></a> shows the correspondance among the main media types addressed in this specification and Selector types. The meaning of the table elements, and their affect on implementation conformance, is as follows.</p>
-
-        <ul>
-            <li>A “✔︎” sign in the table means that the Selector type is relevant for that particular media types. A conformant implementation <em title="MUST" class="rfc2119">MUST</em> implement that particular combination <em>if</em> it handles the corresponding media type.</li>
-
-            <li>A “✘” sign in the table means that the Selector type is not relevant for that particular media types. Conformant implementations <em title="SHOULD" class="rfc2119">SHOULD</em> ignore that particular combination.</li>
-
-            <li>A “?” means that it is not possible to specify, in general, whether that particular combination is meaningful (e.g., fragment identifiers are defined for specific media types, i.e., specific text media types other than plain text may have fragments defined but they are not listed in the table). In other cases the usefulness of such combination is not clear (e.g., Data Position selectors for binary images). Conformant implementations <em title="MAY" class="rfc2119">MAY</em> implement that particular combination.</li>
-        </ul>
-
-    </section>
-</section>
-
-<section property="bibo:hasPart" resource="#terminology" typeof="bibo:Chapter" id="terminology">
-<h3 resource="#h-terminology" id="h-terminology"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.4 </span>Terminology</span></h3>
-
-<dl>
-
-  <dt><dfn id="dfn-iri" data-dfn-type="dfn">IRI</dfn></dt>
-  <dd>An <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>, or Internationalized Resource Identifier, is an extension to the URI specification to allow characters from Unicode, whereas URIs must be made up of a subset of ASCII characters. There is a mapping algorithm for translating between IRIs and the equivalent encoded URI form. IRIs are defined by [<cite><a href="#bib-rfc3987" class="bibref">rfc3987</a></cite>].</dd>
-
-  <dt><dfn id="dfn-resource" data-dfn-type="dfn">Resource</dfn></dt>
-  <dd>An item of interest that <em title="MAY" class="rfc2119">MAY</em> be identified by an <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>.</dd>
-
-  <dt><dfn id="dfn-web-resource" data-dfn-type="dfn">Web Resource</dfn></dt>
-  <dd>A <a data-link-type="dfn" class="internalDFN" href="#dfn-resource">Resource</a> that <em title="MUST" class="rfc2119">MUST</em> be identified by an <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>, as described in the Web Architecture [<cite><a href="#bib-webarch" class="bibref">webarch</a></cite>].  Web Resources <em title="MAY" class="rfc2119">MAY</em> be dereferencable via their IRI.</dd>
-
-  <dt><dfn id="dfn-external-web-resource" data-dfn-type="dfn">External Web Resource</dfn></dt>
-  <dd>A <a data-link-type="dfn" class="internalDFN" href="#dfn-web-resource">Web Resource</a> which is not part of the representation of the Annotation, such as a web page, image, or video. External Web Resources are dereferencable from their <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>.</dd>
-
-  <dt><dfn id="dfn-property" data-dfn-type="dfn">Property</dfn></dt>
-  <dd>A feature of a <a data-link-type="dfn" class="internalDFN" href="#dfn-resource">Resource</a>, that often has a particular data type.  In the model sections, the term "Property" is used to refer to only those features which are <em>not</em> <a data-link-type="dfn" class="internalDFN" href="#dfn-relationship">Relationships</a> and instead have a literal value such as a string, integer or date.  The valid values for a Property are thus any data type other than object, or an array containing members of that data type if more than one is allowed.</dd>
-
-  <dt><dfn id="dfn-relationship" data-dfn-type="dfn">Relationship</dfn></dt>
-  <dd>In the model sections, the term "Relationship" is used to distinguish those features that refer to other <a data-link-type="dfn" class="internalDFN" href="#dfn-resource">Resources</a>, either by reference to the <a data-link-type="dfn" class="internalDFN" href="#dfn-resource">Resource</a>'s <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a> or by including a description of the <a data-link-type="dfn" class="internalDFN" href="#dfn-resource">Resource</a> in the Annotation's representation. The valid values for a Relationship are: a quoted string containing an IRI, an object that has the "id" property, or an array containing either of these if more than one is allowed.</dd>
-
-  <dt><dfn id="dfn-class" data-dfn-type="dfn">Class</dfn></dt>
-  <dd><a data-link-type="dfn" class="internalDFN" href="#dfn-resource">Resources</a> may be divided, conceptually, into groups called "classes"; members of a class are known as <a data-link-type="dfn" class="internalDFN" href="#dfn-instance">Instances</a> of the class. Resources are associated with a particular class through <a data-link-type="dfn" class="internalDFN" href="#dfn-type">typing</a>. Classes are identified by <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRIs</a>, i.e., they are also <a data-link-type="dfn" class="internalDFN" href="#dfn-web-resource">Web Resources</a> themselves.</dd>
-
-  <dt><dfn id="dfn-type" data-dfn-type="dfn">Type</dfn></dt>
-  <dd>A special <a data-link-type="dfn" class="internalDFN" href="#dfn-relationship">Relationship</a> that associates an <a data-link-type="dfn" class="internalDFN" href="#dfn-instance">Instance</a> of a class to the <a data-link-type="dfn" class="internalDFN" href="#dfn-class">Class</a> it belongs to.</dd>
-
-  <dt><dfn id="dfn-instance" data-dfn-type="dfn">Instance</dfn></dt>
-  <dd>An element of a group of <a data-link-type="dfn" class="internalDFN" href="#dfn-resource">Resources</a> represented by a particular <a data-link-type="dfn" class="internalDFN" href="#dfn-class">Class</a>.</dd>
-
-</dl>
-
-</section>
-
-</section>
-
-<!-- End Introduction -->
-
-<section property="bibo:hasPart" resource="#web-annotation-principles" typeof="bibo:Chapter" id="web-annotation-principles">
-<!--OddPage--><h2 resource="#h-web-annotation-principles" id="h-web-annotation-principles"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Principles</span></h2>
-
-<p>
-The Web Annotation Data Model is defined using the following basic principles:
-
-</p><ul>
-<li>An Annotation is a rooted, directed graph that represents a relationship between resources.</li>
-<li>There are two primary types of resource that participate in this relationship, Bodies and Targets.</li>
-<li>Annotations have 0 or more Bodies.</li>
-<li>Annotations have 1 or more Targets.</li>
-<li>The content of the Body resources is related to, and typically "about", the content of the Target resources.</li>
-<li>Annotations, Bodies and Targets may have their own properties and relationships, typically including creation and descriptive information.</li>
-<li>The intent behind the creation of an Annotation or the inclusion of a particular Body or Target is an important property and represented by a Motivation resource.</li>
-</ul>
-<p></p>
-
-<p>
-The following principles describe additional distinctions regarding the exact nature of Target and Body:
-
-</p><ul>
-<li>The Target or Body resource may be more specific than the entity identified by the resource's <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a> alone.</li>
-<li>In particular,
-  <ul>
-<li>The Target or Body resource may be a specific segment of the resource.</li>
-<li>The Target or Body resource may be styled in a specific way.</li>
-<li>The Target or Body resource may be a specific state of the resource.</li>
-<li>The Target or Body resource may be included in the Annotation to play a specific role.</li>
-<li>The Target or Body resource may be any combination of the above.</li>
-</ul></li>
-<li>The resource with these constraints is a separate resource from the Annotation, Body or Target, and is called a SpecificResource.</li>
-<li>The SpecificResource refers to the source resource and the constraints that make it more specific.</li>
-<li>The identity of the SpecificResource is separate from the descriptions of the constraints.</li>
-</ul>
-<p></p>
-
-<p>
-The following principles describe additional semantics regarding multiple resources:
-
-</p><ul>
-<li>A resource may be a choice between multiple resources.</li>
-<li>A resource may be an ordered list of resources.</li>
-</ul>
-<p></p>
-</section>
-
-<section property="bibo:hasPart" resource="#web-annotation-framework" typeof="bibo:Chapter" id="web-annotation-framework">
-	<!--OddPage--><h2 resource="#h-web-annotation-framework" id="h-web-annotation-framework"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Web Annotation Framework</span></h2>
-
-<section property="bibo:hasPart" resource="#annotations" typeof="bibo:Chapter" id="annotations">
-<h3 resource="#h-annotations" id="h-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1 </span>Annotations</span></h3>
-
-<p>
-An Annotation is a web resource. Typically, an Annotation has a single Body, which is a comment or other descriptive resource, and a single Target that the Body is somehow "about".  The Annotation likely also has additional descriptive properties. </p>
-
-<p><b>Example Use Case:</b> Alice has written a post that makes a comment about a particular web page.  Her client creates an Annotation with the post as the body resource, and the web page as the target resource.</p>
-
-<h3 id="model">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>@context</td><td>Property</td><td>The context that determines the meaning of the JSON as an Annotation
-  <br>The Annotation <em title="MUST" class="rfc2119">MUST</em> have 1 or more <code>@context</code> values and <code>http://www.w3.org/ns/anno.jsonld</code> <em title="MUST" class="rfc2119">MUST</em> be one of them. If there is only one value, then it <em title="MUST" class="rfc2119">MUST</em> be provided as a string.</td></tr>
-<tr><td>id</td><td>Property</td><td>The identity of the Annotation
-<br>An Annotation <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a> that identifies it.</td></tr>
-<tr><td>type</td><td>Relationship</td><td>The type of the Annotation.
-  <br>An Annotation <em title="MUST" class="rfc2119">MUST</em> have 1 or more types, and the <code>Annotation</code> class <em title="MUST" class="rfc2119">MUST</em> be one of them.</td></tr>
-<tr><td>Annotation</td><td>Class</td><td>The class for Web Annotations
-<br>The <code>Annotation</code> class <em title="MUST" class="rfc2119">MUST</em> be associated with an Annotation using <code>type</code>.</td></tr>
-<tr><td>body</td><td>Relationship</td><td>The relationship between an Annotation and its Body
-<br>There <em title="SHOULD" class="rfc2119">SHOULD</em> be 1 or more <code>body</code> relationships associated with an Annotation but there <em title="MAY" class="rfc2119">MAY</em> be 0.
-</td></tr>
-<tr><td>target</td><td>Relationship</td><td>The relationship between an Annotation and its Target
-<br>There <em title="MUST" class="rfc2119">MUST</em> be 1 or more <code>target</code> relationships associated with an Annotation.
-</td></tr>
-</tbody></table>
-
-<h3 id="example">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 1</span><span style="text-transform: none">: Basic Annotation Model</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/post1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/page1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#bodies-and-targets" typeof="bibo:Chapter" id="bodies-and-targets">
-  <h3 resource="#h-bodies-and-targets" id="h-bodies-and-targets"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2 </span>Bodies and Targets</span></h3>
-
-The Web is distributed, with different systems working together to provide access to content.  Annotations can be used to link those resources together, being referenced as the Body and Target.  The Target resource is always an External Web Resource, but the Body may also be embedded within the Annotation.  External Web Resources may be separately dereferenced to retrieve a representation of their state, whereas the embedded Body does not need to be dereferenced as the representation is included within the Annotation's representation.
-
-<section property="bibo:hasPart" resource="#external-web-resources" typeof="bibo:Chapter" id="external-web-resources">
-<h4 resource="#h-external-web-resources" id="h-external-web-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.1 </span>External Web Resources</span></h4>
-
-<p>Web Resources are identified with a <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a> and have various properties, often including a format or language for the resource's content.  This information may be recorded as part of the Annotation, even if the representation of the resource must be retrieved from the Web.</p>
-
-<p><b>Example Use Case:</b> Beatrice records a long analysis of a patent, and publishes the audio on her website as an mp3.  She then creates an Annotation with the mp3 as the body, and the PDF of the patent as the target.</p>
-
-<h4 id="model-1">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-  <tr><td>id</td><td>Property</td><td>The <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a> that identifies the Body or Target resource.
-<br>Bodies or Targets which are External Web Resources <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>id</code> with the value of the resource's <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>.
-  </td></tr>
-  <tr><td>language</td><td>Property</td><td>The language of the Web Resource's content
-  <br>The Body or Target <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 language associated with it, but <em title="MAY" class="rfc2119">MAY</em> have 0 or more.  The value of the property <em title="SHOULD" class="rfc2119">SHOULD</em> be a language code following the [<cite><a href="#bib-bcp47" class="bibref">bcp47</a></cite>] specifiction.</td></tr>
-<tr><td>format</td><td>Property</td><td>The format of the Web Resource's content
-  <br>The Body or Target <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 format associated with it, but <em title="MAY" class="rfc2119">MAY</em> have 0 or more.  The value of the property <em title="SHOULD" class="rfc2119">SHOULD</em> be the media-type of the format, following the [<cite><a href="#bib-rfc6838" class="bibref">rfc6838</a></cite>] specification.</td></tr>
-</tbody></table>
-
-<div class="note"><div id="h-note1" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">
-The [<cite><a href="#bib-iana-media-types" class="bibref">iana-media-types</a></cite>] document provides the official registry of media types that can be used with the <code>format</code> property.  The [<cite><a href="#bib-w3c-language-tags" class="bibref">w3c-language-tags</a></cite>] article provides a good overview of the values that implementers can expect to encounter in the <code>language</code> property.
-</div></div>
-
-<h4 id="example-1">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 2</span><span style="text-transform: none">: External Web Resources</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno2"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/analysis1.mp3"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"audio/mpeg"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"fr"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.gov/patent1.pdf"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"application/pdf"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"en"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#classes" typeof="bibo:Chapter" id="classes">
-<h4 resource="#h-classes" id="h-classes"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.2 </span>Classes</span></h4>
-
-<p>It is useful for clients to know the general type of a Web Resource in advance.  If the client cannot render videos, then knowing that the Body is a video will allow it to avoid needlessly downloading a potentially large content stream.  For resources that do not have obvious media types, such as many data formats, it is also useful for a client to know that a resource with the format <code>text/csv</code> should not simply be rendered as plain text, despite the first part of the media type, whereas <code>application/pdf</code> may be able to be rendered by the user agent despite the main type being 'application'.</p>
-
-<p><b>Example Use Case:</b> Corina shoots a video of her comment about a website on her phone and uploads it. She associates the video with the website via an Annotation, and her client adds types as a hint to consuming systems.</p>
-
-<h4 id="model-2">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The type of the Body resource.
-  <br>The Body or Target <em title="MAY" class="rfc2119">MAY</em> have 1 or more <code>type</code>s, and if so, the value <em title="SHOULD" class="rfc2119">SHOULD</em> be drawn from the list of classes below, but <em title="MAY" class="rfc2119">MAY</em> come from other vocabularies.</td></tr>
-<tr><td>Dataset</td><td>Class</td><td>The class for a resource which encodes data in a defined structure</td></tr>
-<tr><td>Image</td><td>Class</td><td>The class for image resources, primarily intended to be seen</td></tr>
-<tr><td>Video</td><td>Class</td><td>The class for video resources, with or without audio</td></tr>
-<tr><td>Sound</td><td>Class</td><td>The class for a resource primarily intended to be heard</td></tr>
-<tr><td>Text</td><td>Class</td><td>The class for a resource primarily intended to be read</td></tr>
-</tbody></table>
-
-<h4 id="example-2">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 3</span><span style="text-transform: none">: Typing of Body and Target</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno3"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/video1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Video"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/website1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Text"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#segments-of-external-resources" typeof="bibo:Chapter" id="segments-of-external-resources">
-<h4 resource="#h-segments-of-external-resources" id="h-segments-of-external-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.3 </span>Segments of External Resources</span></h4>
-
-<p>Many Annotations involve part of an External Web Resource, rather than its entirety. In the Web [<cite><a href="#bib-webarch" class="bibref">webarch</a></cite>], segments of resources are identified using <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRIs</a> with a fragment component that at the same time both describes how to extract the segment of interest from the resource, and identifies the extracted content.  For simple Annotations, it is valuable to be able to use these IRIs with a fragment component as the identifier for either Body or Target.
-</p>
-
-<p><b>Example Use Case:</b> Dawn wants to describe a particular region of an image.  She highlights that area in her client and types in the description. Her client then constructs an IRI with an appropriate fragment component as the target.</p>
-
-<h4 id="model-3">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-  <tr><td>id</td><td>Property</td><td>The IRI that identifies the Body or Target resource.
-<br>Bodies or Targets which are External Web Resources <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>id</code> with the value of the resource's IRI, and that IRI <em title="MAY" class="rfc2119">MAY</em> have a fragment component.
-  </td></tr>
-</tbody></table>
-
-<div class="note"><div id="h-note2" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">Note that other properties of resources such as <code>type</code>, <code>format</code> and <code>language</code>, plus those described in the <a href="#other-properties">Other Properties</a> section below, can be applied to the segment of the resource, just like for the full resource.</div></div>
-
-<p>
-  It is important to be aware of the consequences of using an IRI with a fragment component, and the restrictions that using them places on implementations.
-
-</p><ul>
-<li>Fragments are defined with respect to individual media types. For example, HTML has a specific set of semantics regarding the meaning of the fragment part of the IRI.</li>
-<li>Not every media type has a fragment specification.  For example, Office documents might have a media-type and be published on the web, but not have semantics associated with the fragment part of the IRI.</li>
-<li>Even if a media type does have a fragment definition, it is often not possible to describe the segment of interest sufficiently precisely.  For example, fragments for HTML cannot be used to describe an arbitrary range of text.</li>
-<li>It is not possible to determine with certainty what is being identified without knowing the media type, as the same fragment string might be possible in different specifications.  For example, the same fragment string could identify either a rectangular area in an image, or a strangely named section of an HTML document.</li>
-<li>IRIs with a fragment component are not compatible with other methods of describing the segment more specifically. For example, it is not possible to describe how to retrieve the correct representation, add style information, or associate a role with the resource, using such IRIs. The method to accomplish these requirements is described in the <a href="#fragment-selector">Fragment Selector</a> portion of the <a href="#specific-resources">Specific Resources</a> section.</li>
-<li>As IRIs are considered to be opaque strings, annotation systems may not discover annotations with fragment components when searching by means of the IRI without the fragment.  For example, an Annotation with the Target
- <code>http://example.com/image.jpg#xywh=1,1,1,1</code> would not be discovered in a simple search for
- <code>http://example.com/image.jpg</code>, even though it is part of it.</li>
-</ul>
-
-For more information regarding the use of IRIs with fragment components, please see the Best Practices for Fragment Identifiers and Media Type Definitions [<cite><a href="#bib-fragid-best-practices" class="bibref">fragid-best-practices</a></cite>].
-<p></p>
-
-<h4 id="example-3">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 4</span><span style="text-transform: none">: IRIs with Fragment Components</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno4"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/image1#xywh=100,100,300,300"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Image"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"image/jpeg"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#embedded-textual-body" typeof="bibo:Chapter" id="embedded-textual-body">
-  <h4 resource="#h-embedded-textual-body" id="h-embedded-textual-body"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.4 </span>Embedded Textual Body</span></h4>
-
-<p>In many situations, the body of the Annotation will be in a text format, and created at the same time as the Annotation and not have a separate IRI. In these cases, the Body's text can be included as part of the Annotation to avoid having to interact with multiple systems.  The Body may also have the features of External Web Resources, including especially the language of the text and the format that it is conveyed in.</p>
-
-<p><b>Example Use Case:</b> Emily writes a comment about how much she likes an image on a photo sharing website.  Her client creates an Annotation with the comment embedded within it, and adds that it is in French and formatted using HTML.</p>
-
-<h4 id="model-4">Model</h4>
-
-The fundamental features of a textual body are:
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>id</td><td>Property</td><td>The IRI that identifies the Textual Body
-<br>The Body <em title="MAY" class="rfc2119">MAY</em> have exactly 1 IRI that identifies it.</td></tr>
-<tr><td>type</td><td>Relationship</td><td>The type of the Textual Body resource.
-  <br>The Body <em title="SHOULD" class="rfc2119">SHOULD</em> have the <code>TextualBody</code> class, and <em title="MAY" class="rfc2119">MAY</em> have other classes.</td></tr>
-<tr><td>TextualBody</td><td>Class</td><td>A class assigned to the Body for embedding textual resources within the Annotation.
-<br>The Body <em title="SHOULD" class="rfc2119">SHOULD</em> have the <code>TextualBody</code> class.</td></tr>
-<tr><td>value</td><td>Property</td><td>The character sequence of the content of the Textual Body.<br>
-There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>value</code> property associated with the TextualBody.</td></tr>
-</tbody></table>
-
-<p>Systems <em title="SHOULD" class="rfc2119">SHOULD</em> assume that Textual Bodies have the <code>Text</code> class, described in <a href="#classes">Classes</a> above, even if it is not explicitly included in the <code>type</code> property. </p>
-
-<p>The properties of External Web Resources, such as <code>language</code> and <code>format</code> also apply to embedded Textual Body resources.</p>
-
-<h4 id="example-4">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 5</span><span style="text-transform: none">: Textual Body</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno5"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"&lt;p&gt;Comment text&lt;/p&gt;"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"format"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"text/html"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"language"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="str">"en"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/photo1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#string-body" typeof="bibo:Chapter" id="string-body">
-<h4 resource="#h-string-body" id="h-string-body"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.5 </span>String Body</span></h4>
-
-<p>
-The simplest type of Body is a plain text string, without additional information or properties.  This type of body is useful for the simplest of Annotations only, and is <em title="NOT RECOMMENDED" class="rfc2119">NOT RECOMMENDED</em> for uses where the body may need to be referred to from outside of the Annotation.
-</p>
-
-<p><b>Example Use Case</b> Franceska wants to create a quick Annotation from a simple, command line client.  She creates the JSON serialization in a text file and sends it to her Annotation server to maintain.</p>
-
-<h4 id="model-5">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>bodyValue</td><td>Property</td><td>The string value of the body of the Annotation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>bodyValue</code> for an Annotation, and the value <em title="MUST" class="rfc2119">MUST</em> conform to the requirements below.  If the <code>bodyValue</code> property is present, then the <code>body</code> relationship <em title="MUST NOT" class="rfc2119">MUST NOT</em> also be present.</td></tr>
-</tbody></table>
-
-<p>
-There are several restrictions on when this form may be used and how it is to be interpreted.
-<br>The string body:
-</p><ul>
-	<li><em title="MUST" class="rfc2119">MUST</em> be a single <code>xsd:string</code> and the data type <em title="MUST NOT" class="rfc2119">MUST NOT</em> be expressed in the serialization.</li>
-  <li><em title="MUST NOT" class="rfc2119">MUST NOT</em> have a language associated with it.</li>
-  <li><em title="MUST" class="rfc2119">MUST</em> be interpreted as if it were the value of the <code>value</code> property of a Textual Body.</li>
-	<li><em title="MUST" class="rfc2119">MUST</em> be interpreted as if the Textual Body resource had a <code>format</code> property with the value <code>text/plain</code>.</li>
-  <li><em title="MUST" class="rfc2119">MUST</em> be interpreted as if the Textual Body resource had a <a href="#motivation-and-purpose"><code>purpose</code> property</a> with the value of <code>commenting</code>.</li>
-	<li><em title="MUST NOT" class="rfc2119">MUST NOT</em> have the value of other properties of the Textual Body inferred from similar properties on the Annotation resource.</li>
-</ul>
-<p></p>
-
-<p>If any of the interpretations above are not correct, then the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a> <em title="MUST" class="rfc2119">MUST</em> be used instead.</p>
-
-<div class="note"><div id="h-note3" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">Systems <em title="MAY" class="rfc2119">MAY</em> rewrite Annotations to instead use the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a>, rather than maintaining the <code>bodyValue</code> form.</div></div>
-
-<h4 id="example-5">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: String Body</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno6"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"bodyValue"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Comment text"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/target1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-Which is equivalent to:
-
-<div class="example"><div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: Equivalent Textual Body</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno7"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Comment text"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"text/plain"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"purpose"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"commenting"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/target1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-</section>
-
-<section property="bibo:hasPart" resource="#cardinality-of-bodies-and-targets" typeof="bibo:Chapter" id="cardinality-of-bodies-and-targets">
-<h4 resource="#h-cardinality-of-bodies-and-targets" id="h-cardinality-of-bodies-and-targets"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.6 </span>Cardinality of Bodies and Targets</span></h4>
-
-<p>Some Annotations may not have a Body at all, such as a simple highlight or bookmark without any accompanying text.  It is also possible for an Annotation to have multiple Bodies and/or Targets.  In this case, each Body is considered to be equally related to each Target individually, rather than to the set of all of the Targets.</p>
-
-<p><b>Example Use Case:</b> Gretchen highlights a particular region of her ebook in green and, knowing what such a highlight means, she does not give a comment.  Her client associates a stylesheet with the Annotation, and does not create a body at all.</p>
-
-<p><b>Example Use Case:</b> Hannah associates a tag and a description with two images using a single annotation.</p>
-
-<h4 id="model-6">Model</h4>
-
-<p>The <code>body</code> relationship is omitted when there is no body for the Annotation.</p>
-<p>The <code>body</code> and/or <code>target</code> relationships of the Annotation may be arrays rather than a single object. The values may be either strings containing the IRI of the resource or objects.</p>
-
-<h4 id="example-6">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: Annotations without a Body</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno8"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/ebook1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<div class="example"><div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: Multiple Bodies or Targets</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno9"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    </span><span class="str">"http://example.org/description1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"tag1"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">],</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    </span><span class="str">"http://example.org/image1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"http://example.org/image2"</span><span class="pln">
-  </span><span class="pun">]</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#choice-of-bodies-and-targets" typeof="bibo:Chapter" id="choice-of-bodies-and-targets">
-  <h4 resource="#h-choice-of-bodies-and-targets" id="h-choice-of-bodies-and-targets"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.7 </span>Choice of Bodies and Targets </span></h4>
-
-  <p>A Choice has an ordered list of resources from which an application should select only one to process or display. The order is given from the most preferable to least preferable, according to the Annotation's creator or publisher.</p>
-
-<p><b>Example Use Case:</b> Irina writes up her discussion of a particular website in both French and English.  As the two posts are equivalent, there is no need to display both, and instead she wants French speakers to see the French comment, and everyone else to see the English version.  Her client creates as Choice with the English comment listed first.</p>
-
-<h4 id="model-7">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>Choice</td><td>Class</td><td>A construction that conveys to a consuming application that it should select one of the listed resources to display to the user, and not render all of them.</td></tr>
-<tr><td>items</td><td>Relationship</td><td>A list of resources to choose from, with the default option listed first.</td></tr>
-</tbody></table>
-
-<div class="note"><div id="h-note4" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">Clients <em title="MAY" class="rfc2119">MAY</em> use any algorithm to determine which resource to choose, and <em title="SHOULD" class="rfc2119">SHOULD</em> make use of the information present to do so automatically, but <em title="MAY" class="rfc2119">MAY</em> present a list and require the user to make the decision.</div></div>
-
-<h4 id="example-7">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 10</span><span style="text-transform: none">: Choice</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno10"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Choice"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-      </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"en"</span><span class="pln">
-      </span><span class="pun">},</span><span class="pln">
-      </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note2"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"fr"</span><span class="pln">
-      </span><span class="pun">}</span><span class="pln">
-    </span><span class="pun">]</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/website1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#sets-of-bodies-and-targets" typeof="bibo:Chapter" id="sets-of-bodies-and-targets">
-<h4 resource="#h-sets-of-bodies-and-targets" id="h-sets-of-bodies-and-targets"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.8 </span>Sets of Bodies and Targets</span></h4>
-
-While it is possible to annotate multiple targets, the meaning of that annotation is that each body applies independently to each of the targets.  This might not be the intent of the annotator, such as when all of the targets are required for the annotation to be correctly understood.  In order to allow annotators to capture these requirements, a new resource similar to Choice is used, either Composite (unordered) or List (ordered).
-
-<p><b>Example Use Case:</b> Jane comments on a set of web pages as, together, providing evidence towards her research hypothesis. Her client creates a Composite, as there is no inherent order to the set of web pages.</p>
-
-<p><b>Example Use Case:</b> Kelly tags a list of pages within a book as being important. As the pages have an order in the book, her client creates a List to maintain that order.</p>
-
-<p><b>Example Use Case:</b> Lynda annotates a set of images to classify them as portraits.  As the classification applies to each image independently, her client creates a Independents resource to group them.</p>
-
-<h4 id="model-8">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>Composite</td><td>Class</td><td>A set of resources, all of which are required for the Annotation to be correctly interpreted.</td></tr>
-<tr><td>List</td><td>Class</td><td>An ordered list of resources, all of which are required in order for the Annotation to be correctly interpreted.</td></tr>
-<tr><td>Independents</td><td>Class</td><td>A set of resources, each of which is being annotated separately with the same interpretation as having multiple bodies or targets directly associated with the Annotation. </td></tr>
-<tr><td>items</td><td>Relationship</td><td>The list of resources in the <code>Composite</code>, <code>List</code>, or <code>Independents</code>.</td></tr>
-</tbody></table>
-
-<div class="warning"><div class="warning-title marker"><span>Warning</span></div><div class="">These classes are marked At-Risk, pending implementation experience.</div></div>
-
-<h4 id="example-8">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 11</span><span style="text-transform: none">: Composite</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno11"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"commenting"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"These pages together provide evidence of the conspiracy"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Composite"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-      </span><span class="str">"http://example.com/page1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"http://example.org/page6"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"http://example.net/page4"</span><span class="pln">
-    </span><span class="pun">]</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<div class="example"><div class="example-title marker"><span>Example 12</span><span style="text-transform: none">: List</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno12"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"tagging"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"important"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"List"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-      </span><span class="str">"http://example.com/book/page1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"http://example.com/book/page2"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"http://example.com/book/page3"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"http://example.com/book/page4"</span><span class="pln">
-    </span><span class="pun">]</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<div class="example"><div class="example-title marker"><span>Example 13</span><span style="text-transform: none">: Independents</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno13"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"classifying"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/vocab/art/portrait"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Independents"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-      </span><span class="str">"http://example.com/image1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"http://example.net/image2"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"http://example.com/image4"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"http://example.org/image9"</span><span class="pln">
-    </span><span class="pun">]</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-
-</section>
-
-</section>  <!-- Bodies and Targets -->
-
-<section property="bibo:hasPart" resource="#other-properties" typeof="bibo:Chapter" id="other-properties">
-
-<h3 resource="#h-other-properties" id="h-other-properties"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3 </span>Other Properties</span></h3>
-
-It is often important to have information about the context in which the Annotation and any External Web Resources were created, modified and used.  In particular,
-
-<ul>
-  <li>When was the resource created, modified or generated</li>
-  <li>Who created, modified or generated the serialized form of the Annotation or other resource, and who is it intended for</li>
-  <li>Why was the resource included in the annotation, or the annotation created</li>
-  <li>What other identities the resource has</li>
-  <li>How can the resource be used, according to its rights and licensing</li>
-</ul>
-
-<div class="note"><div id="h-note5" role="heading" aria-level="4" class="note-title marker"><span>Note</span></div><div class="">
-Beyond the features described in this section, other properties <em title="MAY" class="rfc2119">MAY</em> be added features of the Annotation or any resource in the model.  Please see the Extension section of [<cite><a href="#bib-annotation-vocab" class="bibref">annotation-vocab</a></cite>] for more information about how to do this.</div></div>
-
-<section property="bibo:hasPart" resource="#lifecycle-information" typeof="bibo:Chapter" id="lifecycle-information">
-<h4 resource="#h-lifecycle-information" id="h-lifecycle-information"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.1 </span>Lifecycle Information</span></h4>
-
-<p>
-  The person, organization or machine responsible for the Annotation or referenced resource deserves credit for their contribution, and the time at which those resources are created is useful for display ordering and filtering out old, potentially irrelevant content. The creator of the Annotation is also useful for determining the trustworthiness of the Annotation. The software used to create and serialize the Annotation, along with when that activity occurred, is useful for both advertising and debugging issues.
-</p>
-
-<p><b>Example Use Case:</b> Megan writes a review of a restaurant online, and wishes to be associated with that review so that her friends know that it was her review and can trust it.  Her client adds her account's identity, and its own identity, to the Annotation and the appropriate timestamps for when the resources were created.</p>
-
-<h4 id="model-9">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-
-<tr><td>creator</td><td>Relationship</td><td>The agent responsible for creating the Annotation, Body or Target.  This may be either a human, an organization or a software agent.
-<br>There <em title="SHOULD" class="rfc2119">SHOULD</em> be exactly 1 <code>creator</code> relationship per resource, but <em title="MAY" class="rfc2119">MAY</em> be 0 or more than 1, as the resource's creator may wish to remain anonymous, or multiple agents may have worked together on it.</td></tr>
-<tr><td>created</td><td>Property</td><td>The time at which the Annotation, Body or Target was created.
-<br>There <em title="SHOULD" class="rfc2119">SHOULD</em> be exactly 1 <code>created</code> property per resource, and <em title="MUST NOT" class="rfc2119">MUST NOT</em> be more than 1.
-The datetime <em title="MUST" class="rfc2119">MUST</em> be a <a href="http://www.w3.org/TR/xmlschema-2/#dateTime">xsd:dateTime</a> with the UTC timezone expressed as "Z".</td></tr>
-<tr><td>generator</td><td>Relationship</td><td>The agent responsible for generating the serialization of the Annotation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>generator</code> relationships per Annotation</td></tr>
-<tr><td>generated</td><td>Property</td><td>The time at which the Annotation serialization was generated.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>generated</code> property per Annotation, and <em title="MUST NOT" class="rfc2119">MUST NOT</em> be more than 1.
-The datetime <em title="MUST" class="rfc2119">MUST</em> be a <a href="http://www.w3.org/TR/xmlschema-2/#dateTime">xsd:dateTime</a> with the UTC timezone expressed as "Z".</td></tr>
-<tr><td>modified</td><td>Property</td><td>The time at which the Annotation, Body or Target was modified, after creation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>modified</code> property per resource, and <em title="MUST NOT" class="rfc2119">MUST NOT</em> be more than 1.
-The datetime <em title="MUST" class="rfc2119">MUST</em> be a <a href="http://www.w3.org/TR/xmlschema-2/#dateTime">xsd:dateTime</a> with the UTC timezone expressed as "Z".</td></tr>
-</tbody></table>
-
-
-<h4 id="example-9">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 14</span><span style="text-transform: none">: Lifecycle Information</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno14"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-01-28T12:00:00Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"modified"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-01-29T09:00:00Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"generated"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-02-04T12:00:00Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/review1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/user2"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2014-06-02T17:00:00Z"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/restaurant1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#agents" typeof="bibo:Chapter" id="agents">
-<h4 resource="#h-agents" id="h-agents"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.2 </span>Agents</span></h4>
-
-<p>
-More information about the agents involved in the creation of an Annotation is normally required beyond an IRI that identifies them.  This includes whether they are an individual, a group or a piece of software and properties such as real name, account name, and email address.
-</p>
-
-<p><b>Example Use Case:</b> Noelle wants to submit an Annotation to a system that does not manage her identity, and would like a pseudonym to be displayed.  Her client adds this information to the Annotation to send to the service.</p>
-
-<h4 id="model-10">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>id</td><td>Property</td><td>The IRI that identifies the agent
-<br>An Agent <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 IRI that identifies it, and <em title="MUST NOT" class="rfc2119">MUST NOT</em> have more than 1.</td></tr>
-<tr><td>type</td><td>Relationship</td><td>The type of the Agent.
-  <br>An Agent <em title="SHOULD" class="rfc2119">SHOULD</em> have 1 or more classes, from those listed below.</td></tr>
-<tr><td>Person</td><td>Class</td><td>The class for a human agent</td></tr>
-<tr><td>Organization</td><td>Class</td><td>The class for an organization, as opposed to an individual.</td></tr>
-<tr><td>Software</td><td>Class</td><td>The class for a software agent, such as a user's client or a machine learning system that creates Annotations.</td></tr>
-<tr><td>name</td><td>Property</td><td>The name of the agent.
-<br>Each agent <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 <code>name</code> property, and <em title="MAY" class="rfc2119">MAY</em> have 0 or more.</td></tr>
-<tr><td>account</td><td>Property</td><td>The account name of the agent.
-<br>Each agent <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 <code>account</code> property, and <em title="MAY" class="rfc2119">MAY</em> have 0.</td></tr>
-<tr><td>email</td><td>Relationship</td><td>The email address associated with the agent, using the mailto: IRI scheme [<cite><a href="#bib-rfc6086" class="bibref">rfc6086</a></cite>].
-<br>Each agent <em title="MAY" class="rfc2119">MAY</em> have 1 or more <code>email</code> addresses</td></tr>
-<tr><td>email_sha1</td><td>Property</td><td>The text representation of the result of applying the sha1 algorithm to the email IRI of the agent, including the 'mailto:' prefix and no whitespace.  This allows the mail address to be used as an identifier without publishing the address publicly.<br>
-Each agent <em title="MAY" class="rfc2119">MAY</em> have 1 or more values in the <code>email_sha1</code> property.</td></tr>
-<tr><td>homepage</td><td>Relationship</td><td>The home page for the agent.<br>Each agent <em title="MAY" class="rfc2119">MAY</em> have 1 or more home pages.</td></tr>
-
-</tbody></table>
-
-<h4 id="example-10">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 15</span><span style="text-transform: none">: Agents</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno15"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"My Pseudonym"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"pseudo"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"email_sha1"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"58bad08927902ff9307b621c54716dcc5083e339"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SoftwareAgent"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Code v2.1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"homepage"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1/homepage1"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/review1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/restaurant1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#intended-audience" typeof="bibo:Chapter" id="intended-audience">
-<h4 resource="#h-intended-audience" id="h-intended-audience"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.3 </span>Intended Audience</span></h4>
-
-<p>Beyond the agents that are associated with the creation and management of the Annotation and other resources, it is also useful to know the audience or class of consuming agent that the resource is intended for.  This allows for roles (such as teacher versus student) or properties of the class (such as a suggested age range). </p>
-
-<p><b>Example Use Case:</b> Ophelia writes some notes about using a particular textbook to teach a class.  She adds that the intended audience of the Annotation is teachers (who are using the textbook), to distinguish from other Annotations that might have an audience of the students (who are also using the textbook, but to learn from).</p>
-
-<h4 id="model-11">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>id</td><td>Property</td><td>The IRI that identifies the Audience.
-  <br>There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 IRI given that identifies the Audience.</td></tr>
-<tr><td>type</td><td>Relationship</td><td>The type of the Audience, from the schema.org class structure.<br>The Audience <em title="SHOULD" class="rfc2119">SHOULD</em> have 1 or more <code>type</code>s and they <code><em title="SHOULD" class="rfc2119">SHOULD</em></code> come from the schema.org class structure.</td></tr>
-<tr><td>audience</td><td>Relationship</td><td>The relationship between an Annotation and its intended Audience.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more Audiences for each Annotation.</td></tr>
-</tbody></table>
-
-<p>Further properties that describe the audience are used from <a href="http://schema.org/Audience">schema.org's Audience</a> classes.  The properties and class names <em title="MUST" class="rfc2119">MUST</em> be prefixed in the JSON with <code>schema:</code> to ensure that they are uniquely distinguished from any other properties or classes.</p>
-
-<p>
-The use of <code>audience</code> does not imply nor enable any access restriction to prevent the annotation from being seen.  Systems <em title="SHOULD" class="rfc2119">SHOULD</em> use the information for filtering the display of Annotations based on their knowledge of the user, and not assume that the Annotation or other resources will require authentication and authorization.
-</p>
-
-<h4 id="example-11">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 16</span><span style="text-transform: none">: Audience</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno16"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"audience"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.edu/roles/teacher"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"schema:EducationalAudience"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"schema:educationalRole"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"teacher"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/classnotes1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/textbook1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#motivation-and-purpose" typeof="bibo:Chapter" id="motivation-and-purpose">
-<h4 resource="#h-motivation-and-purpose" id="h-motivation-and-purpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.4 </span>Motivation and Purpose</span></h4>
-
-<p>In many cases it is important to understand the reasons why the Annotation was created, or why the Textual Body was included in the Annotation, not just the times and agents involved.  These reasons are provided by declaring the motivation for the Annotation's creation or the purpose for the inclusion of the Body in the Annotation; the "why" rather than the "who" and "when" described in the previous sections.</p>
-
-<p><b>Example Use Case:</b> Petra annotates a resource intending to bookmark it for future reference, and provides a description and a tag to make it easier to find again. Her client adds the right motivations to the Annotation and the Body resources to capture this.</p>
-
-<h4 id="model-12">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>motivation</td><td>Relationship</td><td>The relationship between an Annotation and a Motivation.
-<br>There <em title="SHOULD" class="rfc2119">SHOULD</em> be exactly 1 <code>motivation</code> for each Annotation, and <em title="MAY" class="rfc2119">MAY</em> be 0 or more than 1.</td></tr>
-<tr><td>purpose</td><td>Relationship</td><td>The reason for the inclusion of the Textual Body within the Annotation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>purpose</code>s associated with a <code>TextualBody</code>.</td></tr>
-
-<tr><td>Motivation</td><td>Class</td><td>The Motivation for an Annotation is a reason for its creation, and might include things like Replying to another annotation, Commenting on a resource, or Linking to a related resource. </td></tr>
-<tr><th colspan="3"><strong>Motivations</strong></th></tr>
-<tr><td>bookmarking</td><td>Instance </td><td> The motivation for when the user intends to create a bookmark to the Target or part thereof. For example an Annotation that bookmarks the point in a text where the reader finished reading.</td></tr>
-<tr><td>classifying</td><td>Instance </td><td> The motivation for when the user intends to that classify the Target as something. For example to classify an image as a portrait.</td></tr>
-<tr><td>commenting</td><td>Instance </td><td> The motivation for when the user intends to comment about the Target. For example to provide a commentary about a particular PDF document.</td></tr>
-<tr><td>describing</td><td>Instance </td><td> The motivation for when the user intends to describe the Target, as opposed to a comment about them.  For example describing the above PDF's contents, rather than commenting on their accuracy.</td></tr>
-<tr><td>editing</td><td>Instance </td><td> The motivation for when the user intends to request a change or edit to the Target resource. For example an Annotation that requests a typo to be corrected. </td></tr>
-<tr><td>highlighting</td><td>Instance </td><td> The motivation for when the user intends to highlight the Target resource or segment of it.  For example to draw attention to the selected text that the annotator disagrees with.</td></tr>
-<tr><td>identifying</td><td>Instance</td><td>The motivation for when the user intends to  assign an identity to the Target.  For example to associate the IRI that identifies a city with a mention of the city in a web page.</td></tr>
-<tr><td>linking</td><td>Instance</td><td>The motivation for when the user intends to link to a resource related to the Target.</td></tr>
-<tr><td>moderating</td><td>Instance </td><td> The motivation for when the user intends to assign some value or quality to the Target. For example annotating an Annotation to moderate it up in a trust network or threaded discussion.</td></tr>
-<tr><td>questioning</td><td>Instance </td><td> The motivation for when the user intends to ask a question about the Target. For example to ask for assistance with a particular section of text, or question its veracity.</td></tr>
-<tr><td>replying</td><td>Instance </td> <td> The motivation for when the user intends to reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above.</td></tr>
-<tr><td>reviewing</td><td>Instance</td><td> The motivation for when the user intends to review the Target in some assessing fashion, rather than simply make a comment about it. For example to write a review of a Book.</td></tr>
-<tr><td>tagging</td><td>Instance </td><td> The motivation for when the user intends to associate a tag with the Target.</td></tr>
-
-</tbody></table>
-
-<div class="note"><div id="h-note6" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">
-For more information about how Motivations can be inter-related and new Motivations created, please see the Annotation Vocabulary document [<cite><a href="#bib-annotation-vocab" class="bibref">annotation-vocab</a></cite>].
-</div></div>
-
-<h4 id="example-12">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 17</span><span style="text-transform: none">: Motivation and Purpose</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno17"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"bookmarking"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"readme"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"purpose"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"tagging"</span><span class="pln">
-    </span><span class="pun">},</span><span class="pln">
-    </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"A good description of the topic that bears further investigation"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"purpose"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">],</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/page1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#rights-information" typeof="bibo:Chapter" id="rights-information">
-<h4 resource="#h-rights-information" id="h-rights-information"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.5 </span>Rights Information</span></h4>
-
-<p>It is common practice to associate a licence or rights statement with a resource, in order to describe the conditions under which it may be used.  This allows the user to make appropriate use of the resource, as well as allowing some automated systems to confirm that the usage is permitted.</p>
-
-<p><b>Example Use Case:</b> Qitara writes a review of a product and wishes to be known as the author of the review, however does not mind how the Annotation that relates the review and the product together is used.  She asserts these two separate rights statements with the Annotation and Body individually.</p>
-
-<h4 id="model-13">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>rights</td><td>Relationship</td><td>The relationship between an Annotation, Body or Target and a web resource that contains the rights statement or license under which the resource may be used.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be at exactly 0 or more <code>rights</code> statements or licenses linked from each resource, and the value <em title="MUST" class="rfc2119">MUST</em> be an IRI.</td></tr>
-
-</tbody></table>
-
-<h4 id="example-13">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 18</span><span style="text-transform: none">: Rights</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno18"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/review1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"rights"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://creativecommons.org/licenses/by/4.0/"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/product1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#other-identities" typeof="bibo:Chapter" id="other-identities">
-<h4 resource="#h-other-identities" id="h-other-identities"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.6 </span>Other Identities</span></h4>
-
-<p>In a massively distributed system such as the Web, information is often copied.  In order to track the provenance of the Annotation and other related resources, it is possible to record additional IRIs that also identify the resource.  These may be dereferencable "permalinks", identities assigned by a client offline without any knowledge of the web, or simply the location where the current harvesting system discovered the resource.</p>
-
-<p><b>Example Use Case:</b> Ramona creates an Annotation and sends it to multiple systems to maintain, one personal and one public.  She wants to ensure that the copies can be aligned, and so she sets a UUID as the canonical IRI, allowing the service to assign an HTTP IRI for it.  A subsequent system then harvests the public copy, maintaining the canonical UUID and moves the assigned HTTP IRI to <code>via</code>, replacing the <code>id</code> field with its own IRI. </p>
-
-<h4 id="model-14">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>canonical</td><td>Relationship</td><td>The relationship between an Annotation, Body or Target and the IRI that <em title="SHOULD" class="rfc2119">SHOULD</em> be used to track its identity, regardless of where it is made accessible.  If this property is set, then systems <em title="MUST NOT" class="rfc2119">MUST NOT</em> change or delete it.  Systems <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> assign a canonical IRI without prior agreement if one is not present, as the Annotation could already have a canonical IRI elsewhere.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>canonical</code> IRI for each resource.</td></tr>
-<tr><td>via</td><td>Relationship</td><td>The relationship between an Annotation, Body or Target and the IRI of where that resource was obtained from by the system that is making it available.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more IRIs provided in <code>via</code> for each resource.</td></tr>
-</tbody></table>
-
-<h4 id="example-14">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 19</span><span style="text-transform: none">: Other Identities</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno19"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"canonical"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"via"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://other.example.org/anno1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/review1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"rights"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://creativecommons.org/licenses/by/4.0/"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/product1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-
-</section>
-
-</section> <!-- /Metadata -->
- <!-- /Annotation -->
-
-<section property="bibo:hasPart" resource="#specific-resources" typeof="bibo:Chapter" id="specific-resources">
-<!--OddPage--><h2 resource="#h-specific-resources" id="h-specific-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Specific Resources</span></h2>
-
-<p>
-While it is possible using only the constructions described above to create Annotations that reference parts of resources by using IRIs with a fragment component, there are many situations when this is not sufficient.  For example, even a simple circular region of an image, or a diagonal line across it, are not possible.  Selecting an arbitrary span of text in an HTML page, perhaps the simplest annotation concept, is also not supported by fragments.  Furthermore, there are non-segment use cases that require a client to retrieve a specific state or representation of the resource, to style it in a particular way, to associate a role with the resource that is specific to the Annotation's use of it, or for the Annotation to only apply when the resource is used in a particular context.
-</p>
-
-<p>The Web Annotation Data Model uses a new type of resource to capture these Annotation-specific requirements: a SpecificResource.  The SpecificResource is used in between the Annotation and the Body or Target, as appropriate, to capture additional information about how it is used in the Annotation. The descriptions are typically referenced from the SpecificResource as separate entities and can be of various types to capture the different requirements.  For example, if the Target of the Annotation is a circular region of an image, then the SpecificResource is the circular region, it is described by a Selector, and is also associated with the source Image resource.</p>
-
-<p>Specific Resources and Specifiers <em title="MAY" class="rfc2119">MAY</em> be External Web Resources with their own IRIs, such as in the example for the <a href="#selectors">Selector</a> construction, however it is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> that they be included in the Annotation's representation to avoid requiring unnecessary network interactions to retrieve all of the information needed to process the Annotation.</p>
-
-<p>
-The types of additional specificity that are defined by this document:
-
-</p><ul>
-  <li><a href="#purpose-for-external-web-resources">Purpose:</a> Describe the purpose of including the source resource in the Annotation</li>
-  <li><a href="#selectors">Selector:</a> Describe the desired segment of the source resource for the Annotation</li>
-  <li><a href="#states">State:</a> Describe the desired representation of the source resource for the Annotation</li>
-  <li><a href="#styles">Style:</a> Describe the style in which the source resource should be presented for the Annotation</li>
-  <li><a href="#rendering-software">Rendering:</a> Describe the system used by the client for rendering the resource when the annotation was created</li>
-  <li><a href="#scope-of-a-resource">Scope:</a> Describe the scope in which the source resource applies for the Annotation</li>
-</ul>
-<p></p>
-
-<h2 id="model-15">Model</h2>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>id</td><td>Property</td><td>The identity of the Specific Resource
-<br>A Specific Resource <em title="MAY" class="rfc2119">MAY</em> have exactly 1 IRI that identifies it.</td></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Specific Resource
-  <br>The Specific Resource <em title="SHOULD" class="rfc2119">SHOULD</em> have the <code>SpecificResource</code> class.</td></tr>
-<tr><td>SpecificResource</td><td>Class</td><td>The class for Specific Resources
-<br>The <code>SpecificResource</code> class <em title="SHOULD" class="rfc2119">SHOULD</em> be associated with a Specific Resource to be clear as to its role as a more specific region or state of another resource.</td></tr>
-<tr><td>source</td><td>Relationship</td><td>The relationship between a Specific Resource and the resource that it is a more specific representation of.
-<br>There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>source</code> relationship associated with a Specific Resource.  The source resource <em title="MAY" class="rfc2119">MAY</em> be described in detail as in the core data model or be just the resource's IRI.
-</td></tr>
-</tbody></table>
-
-<p>The same Specific Resource and Specifier classes are used for both Target and Body. The examples in this section only use one of these, however the same model applies for both.</p>
-
-<section property="bibo:hasPart" resource="#purpose-for-external-web-resources" typeof="bibo:Chapter" id="purpose-for-external-web-resources">
-  <h3 resource="#h-purpose-for-external-web-resources" id="h-purpose-for-external-web-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Purpose for External Web Resources</span></h3>
-
-<p>As well as Textual Bodies, External Web Resources may also be given a Motivation as to their inclusion within the Annotation.  This is done using the Specific Resource pattern, as the purpose specifies the way in which the resource is used in the context of the Annotation in the same way as a Selector describes the segment or a State describes the representation.</p>
-
-<p><b>Example Use Case:</b> Sally wants to tag a photo with an identifier for a city, rather than just type the city's name which could be ambiguous. Her client uses a well-known IRI for the city having done a search for it, and creates a Specific Resource to manage that purpose assignment.</p>
-
-
-<h3 id="model-16">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>purpose</td><td>Relationship</td><td>The reason for including the Web Resource in the Annotation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more Motivations associated with the SpecificResource using <code>purpose</code>.</td></tr>
-</tbody></table>
-
-
-<h3 id="example-15">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 20</span><span style="text-transform: none">: Resource with Purpose</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno20"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"purpose"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"tagging"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/city1"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/photo1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Image"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#selectors" typeof="bibo:Chapter" id="selectors">
-<h3 resource="#h-selectors" id="h-selectors"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Selectors</span></h3>
-
-<p>Many Annotations refer to part of a resource, rather than all of it, as the Target. We call that part of the resource a Segment (of Interest). A Selector is used to describe how to determine the Segment from within the Source resource.  The nature of the Selector will be dependent on the type of resource, as the methods to describe Segments from various media-types will differ.</p>
-
-<p><b>Example Use Case:</b> Teynika wants to associate a selection of text in a web page, with a slice of a dataset.  She selects both using her client, and creates the Annotation with a SpecificResource that has a Selector for each of the Body and the Target.</p>
-
-<h3 id="model-17">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>selector</td><td>Relationship</td><td>The relationship between a Specific Resource and a Selector.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>selector</code> relationships associated with a Specific Resource.
-</td></tr>
-</tbody></table>
-
-<h3 id="example-16">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 21</span><span style="text-transform: none">: Selectors</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno21"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/paraselector1"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/dataset1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/dataselector1"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<section property="bibo:hasPart" resource="#fragment-selector" typeof="bibo:Chapter" id="fragment-selector">
-<h4 resource="#h-fragment-selector" id="h-fragment-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.1 </span>Fragment Selector</span></h4>
-
-<p>As the most well understood mechanism for selecting a Segment is to use the fragment part of an IRI defined by the representation's media type, it is useful to allow this as a description mechanism via a Selector.  This allows existing and future fragment specifications to be used with Specific Resources in a consistent way.  To be clear about which fragment type is being used, the Selector may refer to the specification that defines it.</p>
-
-<p><b>Example Use Case:</b> Ulrika wants to associate part of a video as the description of an image.  She selects the time range within the video and clicks that it is describing the target.  Her client then creates the Annotation using a SpecificResource with a FragmentSelector and the <code>describing</code> Motivation. </p>
-
-
-<h4 id="model-18">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Selector.<br>FragmentSelectors <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>FragmentSelector</code>.</td></tr>
-<tr><td>FragmentSelector</td><td>Class</td><td>A resource which describes the Segment through the use of the fragment component of an IRI.</td></tr>
-<tr><td>value</td><td>Property</td><td>The contents of the fragment component of an IRI that describes the Segment.<br>
-The FragmentSelector <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>value</code> property.</td></tr>
-<tr><td>conformsTo</td><td>Relationship</td><td>The relationship between the FragmentSelector and the specification that defines the syntax of the IRI fragment in the <code>value</code> property.
-  <br>The Fragment Selector <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 <code>conformsTo</code> link to the specification that defines the syntax of the fragment and <em title="MUST NOT" class="rfc2119">MUST NOT</em> have more than 1.</td></tr>
-</tbody></table>
-
-<p>It is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> to use <code>FragmentSelector</code> as a consistent method compatible with other means of describing SpecificResources, rather than using the IRI with a fragment directly. Consuming applications <em title="SHOULD" class="rfc2119">SHOULD</em> be aware of both.</p>
-
-<p class="informative">
-The following IRIs are some of the specifications that define the semantics of fragments, and hence may be used with the <code>conformsTo</code> relationship.  Other IRIs <em title="MAY" class="rfc2119">MAY</em> also be used.
-</p><table class="model">
-<tbody><tr><th>Name</th><th>Fragment Specification</th><th>Description</th></tr>
-<tr><td>HTML</td><td>http://tools.ietf.org/rfc/rfc3236</td><td>[<cite><a href="#bib-rfc3236" class="bibref">rfc3236</a></cite>] Example: <code>namedSection</code> </td></tr>
-<tr><td>PDF</td><td>http://tools.ietf.org/rfc/rfc3778</td><td>[<cite><a href="#bib-rfc3778" class="bibref">rfc3778</a></cite>] Example: <code>page=10&amp;viewrect=50,50,640,480</code></td></tr>
-<tr><td>Plain Text</td><td>http://tools.ietf.org/rfc/rfc5147</td><td>[<cite><a href="#bib-rfc5147" class="bibref">rfc5147</a></cite>] Example: <code>char=0,10</code></td></tr>
-<tr><td>XML</td><td>http://tools.ietf.org/rfc/rfc3023</td><td>[<cite><a href="#bib-rfc3023" class="bibref">rfc3023</a></cite>] Example: <code>xpointer(/a/b/c)</code></td></tr>
-<tr><td>RDF/XML</td><td>http://tools.ietf.org/rfc/rfc3870</td><td>[<cite><a href="#bib-rfc3870" class="bibref">rfc3870</a></cite>] Example: <code>namedResource</code></td></tr>
-<tr><td>CSV</td><td>http://tools.ietf.org/rfc/rfc7111</td><td>[<cite><a href="#bib-rfc7111" class="bibref">rfc7111</a></cite>] Example: <code>row=5-7</code></td></tr>
-<tr><td>Media</td><td>http://www.w3.org/TR/media-frags/</td><td>[<cite><a href="#bib-media-frags" class="bibref">media-frags</a></cite>] Example: <code>xywh=50,50,640,480</code></td></tr>
-<tr><td>SVG</td><td>http://www.w3.org/TR/SVG/</td><td>[<cite><a href="#bib-SVG" class="bibref">SVG</a></cite>] Example: <code>svgView(viewBox(50,50,640,480))</code></td></tr>
-<tr><td>EPUB3</td><td>http://www.idpf.org/epub/linking/cfi/epub-cfi.html</td><td>[<cite><a href="#bib-cfi" class="bibref">cfi</a></cite>] Example: <code>epubcfi(/6/4[chap01ref]!/4[body01]/10[para05]/3:10)</code></td></tr>
-</tbody></table>
-<p></p>
-
-<div class="note"><div id="h-note7" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">
-The IRI that uses the fragment may be reconstructed by concatenating the <code>source</code>, a <code>#</code>, and the <code>value</code>. For example, the IRI from the example below would be <code>http://example.org/video1#t=30,60</code>.
-</div></div>
-
-<h4 id="example-17">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 22</span><span style="text-transform: none">: Fragment Selector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno22"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/video1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"role"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"FragmentSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"conformsTo"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/TR/media-frags/"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"t=30,60"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-
-<section property="bibo:hasPart" resource="#css-selector" typeof="bibo:Chapter" id="css-selector">
-  <h4 resource="#h-css-selector" id="h-css-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.2 </span>CSS Selector</span></h4>
-
-<p>One of the most common ways to select elements in the HTML Document Object Model is to use CSS Selectors [<cite><a href="#bib-CSS3-selectors" class="bibref">CSS3-selectors</a></cite>].  CSS Selectors allow for a wide variety of well supported ways to describe the path to an element in a web page, and thus cover many of the basic use cases for Web Annotation.  Results are not defined for when a CSS Selector is applied to a representation that does not conform to the Document Object Model.</p>
-
-<p>Note that CSS may also be used for <a href="#styles">styling</a> a resource within an annotation. This class is specifically to re-use the CSS Selector mechanism to select a segment of a resource that conforms to the Document Object Model.</p>
-
-<p><b>Example Use Case:</b> Valeria selects a paragraph in a web page that she wishes to write a note about.  Her client calculates a CSS path that cleanly identifies that element and adds it to the annotation.</p>
-
-<h4 id="model-19">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Selector.<br>CssSelectors <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>CssSelector</code>.</td></tr>
-<tr><td>CssSelector</td><td>Class</td><td>The type of the CSS Selector resource.
-  <br>CSS Selectors <em title="MUST" class="rfc2119">MUST</em> have this class associated with them.</td></tr>
-<tr><td>value</td><td>Property</td><td>The CSS selection path to the Segment.
-<br>There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>value</code> associated with a CSS Selector.</td></tr>
-</tbody></table>
-
-<div class="note"><div id="h-note8" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">
-Implementers <em title="SHOULD" class="rfc2119">SHOULD</em> use only commonly supported features of CSS that directly contribute to selection of an element or content, rather than styling or transformation, in order to maximize interoperability between systems.
-</div></div>
-
-<h4 id="example-18">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 23</span><span style="text-transform: none">: CSS Selector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno23"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1.html"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"#elemid &gt; .elemclass + p"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#xpath-selector" typeof="bibo:Chapter" id="xpath-selector">
-  <h4 resource="#h-xpath-selector" id="h-xpath-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.3 </span>XPath Selector</span></h4>
-
-<p>Another common method of selecting elements and content within a resource that supports the Document Object Model (DOM), such as documents in XML or HTML, is to use an XPath selection [<cite><a href="#bib-DOM-Level-3-XPath" class="bibref">DOM-Level-3-XPath</a></cite>].  XPath allows a great deal of flexibility when describing the path through the structure to the selected content.  Results are not defined for when an XPath Selector is applied to a representation that does not conform to the DOM.</p>
-
-<div class="note"><div id="h-note9" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">
-Implementers should note that the <a href="https://www.w3.org/TR/html5/syntax.html#optional-tags">HTML5 specification</a> allows parsers to add elements into the DOM that are considered to be missing. XPaths <em title="SHOULD" class="rfc2119">SHOULD</em> be constructed to include these elements, rather than from the element structure in the document.
-</div></div>
-
-<p><b>Example Use Case:</b> Wendy selects a span within a table in an HTML page and writes a note about the content.  To refer explicitly to this element, her client carefully constructs an XPath to identify it as the target of the Annotation.</p>
-
-<h4 id="model-20">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Selector.<br>XPath Selectors <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>XPathSelector</code>.</td></tr>
-<tr><td>XPathSelector</td><td>Class</td><td>The type of the XPath Selector resource.
-  <br>XPath Selectors <em title="MUST" class="rfc2119">MUST</em> have this class associated with them.</td></tr>
-<tr><td>value</td><td>Property</td><td>The xpath to the selected segment.
-<br>There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>value</code> associated with an XPath Selector.</td></tr>
-</tbody></table>
-
-<div class="note"><div id="h-note10" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">
-Implementers <em title="SHOULD" class="rfc2119">SHOULD</em> use only commonly supported features of XPath that directly contribute to selection of an element or content in order to maximize interoperability between systems.
-</div></div>
-
-<h4 id="example-19">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 24</span><span style="text-transform: none">: XPath Selector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno24"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1.html"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"XPathSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"/html/body/p[2]/table/tr[2]/td[3]/span"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#text-quote-selector" typeof="bibo:Chapter" id="text-quote-selector">
-<h4 resource="#h-text-quote-selector" id="h-text-quote-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.4 </span>Text Quote Selector</span></h4>
-
-<p>This Selector describes a range of text by copying it, and including some of the text immediately before (a prefix) and after (a suffix) it to distinguish between multiple copies of the same sequence of characters.
-</p>
-<p>
-For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could select "efg" by a prefix of "abcd", the match of "efg" and a suffix of "hijk".
-</p>
-
-<p><b>Example Use Case:</b> Xena selects a typo ('anotation') in a web page and adds a comment that it should be replaced with the correct spelling ('annotation').</p>
-
-<h4 id="model-21">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Selector.<br>Text Quote Selectors <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>TextQuoteSelector</code>.</td></tr>
-<tr><td>TextQuoteSelector</td><td>Class</td><td>The class for a Selector that describes a textual segment by means of quoting it, plus passages before or after it.
-<br>The TextQuoteSelector <em title="MUST" class="rfc2119">MUST</em> have this class associated with it.</td></tr>
-<tr><td>exact</td><td>Property</td><td>A copy of the text which is being selected, after normalization.
-<br>Each TextQuoteSelector <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>exact</code> property. </td></tr>
-<tr><td>prefix</td><td>Property</td><td>A snippet of text that occurs immediately before the text which is being selected.
-<br>Each TextQuoteSelector <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 <code>prefix</code> property, and <em title="MUST NOT" class="rfc2119">MUST NOT</em> have more than 1.</td></tr>
-<tr><td>suffix</td><td>Property</td><td>The snippet of text that occurs immediately after the text which is being selected.
-<br>Each TextQuoteSelector <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 <code>suffix</code> property, and <em title="MUST NOT" class="rfc2119">MUST NOT</em> have more than 1.</td></tr>
-</tbody></table>
-
-<p>The text <em title="MUST" class="rfc2119">MUST</em> be normalized before recording.  Thus HTML/XML tags should be removed, character entities should be replaced with the character that they encode, unnecessary whitespace should be normalized, character encoding should be turned into UTF-8, and so forth. The normalization routine may be performed automatically by a browser, and other applications should implement the <a href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-5DFED1F0">DOM String Comparisons</a> method. This allows the Selector to be used with different encodings and user agents and still have the same semantics and utility.
-</p>
-
-<p>When generating the Text Position Selector values, it is recommended that implementations built for an environment that supports DOM Level 3 APIs use the <code>textContent</code> property of top level, user visible Node object [<cite><a href="#bib-DOM-Level-3-Core" class="bibref">DOM-Level-3-Core</a></cite>] of the resource. This content would be located at <code>document.body.textContent</code> in an HTML5 document being accessed via a JavaScript DOM implementation.</p>
-
-<p>If, after processing the prefix, exact, and suffix, the user agent discovers multiple matching text sequences, then the selection <em title="SHOULD" class="rfc2119">SHOULD</em> be treated as matching all of the matches.</p>
-
-<div class="note"><div id="h-note11" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">If the content is under copyright or has other rights asserted on its use, then this method of selecting text is potentially dangerous. A user might select the entire text of the document to annotate, which would not be desirable to copy into the Annotation and share. For static texts with access and/or distribution restrictions, the use of the Text Position Selector is perhaps more appropriate.
-</div></div>
-
-<h4 id="example-20">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 25</span><span style="text-transform: none">: Text Quote Selector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno25"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextQuoteSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"exact"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"anotation"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"prefix"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"this is an "</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"suffix"</span><span class="pun">:</span><span class="pln"> </span><span class="str">" that has some"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#text-position-selector" typeof="bibo:Chapter" id="text-position-selector">
-<h4 resource="#h-text-position-selector" id="h-text-position-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.5 </span>Text Position Selector</span></h4>
-
-<p>
-This Selector describes a range of text by recording the start and end positions of the selection in the stream.  Position 0 would be immediately before the first character, position 1 would be immediately before the second character, and so on.  The start character is thus included in the list, but the end character is not.</p>
-<p>
-For example, if the document was "abcdefghijklmnopqrstuvwxyz", the start was 4, and the end was 7, then the selection would be "efg".
-</p>
-
-<p><b>Example Use Case:</b> Yadira writes a review of an ebook that does not allow its content to be extracted and copied.  Her client describes the selection using its start and end position in the content.</p>
-
-<h4 id="model-22">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Selector.<br>Text Position Selectors <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>TextPositionSelector</code>.</td></tr>
-<tr><td>TextPositionSelector</td><td>Class</td><td>The class for a Selector which describes a range of text based on its start and end positions.
-<br>The TextPositionSelector <em title="MUST" class="rfc2119">MUST</em> have this class associated with it.</td></tr>
-<tr><td>start</td><td>Property</td><td>The starting position of the segment of text. The first character in the full text is character position 0, and the character is included within the segment.
-<br>Each TextPositionSelector <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>start</code> property, and the value <em title="MUST" class="rfc2119">MUST</em> be a non-negative integer.</td></tr>
-<tr><td>end</td><td>Property</td><td>The end position of the segment of text. The character is not included within the segment.
-<br>Each TextPositionSelector <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>end</code> property, and the value <em title="MUST" class="rfc2119">MUST</em> be a non-negative integer.</td></tr>
-
-</tbody></table>
-
-<p>The text <em title="MUST" class="rfc2119">MUST</em> be normalized before counting the characters, in the same way as for Text Quote Selector.</p>
-
-<div class="note"><div id="h-note12" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">
-The use of this Selector does not require text to be copied from the Source document into the Annotation graph, unlike the Text Quote Selector, but is very brittle with regards to changes to the resource. Any edits or dynamically transcluded content may change the selection, and thus it is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> that a <a href="#states">State</a> be additionally used to help identify the correct representation.
-</div></div>
-
-<h4 id="example-21">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 26</span><span style="text-transform: none">: Text Position Selector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno26"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/review1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/ebook1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextPositionSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"start"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">412</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"end"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">795</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#data-position-selector" typeof="bibo:Chapter" id="data-position-selector">
-<h4 resource="#h-data-position-selector" id="h-data-position-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.6 </span>Data Position Selector</span></h4>
-
-<p>
-Similar to the Text Position Selector, the Data Position Selector uses the same properties but works at the byte in bitstream level rather than the character in text level.</p>
-
-<p><b>Example Use Case:</b> Zara writes comments about regions of online disk images for forensic purposes and describing emulation requirements.  Her client generates the start and end positions from the binary stream, rather than the more human readable display she is using.</p>
-
-
-<h4 id="model-23">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Selector.<br>Data Position Selectors <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>DataPositionSelector</code>.</td></tr>
-<tr><td>DataPositionSelector</td><td>Class</td><td>The class for a Selector which describes a range of data based on its start and end positions within the byte stream.
-<br>The DataPositionSelector <em title="MUST" class="rfc2119">MUST</em> have this class associated with it.</td></tr>
-<tr><td>start</td><td>Property</td><td>The starting position of the segment of data. The first byte is character position 0.
-<br>Each DataPositionSelector <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>start</code> property.</td></tr>
-<tr><td>end</td><td>Property</td><td>The end position of the segment of data. The last character is not included within the segment.
-<br>Each DataPositionSelector <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>end</code> property.</td></tr>
-</tbody></table>
-
-<h4 id="example-22">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 27</span><span style="text-transform: none">: Data Position Selector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno27"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/diskimg1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"DataPositionSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"start"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">4096</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"end"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">4104</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#svg-selector" typeof="bibo:Chapter" id="svg-selector">
-<h4 resource="#h-svg-selector" id="h-svg-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.7 </span>SVG Selector</span></h4>
-
-<p>An SvgSelector defines an area through the use of the Scalable Vector Graphics [<cite><a href="#bib-SVG" class="bibref">SVG</a></cite>] standard.  This allows the user to select a non-rectangular area of the content, such as a circle or polygon by describing the region using SVG.  The SVG may be either embedded within the Annotation or referenced as an External Web Resource.</p>
-
-<p>Note that the SvgSelector uses SVG to select an area of a resource. Segments of an SVG representation may also be selected using selectors, including the FragmentSelector or even an SvgSelector.</p>
-
-<p><b>Example Use Case:</b> Alexandra is tagging an old map online with a diagonal region for a historical road.  Her client creates SVG polygon to describe the region, relative to the image content.</p>
-
-<h4 id="model-24">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Selector.<br>SVG Selectors <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> include <code>SvgSelector</code>. It <em title="MUST" class="rfc2119">MUST</em> also include the <code>Content</code> class if the SVG representation is embedded within the Annotation document.</td></tr>
-<tr><td>SvgSelector</td><td>Class</td><td>The class for a Selector which defines a shape for the selected area using the SVG standard.
-<br>The Selector <em title="MUST" class="rfc2119">MUST</em> have this class associated with it and <em title="MAY" class="rfc2119">MAY</em> also have the <code>Content</code> class associated with it.
-</td></tr>
-<tr><td>value</td><td>Property</td><td>The character sequence of the SVG content.<br>
-There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>value</code> property associated with the Selector, and if so the value of the property <em title="MUST" class="rfc2119">MUST</em> be well-formed SVG XML.</td></tr>
-</tbody></table>
-
-<p>The dimensions of the SVG shape or canvas <em title="MUST" class="rfc2119">MUST</em> be relative to the dimensions of the Source resource, such that scaling the shape's size to the full size of the image correctly describes the desired area.</p>
-
-<div class="note"><div id="h-note13" role="heading" aria-level="5" class="note-title marker"><span>Note</span></div><div class="">
-Implementers <em title="SHOULD" class="rfc2119">SHOULD</em> use only commonly supported features of SVG that directly contribute to describing a region, rather than styling or transformation, in order to maximize interoperability between systems. It is <em title="NOT RECOMMENDED" class="rfc2119">NOT RECOMMENDED</em> to include style information within the SVG element, nor Javascript, animation, text or other non-shape oriented information. Clients <em title="SHOULD" class="rfc2119">SHOULD</em> ignore such information if present.
-</div></div>
-
-<h4 id="example-23">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 28</span><span style="text-transform: none">: SVG Selector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno28"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/road1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/map1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/svg1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SvgSelector"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<div class="example"><div class="example-title marker"><span>Example 29</span><span style="text-transform: none">: SVG Selector, embedded</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno29"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/road1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/map1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SvgSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"&lt;svg:svg&gt; ... &lt;/svg:svg&gt;"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#range-selector" typeof="bibo:Chapter" id="range-selector">
-  <h4 resource="#h-range-selector" id="h-range-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.8 </span>Range Selector</span></h4>
-
-<p>Selections made by users may be extensive and/or cross over internal boundaries in the representation, making it difficult to construct a single selector that robustly describes the correct content.  A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors.  In this way, two points can be accurately identified using the most appropriate selection mechanisms, and then linked together to form the selection.  The selection consists of everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it.</p>
-
-<p><b>Example Use Case:</b> Britney wants to comment on two adjacent cells in a table that is part of a web page.  She selects the two cells and her client constructs XPaths to the the first cell, and the cell that immediately follows the second. Her client then creates a Range Selector with the first XPath Selector as the start, and the second XPath selector as the end.</p>
-
-<h4 id="model-25">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Selector.<br>Range Selectors <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>RangeSelector</code>.</td></tr>
-<tr><td>RangeSelector</td><td>Class</td><td>The type of the Range Selector resource.
-  <br>Range Selectors <em title="MUST" class="rfc2119">MUST</em> have this class associated with them.</td></tr>
-<tr><td>startSelector</td><td>Relationship</td><td>The Selector which describes the inclusive starting point of the range.
-<br>There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>startSelector</code> associated with a Range Selector.</td></tr>
-<tr><td>endSelector</td><td>Relationship</td><td>The Selector which describes the exclusive ending point of the range.
-<br>There <em title="MUST" class="rfc2119">MUST</em> be exactly 1 <code>endSelector</code> associated with a Range Selector.  Both <code>startSelector</code> and <code>endSelector</code> <em title="SHOULD" class="rfc2119">SHOULD</em> be of the same class.</td></tr>
-</tbody></table>
-
-<h4 id="example-24">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 30</span><span style="text-transform: none">: Range Selector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno30"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1.html"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"RangeSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"startSelector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"XPathSelector"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"//table[1]/tr[1]/td[2]"</span><span class="pln">
-      </span><span class="pun">},</span><span class="pln">
-      </span><span class="str">"endSelector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"XPathSelector"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"//table[1]/tr[1]/td[4]"</span><span class="pln">
-      </span><span class="pun">}</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#refinement-of-selection" typeof="bibo:Chapter" id="refinement-of-selection">
-  <h4 resource="#h-refinement-of-selection" id="h-refinement-of-selection"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.9 </span>Refinement of Selection</span></h4>
-
-  <p>It may be easier, more reliable or more accurate to specify the segment of interest of a resource as a selection of a selection, rather than as a selection of the complete resource.  Particularly for resources that contain other resources, such as various packaging formats, this also allows decomposition of the selection mechanisms when the components do not have unique identifiers.  This is accomplished by having selectors chained together, where each refines the results of the previous one.</p>
-
-  <p><b>Example Use Case:</b> Carla selects a paragraph of text and then a short phrase within it to comment on.  Her client records the phrase as a TextQuoteSelector that further modifies a FragmentSelector used to identify the paragraph that the phrase is part of.</p>
-
-  <h4 id="model-26">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>refinedBy</td><td>Relationship</td><td>The relationship between a broader selector and the more specific selector that should be applied to the results of the first.
-  <br>A Selector <em title="MAY" class="rfc2119">MAY</em> be <code>refinedBy</code> 1 or more other Selectors.  If more than 1 is given, then they are considered to be alternatives that will result in the same selection.</td></tr>
-</tbody></table>
-
-  <h4 id="example-25">Example</h4>
-
-  <div class="example"><div class="example-title marker"><span>Example 31</span><span style="text-transform: none">: Refinement of Selection</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno31"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"FragmentSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"para5"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"refinedBy"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextQuoteSelector"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"exact"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Selected Text"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"prefix"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"text before the "</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"suffix"</span><span class="pun">:</span><span class="pln"> </span><span class="str">" and text after it"</span><span class="pln">
-      </span><span class="pun">}</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-</section> <!-- /Selectors -->
-
-<section property="bibo:hasPart" resource="#states" typeof="bibo:Chapter" id="states">
-<h3 resource="#h-states" id="h-states"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3 </span>States</span></h3>
-
-<p>A State describes the intended state of a resource as applied to the particular Annotation, and thus provides
- the information needed to retrieve the correct representation of that resource. Web resources change over time, and a State might be used to describe how to recover the intended previous version.  Web resources also have multiple formats, and a State might equally be used to describe how to retrieve that particular format.</p>
-
-<p><b>Example Use Case:</b> Devina makes a comment about a web page that changes frequently. Her client records information to allow other clients to hopefully reconstruct the original target of the annotation.</p>
-
-<h3 id="model-27">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>state</td><td>Relationship</td><td>The relationship between the SpecificResource and the State.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>state</code> relationships for each SpecificResource.</td></tr>
-</tbody></table>
-
-<p>States <em title="MUST" class="rfc2119">MUST</em> be processed before processing Selector or Style information.</p>
-
-<h3 id="example-26">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 32</span><span style="text-transform: none">: State</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno32"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/state1"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<section property="bibo:hasPart" resource="#time-state" typeof="bibo:Chapter" id="time-state">
-<h4 resource="#h-time-state" id="h-time-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3.1 </span>Time State</span></h4>
-
-<p>A Time State resource records the time at which the resource is appropriate for the Annotation, typically the time that the Annotation was created and/or a link to a persistent copy of the current version.  The timestamp for the resource could be resolved via the Memento protocol, described in RFC 7089 [<cite><a href="#bib-rfc7089" class="bibref">rfc7089</a></cite>].</p>
-
-<p><b>Example Use Case:</b> Erin makes a note about the current state of the front page of a news website, and flags that the page is likely to change often.  Her client adds in a State with the current time to describe the version of the page being annotated.</p>
-
-
-<h4 id="model-28">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the State.<br>Time States <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>TimeState</code>.</td></tr>
-<tr><td>TimeState</td><td>Class</td><td>A description of how to retrieve a representation
-of the Source resource that is temporally appropriate for the Annotation.
-<br>The State <em title="MUST" class="rfc2119">MUST</em> have this class associated with it.
-</td></tr>
-<tr><td>sourceDate</td><td>Property</td><td>The timestamp at which the Source resource should be interpreted for the Annotation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>sourceDate</code> properties per TimeState. If there is more than 1, each gives an alternative timestamp at which the Source may be interpreted. The timestamp <em title="MUST" class="rfc2119">MUST</em> be expressed in the <code>xsd:dateTime</code> format, and <em title="MUST" class="rfc2119">MUST</em> use the UTC timezone expressed as "Z". If <code>sourceDate</code> is provided, then <code>sourceDateStart</code> and <code>sourceDateEnd</code> <em title="MUST NOT" class="rfc2119">MUST NOT</em> be provided.</td></tr>
-<tr><td>sourceDateStart</td><td>Property</td><td>The timestamp that begins the interval over which the Source resource should be interpreted for the Annotation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>sourceDateStart</code> property per TimeState. The timestamp <em title="MUST" class="rfc2119">MUST</em> be expressed in the <code>xsd:dateTime</code> format, and <em title="MUST" class="rfc2119">MUST</em> use the UTC timezone expressed as "Z". If <code>sourceDateStart</code> is provided then <code>sourceDateEnd</code> <em title="MUST" class="rfc2119">MUST</em> also be provided.</td></tr>
-<tr><td>sourceDateEnd</td><td>Property</td><td>The timestamp that ends the interval over which the Source resource should be interpreted for the Annotation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be exactly 1 <code>sourceDateEnd</code> property per TimeState. The timestamp <em title="MUST" class="rfc2119">MUST</em> be expressed in the <code>xsd:dateTime</code> format, and <em title="MUST" class="rfc2119">MUST</em> use the UTC timezone expressed as "Z". If <code>sourceDateEnd</code> is provided then <code>sourceDateStart</code> <em title="MUST" class="rfc2119">MUST</em> also be provided.</td></tr>
-<tr><td>cached</td><td>Relationship</td><td>A link to a copy of the Source resource's
-representation, appropriate for the Annotation.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>cached</code> relationships per TimeState. If there is more than 1, each gives an alternative copy of the representation.
-</td></tr>
-</tbody></table>
-
-
-<h4 id="example-27">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 33</span><span style="text-transform: none">: Time State</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno33"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TimeState"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"cached"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://archive.example.org/copy1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"sourceDate"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-07-20T13:30:00Z"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#request-header-state" typeof="bibo:Chapter" id="request-header-state">
-<h4 resource="#h-request-header-state" id="h-request-header-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3.2 </span>Request Header State</span></h4>
-
-<p>As there are potentially many representations that can be delivered from a resource with a single IRI, and a
-Specific Resource may only apply to one of them, it is important to be able to record the HTTP Request headers
-that need to be sent to retrieve the correct representation.  The HttpRequestState resource maintains a copy
-of the headers to be replayed when obtaining the representation. </p>
-
-<p><b>Example Use Case:</b> Felicity retrieves a PDF representation of a web resource that can deliver HTML, PDF or plain text and then writes a description about it.  She signals that her description is only about the PDF representation.  Her client then includes a State to describe how to retrieve the target representation.</p>
-
-<h4 id="model-29">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the State.<br>Request Header States <em title="MUST" class="rfc2119">MUST</em> have a <code>type</code> and the value <em title="MUST" class="rfc2119">MUST</em> be <code>HttpRequestState</code>.</td></tr>
-<tr><td>HttpRequestState</td><td>Class</td><td>A description of how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send on the request.
-<br>The State <em title="MUST" class="rfc2119">MUST</em> have this class associated with it.</td></tr>
-<tr><td>value</td><td>Property</td><td>The HTTP request headers to send as a single, complete string.
-<br>An HttpRequestState <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>value</code> property.</td></tr>
-</tbody></table>
-
-<h4 id="example-28">Example</h4>
-
-<div class="example"><div class="example-title marker"><span>Example 34</span><span style="text-transform: none">: HTTP Request State</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno34"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/description1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/resource1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"HttpRequestState"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Accept: application/pdf"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#refinement-of-state" typeof="bibo:Chapter" id="refinement-of-state">
-  <h4 resource="#h-refinement-of-state" id="h-refinement-of-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3.3 </span>Refinement of State</span></h4>
-
-  <p>Similar to the <a href="#refinement-of-selection">refinement of selection</a>, it may be easier, more reliable or more accurate to specify the appropriate state of the resource as a hierarchy of atomic State resources.  This is particularly appropriate for representing the combination of a State that reflects an internal transformation along with the results of a State that describes an external request. This decomposition is accomplished by having the states chained together in the same way as Selectors.</p>
-
-<p>Further, given that the State(s) will likely result in a specific representation, there may be specific Selectors that are appropriate for describing the segment of the representation.  In order to accomodate this, States may also be refined by Selectors.</p> 
-
-  <p><b>Example Use Case:</b> Gabrielle writes a comment about a travel e-book which has many versions available over time, and is available in different formats.  She is particularly commenting on a specific version and format, so her client adds both a TimeState to capture the time and an HttpRequestState to capture the format, and then a particular FragmentSelector that is appropriate to that format.</p>
-
-  <h4 id="model-30">Model</h4>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>refinedBy</td><td>Relationship</td><td>The relationship between a broader State and either a more specific State or a Selector that should be applied to the results of the first.
-  <br>Each State <em title="MAY" class="rfc2119">MAY</em> be <code>refinedBy</code> 1 or more other States or Selectors.  If more than 1 is given, then they are considered to be alternatives that will result in the same result.</td></tr>
-</tbody></table>
-
-  <h4 id="example-29">Example</h4>
-
-  <div class="example"><div class="example-title marker"><span>Example 35</span><span style="text-transform: none">: Refinement of States</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno35"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/ebook1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TimeState"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"sourceDate"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2016-02-01T12:05:23Z"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"refinedBy"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"HttpRequestState"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Accept: application/pdf"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"refinedBy"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-          </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"FragmentSelector"</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"page=10"</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"conformsTo"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://tools.ietf.org/rfc/rfc3778"</span><span class="pln">
-        </span><span class="pun">}</span><span class="pln">
-      </span><span class="pun">}</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-</section> <!-- /States -->
-
-<section property="bibo:hasPart" resource="#styles" typeof="bibo:Chapter" id="styles">
-<h3 resource="#h-styles" id="h-styles"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.4 </span>Styles</span></h3>
-
-<p>The interpretation of a particular Annotation, or the Annotation's body, may rely on the rendering style of the Annotation being consistent across implementations.  For Annotations on binary content such as Images or Video, the background color of the target may not be accessible to the annotation client, and the default coloring may be difficult to perceive, such as a black rectangle rendered as the target area on an image of the night sky. Rendering information is recorded using CSS stylesheets and references to classes defined in those stylesheets.</p>
-
-<p><b>Example Use Case:</b> Heather highlights two paragraphs in a document, and selects in her client that one should be highlighted in red and the other in yellow.  She then makes a comment that the yellow part contradicts the red part. Her client records that she selected the red and yellow coloration of the targets. </p>
-
-<h3 id="model-31">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>type</td><td>Relationship</td><td>The class of the Style.<br>CSS Stylesheets <em title="MAY" class="rfc2119">MAY</em> have a <code>type</code> and if included the value <em title="MUST" class="rfc2119">MUST</em> be <code>CssStylesheet</code>.</td></tr>
-<tr><td>CssStylesheet</td><td>Class</td><td>A resource which describes styles for resources participating in the Annotation using CSS.
-<br>The class <em title="MAY" class="rfc2119">MAY</em> be associated with the stylesheet resource.</td></tr>
-<tr><td>stylesheet</td><td>Relationship</td><td>The relationship between an <b>Annotation</b> and the Style.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or 1 <code>stylesheet</code> relationships for each Annotation.</td></tr>
-<tr><td>styleClass</td><td>Property</td><td>The name of the class used in the CSS description that should be applied to the Specific Resource.<br>
-There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>styleClass</code> properties on a Specific Resource.</td></tr>
-</tbody></table>
-
-<p>The CSS Stylesheet is associated with the Annotation itself, and the content provides the rendering hints about the Annotation's constituent resources. It <em title="MAY" class="rfc2119">MAY</em> have its own dereferenceable IRI that provides the information, or it may be embedded within the Annotation. This is to avoid having single line stylesheets each associated with different resources, and instead to allow reference to a single IRI that governs the full set of styles for a particular implementation.</p>
-
-<p>Publishing systems <em title="MUST NOT" class="rfc2119">MUST NOT</em> assume that they will be processed; they are only provided as hints rather than requirements.</p>
-
-<p>When rendering a Specific Resource, consuming applications <em title="SHOULD" class="rfc2119">SHOULD</em> check to see if it has a <code>styleClass</code> property.  If it does, then the application <em title="SHOULD" class="rfc2119">SHOULD</em> attempt to locate the appropriate selector in the CSS document, and then apply the css-value block.  If a Specific Resource has a <code>styleClass</code> value, but no such class is described by a <code>stylesheet</code> attached to the Annotation, then the <code>styleClass</code> <em title="MUST" class="rfc2119">MUST</em> be ignored.</p>
-
-<h3 id="example-30">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 36</span><span style="text-transform: none">: CSS Style</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno36"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/style1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/document1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"styleClass"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"red"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<div class="example"><div class="example-title marker"><span>Example 37</span><span style="text-transform: none">: CSS Style, embedded</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno37"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssStylesheet"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">".red { color: red }"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/body1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/target1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"styleClass"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"red"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#rendering-software" typeof="bibo:Chapter" id="rendering-software">
-  <h3 resource="#h-rendering-software" id="h-rendering-software"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.5 </span>Rendering Software</span></h3>
-  <p>It may be valuable to know the software that was used to process and/or render the target resource when the annotation was created. This information can be used by later systems to potentially recreate the environment to ensure that the annotation can be more easily and more accurately reconnected with the appropriate part of the target's representation. This life cycle information is associated with the Specific Resource, as it is very likely to change between Annotations for the same target, and thus cannot be associated with the target resource directly.</p>
-
-<p><b>Example Use Case:</b> Ingeborg is using a browser based client to render a PDF of a scholarly article.  Her browser uses a particular library to render the PDF as HTML.  She annotates a paragraph in the view that she sees, the HTML rendering, and her client records that the library that was used for rendering in the annotation, along with her comment and the target PDF.</p>
-
-<h3 id="model-32">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>renderedVia</td><td>Relationship</td><td>
-The relationship between the Specific Resource that represents the target in the annotation, and the piece of software or other system that was used to render the target when the annotation was created.
-<br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>renderedVia</code> relationships for each Specific Resource.
-</td></tr>
-</tbody></table>
-
-<div class="note"><div id="h-note14" role="heading" aria-level="4" class="note-title marker"><span>Note</span></div><div class="">Other properties may be associated with the rendering system, including such things as schema:softwareVersion, accessibility functions, labels, references to the actual code, and so forth.  These extensions are beyond the scope of this specification, but please see the Extensions section of [<cite><a href="#bib-annotation-vocab" class="bibref">annotation-vocab</a></cite>].</div></div>
-
-<h3 id="example-31">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 38</span><span style="text-transform: none">: Rendering Software</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno38"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.edu/article.pdf"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/selectors/html-selector1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"renderedVia"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/pdf-to-html-library"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Software"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"schema:softwareVersion"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2.5"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-</section>
-
-<section property="bibo:hasPart" resource="#scope-of-a-resource" typeof="bibo:Chapter" id="scope-of-a-resource">
-	<h3 resource="#h-scope-of-a-resource" id="h-scope-of-a-resource"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.6 </span>Scope of a Resource</span></h3>
-	<p>It is sometimes important for an Annotation to capture the context in which it was made, in terms of the resources that the annotator was viewing or using at the time.  This does not imply an assertion that the annotation is only valid for the image in the context of that page, it just records that the page was being viewed.</p>
-
-<p><b>Example Use Case:</b> Juliet makes a comment about an image in a particular web page to say that it is not the right organization's logo.  Her client includes the page that the image is being rendered in, however the annotation is associated with the image resource itself.</p>
-
-<h3 id="model-33">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>scope</td><td>Relationship</td><td>The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.
-  <br>There <em title="MAY" class="rfc2119">MAY</em> be 0 or more <code>scope</code> relationships for each Specific Resource.
-</td></tr>
-</tbody></table>
-
-<h3 id="example-32">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 39</span><span style="text-transform: none">: Scope</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno39"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/note1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/image1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"scope"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-</section>  <!-- /Specific Resources -->
-
-<section property="bibo:hasPart" resource="#collections" typeof="bibo:Chapter" id="collections">
-  <!--OddPage--><h2 resource="#h-collections" id="h-collections"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Collections</span></h2>
-
-  <p>It is often useful to be able to collect Annotations together into a list, called an Annotation Collection.  This list, which is always ordered, serves as a means to refer to the Annotations that are contained within it, and to maintain any information about the Collection itself.</p>
-
-  <p>The Collection model is divided into two sections: the Annotation Collection that manages the identity of the list and its description, and Annotation Pages that list the Annotations which are members of the Collection.</p>
-
-  <p><b>Example Use Case:</b> Karin works for a publishing house and has transformed the author's commentary on their steampunk novel into a set of annotations for sale. The company wishes to have them available as an add-on for customers that have already bought the novel, and also in a bundle for new sales.</p>
-
-<section property="bibo:hasPart" resource="#annotation-collection" typeof="bibo:Chapter" id="annotation-collection">
-	<h3 resource="#h-annotation-collection" id="h-annotation-collection"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Annotation Collection</span></h3>
-
-	<p>As Annotation Collections might get very large, the model distinguishes between the Collection itself and sequence of component pages that in turn list the Annotations.  The Collection maintains information about itself, including creation or descriptive information to aid with discovery and understanding of the Collection, and also references to at least the first Page of Annotations.  By starting with the first Annotation in the first Page, and traversing the Pages to the last Annotation of the last Page, all Annotations in the Collection will have been discovered.</p>
-
-<p>Annotations <em title="MAY" class="rfc2119">MAY</em> be within multiple Collections at the same time, and the Collection <em title="MAY" class="rfc2119">MAY</em> be created or maintained by agents other than those that create or maintain the included Annotations.</p>
-
-<h3 id="model-34">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>@context</td><td>Property</td><td>The context that determines the meaning of the JSON as an Annotation Collection.
-  <br>The Collection <em title="MUST" class="rfc2119">MUST</em> have 1 or more <code>@context</code> values and <code>http://www.w3.org/ns/anno.jsonld</code> <em title="MUST" class="rfc2119">MUST</em> be one of them.</td></tr>
-<tr><td>id</td><td>Property</td><td>The identity of the Collection.<br>The Collection <em title="MUST" class="rfc2119">MUST</em> have exactly 1 IRI that identifies it.</td></tr>
-<tr><td>type</td><td>Property</td><td>The type of the Collection.<br>The Collection <em title="MUST" class="rfc2119">MUST</em> have 1 or more types, and the <code>AnnotationCollection</code> class <em title="MUST" class="rfc2119">MUST</em> be one of them.</td></tr>
-<tr><td>AnnotationCollection</td><td>Class</td><td>The class for ordered Collections of Annotations.<br>This class <em title="MUST" class="rfc2119">MUST</em> be associated with the Collection using <code>type</code></td></tr>
-<tr><td>label</td><td>Property</td><td>A human readable label intended as the name of the Collection.<br>Collections <em title="SHOULD" class="rfc2119">SHOULD</em> have 1 or more <code>label</code>, and the value <em title="MUST" class="rfc2119">MUST</em> be a string.</td></tr>
-<tr><td>total</td><td>Property</td><td>The total number of Annotations in the Collection.<br>Collections <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 <code>total</code>, and if present it <em title="MUST" class="rfc2119">MUST</em> be an <code>xsd:nonNegaiveInteger</code>. </td></tr>
-<tr><td>first</td><td>Relationship</td><td>The first page of Annotations that are included within the Collection.<br>A Collection that has a total number of Annotations greater than 0 <em title="MUST" class="rfc2119">MUST</em> have exactly 1 <code>first</code> page of Annotations. The first Page <em title="MAY" class="rfc2119">MAY</em> be embedded within the representation of the Collection, or it <em title="MAY" class="rfc2119">MAY</em> be given as an IRI.</td></tr>
-<tr><td>last</td><td>Relationship</td><td>The last page of Annotations that are included within the Collection.<br>A Collection that has a total number of Annotations greater than 0 <em title="SHOULD" class="rfc2119">SHOULD</em> have a reference to the IRI of the <code>last</code> page of Annotations.</td></tr>
-</tbody></table>
-
-<p>Other properties <em title="MAY" class="rfc2119">MAY</em> be added to the Collection to describe its use, intellectual property rights, provenance and any other features that are considered useful.  These properties <em title="SHOULD" class="rfc2119">SHOULD</em> come from those described in this specification if possible, but <em title="MAY" class="rfc2119">MAY</em> come from any appropriate vocabulary.</p>
-
-<h3 id="example-33">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 40</span><span style="text-transform: none">: Annotation Collection</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/collection1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"AnnotationCollection"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"label"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Steampunk Annotations"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/publisher"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"total"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">42023</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"first"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"last"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page42"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
-
-<section property="bibo:hasPart" resource="#annotation-page" typeof="bibo:Chapter" id="annotation-page">
-  <h3 resource="#h-annotation-page" id="h-annotation-page"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.2 </span>Annotation Page</span></h3>
-
-  <p>An Annotation Page is part of an Annotation Collection, and has an ordered list of some or all of the Annotations that are within the Collection. Each Collection may have multiple pages, and these are traversed by following the <code>next</code> and <code>prev</code> links between the pages.</p>
-
-<h3 id="model-35">Model</h3>
-
-<table class="model">
-<tbody><tr><th>Term</th><th>Type</th><th>Description</th></tr>
-<tr><td>@context</td><td>Property</td><td>The context that determines the meaning of the JSON as an Annotation Collection Page.
-  <br>If the Page is NOT embedded within a Collection, it <em title="MUST" class="rfc2119">MUST</em> have 1 or more <code>@context</code> values and <code>http://www.w3.org/ns/anno.jsonld</code> <em title="MUST" class="rfc2119">MUST</em> be one of them. If it is embedded, then it <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> have an <code>@context</code> property.</td></tr>
-<tr><td>id</td><td>Property</td><td>The identity of the Page.<br>The Page <em title="MUST" class="rfc2119">MUST</em> have exactly 1 IRI that provides its identity.</td></tr>
-<tr><td>type</td><td>Property</td><td>The type of the Page.<br>The Page <em title="MUST" class="rfc2119">MUST</em> have 1 or more types, and the <code>AnnotationPage</code> class <em title="MUST" class="rfc2119">MUST</em> be one of them.</td></tr>
-<tr><td>AnnotationPage</td><td>Class</td><td>The class of Annotation Pages.<br>This class <em title="MUST" class="rfc2119">MUST</em> be associated with the Page using <code>type</code>.</td></tr>
-<tr><td>partOf</td><td>Relationship</td><td>The relationship between the Page and the Annotation Collection that it is part of.<br>Each Page <em title="SHOULD" class="rfc2119">SHOULD</em> have a exactly 1 <code>partOf</code> relationship to the Collection. Properties of the Collection, such as the total, <em title="MAY" class="rfc2119">MAY</em> be included in the representation of the Page.</td></tr>
-<tr><td>items</td><td>Relationship</td><td>The list of Annotations that are the members of the Page.<br>Each Page <em title="MUST" class="rfc2119">MUST</em> have an array of 1 or more Annotations as the value of <code>items</code>.</td></tr>
-<tr><td>next</td><td>Relationship</td><td>A reference to the next Page in the sequence of pages that make up the Collection.<br>If the current page is not the last page in the Collection, it <em title="MUST" class="rfc2119">MUST</em> have a reference to the IRI of the page that follows it.</td></tr>
-<tr><td>prev</td><td>Relationship</td><td>A reference to the previous Page in the sequence of pages that make up the Collection.<br>If the current page is not the first page in the Collection, it <em title="SHOULD" class="rfc2119">SHOULD</em> have a reference to the IRI of the page that it follows.</td></tr>
-<tr><td>startIndex</td><td>Property</td><td>The relative position of the first Annotation in the <code>items</code> list, relative to the Annotation Collection. The first entry in the first page is considered to be entry 0.<br>Each Page <em title="SHOULD" class="rfc2119">SHOULD</em> have exactly 1 <code>startIndex</code>, and <em title="MUST NOT" class="rfc2119">MUST NOT</em> have more than 1.  The value <em title="MUST" class="rfc2119">MUST</em> be an <code>xsd:nonNegativeInteger</code>.</td></tr>
-</tbody></table>
-
-<h3 id="example-34">Example</h3>
-
-<div class="example"><div class="example-title marker"><span>Example 41</span><span style="text-transform: none">: Annotation Page</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"AnnotationPage"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"partOf"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/collection1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"next"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page2"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"startIndex"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">0</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/comment1"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/book/chapter1"</span><span class="pln">
-    </span><span class="pun">},</span><span class="pln">
-    </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno2"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/comment2"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/book/chapter2"</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">]</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<div class="example"><div class="example-title marker"><span>Example 42</span><span style="text-transform: none">: Annotation Collection with Embedded Page</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/collection1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"AnnotationCollection"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"label"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Two Annotations"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"total"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">2</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"first"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/page1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"AnnotationPage"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"startIndex"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">0</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-      </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno1"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/comment1"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/book/chapter1"</span><span class="pln">
-      </span><span class="pun">},</span><span class="pln">
-      </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno2"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.net/comment2"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/book/chapter2"</span><span class="pln">
-      </span><span class="pun">}</span><span class="pln">
-    </span><span class="pun">]</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-</section>
-</section> <!-- /Lists -->
-
-<section property="bibo:hasPart" resource="#media_selector" typeof="bibo:Chapter" id="media_selector" class="appendix">
-    <!--OddPage--><h2 resource="#h-media_selector" id="h-media_selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Correspondance Among Media Types and Selectors</span></h2>
-
-    <p>The table below shows the relationships among major media types and selector types.  It is relevant to the <a class="sec-ref" href="#conformance"><span class="secno">1.3</span> <span class="sec-title">Conformance</span></a> section of this document.
+  <section id="sotd" class="introductory">
+    <h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+    <p>
+      <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
     </p>
 
-    <div class="overlarge"><table id="media_table" class="data">
-      <thead>
-        <tr>
-          <td> </td>
-          <th>Fragment</th>
-          <th>CSS</th>
-          <th>XPath</th>
-          <th>Text Quote</th>
-          <th>Text Position</th>
-          <th>Data Position</th>
-          <th>Svg</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th>HTML (text/html)</th>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>CSV (text/csv)</th>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>Plain Text (text/plain)</th>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>Other text files (text/*) </th>
-          <td>?</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>EPUB2, EPUB3 (application/epub+zip)</th>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>PDF (application/pdf) </th>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>XML (application/xml, application/*+xml) </th>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>SVG (image/svg+xml)</th>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✔︎</td>
-        </tr>
-        <tr>
-          <th>Image, other than SVG (image/gif, image/jpeg, image/png,
-            image/tiff)</th>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>?</td>
-          <td>✔︎</td>
-        </tr>
-        <tr>
-          <th>Video (video/*)</th>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>?</td>
-          <td>✔︎</td>
-        </tr>
-        <tr>
-          <th>Binary Data Files</th>
-          <td>?</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>✘</td>
-        </tr>
-      </tbody>
-    </table></div>
+    <p>
+      <b>This is a work in progress. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future. If you feel something should be covered, please <a href="mailto:public-annotation@w3.org">tell us!</a></b>
+    </p>
 
-<section property="bibo:hasPart" resource="#additional-media-types-selector-combination" typeof="bibo:Chapter" id="additional-media-types-selector-combination" class="informative">
-    <h3 resource="#h-additional-media-types-selector-combination" id="h-additional-media-types-selector-combination"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Additional Media Types/Selector Combination</span></h3><p><em>This section is non-normative.</em></p>
+    <p>
+      This specification was derived from the Open Annotation Community Group's outcomes, and details of the differences between the two are maintained in the <a href="#acknowledgements">Acknowledgement</a> appendix.
+    </p>
 
-    <p>The table below contains some other, possible combinations of media types and selector types, which <em title="MAY" class="rfc2119">MAY</em> be implemented but are not mandated by this specification. Some of these combinations may also form the basis for defining new, implementation-specific selector extensions.</p>
 
-    <div class="overlarge"><table class="data">
-      <caption>Additional relationships among other media types and selector types</caption>
-      <thead>
-        <tr>
-          <td> </td>
-          <th>Fragment</th>
-          <th>CSS</th>
-          <th>XPath</th>
-          <th>Text Quote</th>
-          <th>Text Position</th>
-          <th>Data Position</th>
-          <th>Svg</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th>CSS (text/css)</th>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>TSV (text/tab-separated-values)</th>
-          <td>✔︎<sup>✝</sup></td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>✔︎</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>RDF/Turtle (text/turtle)</th>
-          <td>✔︎<sup>✝</sup></td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>?</td>
-          <td>?</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>JSON (application/json, application/*+json)</th>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>?</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-        <tr>
-          <th>Programming languages (application/javascript, python files, etc.)</th>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✘</td>
-          <td>✔︎</td>
-          <td>?</td>
-          <td>✘</td>
-          <td>✘</td>
-        </tr>
-      </tbody>
-      <tfoot>
+    <p>
+      This document was published by the <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> as a Working Draft. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation. If you wish to make comments regarding this document, please send them to
+      <a href="mailto:public-annotation@w3.org">public-annotation@w3.org</a> (
+      <a href="mailto:public-annotation-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="http://lists.w3.org/Archives/Public/public-annotation/">archives</a>). All comments are welcome.
+    </p>
+    <p>
+      Publication as a Working Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.
+    </p>
+    <p>
+      This document was produced by a group operating under the
+      <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+              Policy</a>.
+      <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/73180/status" rel="disclosure">public list of any patent
+                disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+              Claim(s)</a> must disclose the information in accordance with
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    </p>
+    <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+    </p>
+
+  </section>
+  <nav id="toc">
+    <h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
+    <ul class="toc" role="directory">
+      <li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#aims-of-the-model" class="tocxref"><span class="secno">1.1 </span>Aims of the Model</a></li>
+          <li class="tocline"><a href="#serialization-of-the-model" class="tocxref"><span class="secno">1.2 </span>Serialization of the Model</a></li>
+          <li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">1.3 </span>Conformance</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#conformance-requirements-related-to-selectors" class="tocxref"><span class="secno">1.3.1 </span>Conformance Requirements Related to Selectors</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#terminology" class="tocxref"><span class="secno">1.4 </span>Terminology</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#web-annotation-principles" class="tocxref"><span class="secno">2. </span>Web Annotation Principles</a></li>
+      <li class="tocline"><a href="#web-annotation-framework" class="tocxref"><span class="secno">3. </span>Web Annotation Framework</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#annotations" class="tocxref"><span class="secno">3.1 </span>Annotations</a></li>
+          <li class="tocline"><a href="#bodies-and-targets" class="tocxref"><span class="secno">3.2 </span>Bodies and Targets</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#external-web-resources" class="tocxref"><span class="secno">3.2.1 </span>External Web Resources</a></li>
+              <li class="tocline"><a href="#classes" class="tocxref"><span class="secno">3.2.2 </span>Classes</a></li>
+              <li class="tocline"><a href="#segments-of-external-resources" class="tocxref"><span class="secno">3.2.3 </span>Segments of External Resources</a></li>
+              <li class="tocline"><a href="#embedded-textual-body" class="tocxref"><span class="secno">3.2.4 </span>Embedded Textual Body</a></li>
+              <li class="tocline"><a href="#string-body" class="tocxref"><span class="secno">3.2.5 </span>String Body</a></li>
+              <li class="tocline"><a href="#cardinality-of-bodies-and-targets" class="tocxref"><span class="secno">3.2.6 </span>Cardinality of Bodies and Targets</a></li>
+              <li class="tocline"><a href="#choice-of-bodies-and-targets" class="tocxref"><span class="secno">3.2.7 </span>Choice of Bodies and Targets </a></li>
+              <li class="tocline"><a href="#sets-of-bodies-and-targets" class="tocxref"><span class="secno">3.2.8 </span>Sets of Bodies and Targets</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#other-properties" class="tocxref"><span class="secno">3.3 </span>Other Properties</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#lifecycle-information" class="tocxref"><span class="secno">3.3.1 </span>Lifecycle Information</a></li>
+              <li class="tocline"><a href="#agents" class="tocxref"><span class="secno">3.3.2 </span>Agents</a></li>
+              <li class="tocline"><a href="#intended-audience" class="tocxref"><span class="secno">3.3.3 </span>Intended Audience</a></li>
+              <li class="tocline"><a href="#accessibility-of-content" class="tocxref"><span class="secno">3.3.4 </span>Accessibility of Content</a></li>
+              <li class="tocline"><a href="#motivation-and-purpose" class="tocxref"><span class="secno">3.3.5 </span>Motivation and Purpose</a></li>
+              <li class="tocline"><a href="#rights-information" class="tocxref"><span class="secno">3.3.6 </span>Rights Information</a></li>
+              <li class="tocline"><a href="#other-identities" class="tocxref"><span class="secno">3.3.7 </span>Other Identities</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#specific-resources" class="tocxref"><span class="secno">4. </span>Specific Resources</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#purpose-for-external-web-resources" class="tocxref"><span class="secno">4.1 </span>Purpose for External Web Resources</a></li>
+          <li class="tocline"><a href="#selectors" class="tocxref"><span class="secno">4.2 </span>Selectors</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#fragment-selector" class="tocxref"><span class="secno">4.2.1 </span>Fragment Selector</a></li>
+              <li class="tocline"><a href="#css-selector" class="tocxref"><span class="secno">4.2.2 </span>CSS Selector</a></li>
+              <li class="tocline"><a href="#xpath-selector" class="tocxref"><span class="secno">4.2.3 </span>XPath Selector</a></li>
+              <li class="tocline"><a href="#text-quote-selector" class="tocxref"><span class="secno">4.2.4 </span>Text Quote Selector</a></li>
+              <li class="tocline"><a href="#text-position-selector" class="tocxref"><span class="secno">4.2.5 </span>Text Position Selector</a></li>
+              <li class="tocline"><a href="#data-position-selector" class="tocxref"><span class="secno">4.2.6 </span>Data Position Selector</a></li>
+              <li class="tocline"><a href="#svg-selector" class="tocxref"><span class="secno">4.2.7 </span>SVG Selector</a></li>
+              <li class="tocline"><a href="#range-selector" class="tocxref"><span class="secno">4.2.8 </span>Range Selector</a></li>
+              <li class="tocline"><a href="#refinement-of-selection" class="tocxref"><span class="secno">4.2.9 </span>Refinement of Selection</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#states" class="tocxref"><span class="secno">4.3 </span>States</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#time-state" class="tocxref"><span class="secno">4.3.1 </span>Time State</a></li>
+              <li class="tocline"><a href="#request-header-state" class="tocxref"><span class="secno">4.3.2 </span>Request Header State</a></li>
+              <li class="tocline"><a href="#refinement-of-state" class="tocxref"><span class="secno">4.3.3 </span>Refinement of State</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#styles" class="tocxref"><span class="secno">4.4 </span>Styles</a></li>
+          <li class="tocline"><a href="#rendering-software" class="tocxref"><span class="secno">4.5 </span>Rendering Software</a></li>
+          <li class="tocline"><a href="#scope-of-a-resource" class="tocxref"><span class="secno">4.6 </span>Scope of a Resource</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#collections" class="tocxref"><span class="secno">5. </span>Collections</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#annotation-collection" class="tocxref"><span class="secno">5.1 </span>Annotation Collection</a></li>
+          <li class="tocline"><a href="#annotation-page" class="tocxref"><span class="secno">5.2 </span>Annotation Page</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#media_selector" class="tocxref"><span class="secno">A. </span>Correspondance Among Media Types and Selectors</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#additional-media-types-selector-combination" class="tocxref"><span class="secno">A.1 </span>Additional Media Types/Selector Combination</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#complete-example" class="tocxref"><span class="secno">B. </span>Complete Example</a></li>
+      <li class="tocline"><a href="#index-of-json-keys" class="tocxref"><span class="secno">C. </span>Index of JSON Keys</a></li>
+      <li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">D. </span>Acknowledgements</a></li>
+      <li class="tocline"><a href="#changes-from-previous-draft" class="tocxref"><span class="secno">E. </span>Changes from Previous Draft</a></li>
+      <li class="tocline"><a href="#references" class="tocxref"><span class="secno">F. </span>References</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">F.1 </span>Normative references</a></li>
+          <li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">F.2 </span>Informative references</a></li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+
+
+  <section class="informative" id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
+    <p><em>This section is non-normative.</em></p>
+
+    <p>Annotating, the act of creating associations between distinct pieces of information, is a pervasive activity online in many guises. Web citizens make comments about online resources using either tools built in to the hosting website, external web services, or the functionality of an annotation client. Comments about shared photos or videos, reviews of products, or even social network mentions of web resources could all be considered as annotations. In addition, there are a plethora of "sticky note" systems and stand-alone multimedia annotation systems. This specification describes a common approach to expressing these annotations, and more.
+    </p>
+
+    <p>The Web Annotation Data Model provides an extensible, interoperable framework for expressing annotations such that they can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.</p>
+
+    <p>An annotation is considered to be a set of connected resources, typically including a body and target, and conveys that the body is related to the target. The exact nature of this relationship changes according to the intention of the annotation, but the body is most frequently somehow "about" the target. This perspective results in a basic model with three parts, depicted below. The full model supports additional functionality, enabling content to be embedded within the annotation, selecting arbitrary segments of resources, choosing the appropriate representation of a resource and providing styling hints to help clients render the annotation appropriately. Annotations created by or intended for machines are also possible, ensuring that the Data Web is not ignored in favor of only considering the human-oriented Document Web.</p>
+
+    <img src="images/intro_model.png" alt="Basic Model: Annotation, Body and Target" width="400">
+
+    <p>The Web Annotation Data Model does not prescribe a transport protocol for creating, managing and retrieving annotations. Instead it describes a resource oriented structure and serialization of that structure that could be carried over many different protocols. The related [<cite><a class="bibref" href="#bib-annotation-protocol">annotation-protocol</a></cite>] specification describes a recommended transport layer, which may be adopted separately.</p>
+
+
+    <section id="aims-of-the-model" typeof="bibo:Chapter" resource="#aims-of-the-model" property="bibo:hasPart">
+      <h3 id="h-aims-of-the-model" resource="#h-aims-of-the-model"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Aims of the Model</span></h3>
+
+      <p>
+        The primary aim of the Web Annotation Data Model is to provide a standard description model and format to enable annotations to be shared between systems. This interoperability may be either for sharing with others, or the migration of private annotations between devices or platforms. The shared annotations must be able to be integrated into existing collections and reused without loss of significant information. The model should cover as many annotation use cases as possible, while keeping the simple annotations easy and expanding from that baseline to make complex uses possible.
+      </p>
+
+      <p>
+        The Web Annotation Data Model is a single, consistent model that can be used by all interested parties. All efforts have been made to keep the implementation costs for both producers and consumers to a minimum. A single method of fulfilling a use case is strongly preferred over multiple methods, unless there are existing standards that need to be accommodated or there is a significant cost associated with using only a single method. While the Data Model is built using Linked Data fundamentals, the design is intended to allow rich and performant non-graph-based implementations. As such, inferencing and other graph-based queries are explicitly not a priority for optimization in the design of the model.
+
+      </p>
+    </section>
+
+    <section id="serialization-of-the-model" typeof="bibo:Chapter" resource="#serialization-of-the-model" property="bibo:hasPart">
+      <h3 id="h-serialization-of-the-model" resource="#h-serialization-of-the-model"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Serialization of the Model</span></h3>
+
+      <p>
+        The examples throughout the document are serialized as [<cite><a class="bibref" href="#bib-JSON-LD">JSON-LD</a></cite>] using the Context given in Appendix A of the Annotation Vocabulary [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>], which is the preferred serialization format.
+      </p>
+
+      <p>When the only information that is recorded in the annotation is the <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a> of a resource, then that IRI is used as the value of the relationship, as in <a href="#annotations">Example 1</a>. When there is more information about the resource, the IRI is the value of the <code>id</code> property of the object which is the value of the relationship, as in <a href="#external-web-resources">Example 2</a>.</p>
+
+
+    </section>
+
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart">
+      <h3 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
+      <p>
+        As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
+      </p>
+      <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="NOT RECOMMENDED">NOT RECOMMENDED</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+      </p>
+
+      <section id="conformance-requirements-related-to-selectors" typeof="bibo:Chapter" resource="#conformance-requirements-related-to-selectors" property="bibo:hasPart">
+        <h4 id="h-conformance-requirements-related-to-selectors" resource="#h-conformance-requirements-related-to-selectors"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3.1 </span>Conformance Requirements Related to Selectors</span></h4>
+        <p>Not all <a href="#selectors">Selectors</a> are relevant for all media types; some combinations are meaningless or not formally defined. An implementation may therefore ignore certain types of Selectors in case the corresponding media types are not handled by that particular implementation.</p>
+
+        <p>The table in <a href="#media_selector" class="sec-ref"><span class="secno">A.</span> <span class="sec-title">Correspondance Among Media Types and Selectors</span></a> shows the correspondance among the main media types addressed in this specification and Selector types. The meaning of the table elements, and their affect on implementation conformance, is as follows.</p>
+
+        <ul>
+          <li>A “✔︎” sign in the table means that the Selector type is relevant for that particular media types. A conformant implementation <em class="rfc2119" title="MUST">MUST</em> implement that particular combination <em>if</em> it handles the corresponding media type.</li>
+
+          <li>A “✘” sign in the table means that the Selector type is not relevant for that particular media types. Conformant implementations <em class="rfc2119" title="SHOULD">SHOULD</em> ignore that particular combination.</li>
+
+          <li>A “?” means that it is not possible to specify, in general, whether that particular combination is meaningful (e.g., fragment identifiers are defined for specific media types, i.e., specific text media types other than plain text may have fragments defined but they are not listed in the table). In other cases the usefulness of such combination is not clear (e.g., Data Position selectors for binary images). Conformant implementations <em class="rfc2119" title="MAY">MAY</em> implement that particular combination.</li>
+        </ul>
+
+      </section>
+    </section>
+
+    <section id="terminology" typeof="bibo:Chapter" resource="#terminology" property="bibo:hasPart">
+      <h3 id="h-terminology" resource="#h-terminology"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.4 </span>Terminology</span></h3>
+
+      <dl>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-iri">IRI</dfn></dt>
+        <dd>An <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>, or Internationalized Resource Identifier, is an extension to the URI specification to allow characters from Unicode, whereas URIs must be made up of a subset of ASCII characters. There is a mapping algorithm for translating between IRIs and the equivalent encoded URI form. IRIs are defined by [<cite><a class="bibref" href="#bib-rfc3987">rfc3987</a></cite>].</dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-resource">Resource</dfn></dt>
+        <dd>An item of interest that <em class="rfc2119" title="MAY">MAY</em> be identified by an <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>.</dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-web-resource">Web Resource</dfn></dt>
+        <dd>A <a href="#dfn-resource" class="internalDFN" data-link-type="dfn">Resource</a> that <em class="rfc2119" title="MUST">MUST</em> be identified by an <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>, as described in the Web Architecture [<cite><a class="bibref" href="#bib-webarch">webarch</a></cite>]. Web Resources <em class="rfc2119" title="MAY">MAY</em> be dereferencable via their IRI.</dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-external-web-resource">External Web Resource</dfn></dt>
+        <dd>A <a href="#dfn-web-resource" class="internalDFN" data-link-type="dfn">Web Resource</a> which is not part of the representation of the Annotation, such as a web page, image, or video. External Web Resources are dereferencable from their <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>.</dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-property">Property</dfn></dt>
+        <dd>A feature of a <a href="#dfn-resource" class="internalDFN" data-link-type="dfn">Resource</a>, that often has a particular data type. In the model sections, the term "Property" is used to refer to only those features which are <em>not</em> <a href="#dfn-relationship" class="internalDFN" data-link-type="dfn">Relationships</a> and instead have a literal value such as a string, integer or date. The valid values for a Property are thus any data type other than object, or an array containing members of that data type if more than one is allowed.</dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-relationship">Relationship</dfn></dt>
+        <dd>In the model sections, the term "Relationship" is used to distinguish those features that refer to other <a href="#dfn-resource" class="internalDFN" data-link-type="dfn">Resources</a>, either by reference to the <a href="#dfn-resource" class="internalDFN" data-link-type="dfn">Resource</a>'s <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a> or by including a description of the <a href="#dfn-resource" class="internalDFN" data-link-type="dfn">Resource</a> in the Annotation's representation. The valid values for a Relationship are: a quoted string containing an IRI, an object that has the "id" property, or an array containing either of these if more than one is allowed.</dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-class">Class</dfn></dt>
+        <dd><a href="#dfn-resource" class="internalDFN" data-link-type="dfn">Resources</a> may be divided, conceptually, into groups called "classes"; members of a class are known as <a href="#dfn-instance" class="internalDFN" data-link-type="dfn">Instances</a> of the class. Resources are associated with a particular class through <a href="#dfn-type" class="internalDFN" data-link-type="dfn">typing</a>. Classes are identified by <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRIs</a>, i.e., they are also <a href="#dfn-web-resource" class="internalDFN" data-link-type="dfn">Web Resources</a> themselves.</dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-type">Type</dfn></dt>
+        <dd>A special <a href="#dfn-relationship" class="internalDFN" data-link-type="dfn">Relationship</a> that associates an <a href="#dfn-instance" class="internalDFN" data-link-type="dfn">Instance</a> of a class to the <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> it belongs to.</dd>
+
+        <dt><dfn data-dfn-type="dfn" id="dfn-instance">Instance</dfn></dt>
+        <dd>An element of a group of <a href="#dfn-resource" class="internalDFN" data-link-type="dfn">Resources</a> represented by a particular <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.</dd>
+
+      </dl>
+
+    </section>
+
+  </section>
+
+  <!-- End Introduction -->
+
+  <section id="web-annotation-principles" typeof="bibo:Chapter" resource="#web-annotation-principles" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-web-annotation-principles" resource="#h-web-annotation-principles"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Principles</span></h2>
+
+    <p>
+      The Web Annotation Data Model is defined using the following basic principles:
+
+    </p>
+    <ul>
+      <li>An Annotation is a rooted, directed graph that represents a relationship between resources.</li>
+      <li>There are two primary types of resource that participate in this relationship, Bodies and Targets.</li>
+      <li>Annotations have 0 or more Bodies.</li>
+      <li>Annotations have 1 or more Targets.</li>
+      <li>The content of the Body resources is related to, and typically "about", the content of the Target resources.</li>
+      <li>Annotations, Bodies and Targets may have their own properties and relationships, typically including creation and descriptive information.</li>
+      <li>The intent behind the creation of an Annotation or the inclusion of a particular Body or Target is an important property and represented by a Motivation resource.</li>
+    </ul>
+    <p></p>
+
+    <p>
+      The following principles describe additional distinctions regarding the exact nature of Target and Body:
+
+    </p>
+    <ul>
+      <li>The Target or Body resource may be more specific than the entity identified by the resource's <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a> alone.</li>
+      <li>In particular,
+        <ul>
+          <li>The Target or Body resource may be a specific segment of the resource.</li>
+          <li>The Target or Body resource may be styled in a specific way.</li>
+          <li>The Target or Body resource may be a specific state of the resource.</li>
+          <li>The Target or Body resource may be included in the Annotation to play a specific role.</li>
+          <li>The Target or Body resource may be any combination of the above.</li>
+        </ul>
+      </li>
+      <li>The resource with these constraints is a separate resource from the Annotation, Body or Target, and is called a SpecificResource.</li>
+      <li>The SpecificResource refers to the source resource and the constraints that make it more specific.</li>
+      <li>The identity of the SpecificResource is separate from the descriptions of the constraints.</li>
+    </ul>
+    <p></p>
+
+    <p>
+      The following principles describe additional semantics regarding multiple resources:
+
+    </p>
+    <ul>
+      <li>A resource may be a choice between multiple resources.</li>
+      <li>A resource may be an ordered list of resources.</li>
+    </ul>
+    <p></p>
+  </section>
+
+  <section id="web-annotation-framework" typeof="bibo:Chapter" resource="#web-annotation-framework" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-web-annotation-framework" resource="#h-web-annotation-framework"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Web Annotation Framework</span></h2>
+
+    <section id="annotations" typeof="bibo:Chapter" resource="#annotations" property="bibo:hasPart">
+      <h3 id="h-annotations" resource="#h-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1 </span>Annotations</span></h3>
+
+      <p>
+        An Annotation is a web resource. Typically, an Annotation has a single Body, which is a comment or other descriptive resource, and a single Target that the Body is somehow "about". The Annotation likely also has additional descriptive properties. </p>
+
+      <p><b>Example Use Case:</b> Alice has written a post that makes a comment about a particular web page. Her client creates an Annotation with the post as the body resource, and the web page as the target resource.</p>
+
+      <h3 id="model">Model</h3>
+
+      <table class="model">
+        <tbody>
           <tr>
-              <td colspan="8" style="font-size:70%">
-                  <sup>✝</sup>Fragments are not formally defined through IETF, though there are well-known connections to existing fragments or practices
-              </td>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
           </tr>
-      </tfoot>
-    </table></div>
-</section>
-</section>
+          <tr>
+            <td>@context</td>
+            <td>Property</td>
+            <td>The context that determines the meaning of the JSON as an Annotation
+              <br>The Annotation <em class="rfc2119" title="MUST">MUST</em> have 1 or more <code>@context</code> values and <code>http://www.w3.org/ns/anno.jsonld</code> <em class="rfc2119" title="MUST">MUST</em> be one of them. If there is only one value, then it <em class="rfc2119" title="MUST">MUST</em> be provided as a string.</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            <td>Property</td>
+            <td>The identity of the Annotation
+              <br>An Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a> that identifies it.</td>
+          </tr>
+          <tr>
+            <td>type</td>
+            <td>Relationship</td>
+            <td>The type of the Annotation.
+              <br>An Annotation <em class="rfc2119" title="MUST">MUST</em> have 1 or more types, and the <code>Annotation</code> class <em class="rfc2119" title="MUST">MUST</em> be one of them.</td>
+          </tr>
+          <tr>
+            <td>Annotation</td>
+            <td>Class</td>
+            <td>The class for Web Annotations
+              <br>The <code>Annotation</code> class <em class="rfc2119" title="MUST">MUST</em> be associated with an Annotation using <code>type</code>.</td>
+          </tr>
+          <tr>
+            <td>body</td>
+            <td>Relationship</td>
+            <td>The relationship between an Annotation and its Body
+              <br>There <em class="rfc2119" title="SHOULD">SHOULD</em> be 1 or more <code>body</code> relationships associated with an Annotation but there <em class="rfc2119" title="MAY">MAY</em> be 0.
+            </td>
+          </tr>
+          <tr>
+            <td>target</td>
+            <td>Relationship</td>
+            <td>The relationship between an Annotation and its Target
+              <br>There <em class="rfc2119" title="MUST">MUST</em> be 1 or more <code>target</code> relationships associated with an Annotation.
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-<section property="bibo:hasPart" resource="#complete-example" typeof="bibo:Chapter" id="complete-example" class="appendix informative">
-  <!--OddPage--><h2 resource="#h-complete-example" id="h-complete-example"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>Complete Example</span></h2><p><em>This section is non-normative.</em></p>
+      <h3 id="example">Example</h3>
 
-<p><b>Entirely Contrived Example Use Case:</b> Lana wants to associate a comment that she wrote in English within the annotation or a external mp3 of the same content in German by someone else, plus a tag, with a range of characters from a particular element in an XML representation of a document as it was at a certain point in time, and for it to be displayed in a particular way.</p>
+      <div class="example">
+        <div class="example-title marker"><span>Example 1</span><span style="text-transform: none">: Basic Annotation Model</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno1"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/post1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/page1"</span>
+</span>}</pre></div>
+    </section>
 
-<div class="example"><div class="example-title marker"><span>Example 43</span><span style="text-transform: none">: Complete Example</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno40"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"commenting"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"A. Person"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"nick"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"user1"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-10-13T13:00:00Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/client1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SoftwareAgent"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"name"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Code v2.1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"homepage"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/homepage1"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"generated"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-10-14T15:13:28Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/stylesheet1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"CssStylesheet"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"purpose"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"tagging"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"love"</span><span class="pln">
-    </span><span class="pun">},</span><span class="pln">
-    </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Choice"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-        </span><span class="pun">{</span><span class="pln">
-          </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"purpose"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I really love this particular bit of text in this XML. No really."</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"text/plain"</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"en"</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user1"</span><span class="pln">
-        </span><span class="pun">},</span><span class="pln">
-        </span><span class="pun">{</span><span class="pln">
-          </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"purpose"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"describing"</span><span class="pun">,</span><span class="pln">
-          </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-            </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/comment1"</span><span class="pun">,</span><span class="pln">
-            </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Audio"</span><span class="pun">,</span><span class="pln">
-            </span><span class="str">"format"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"audio/mpeg"</span><span class="pun">,</span><span class="pln">
-            </span><span class="str">"language"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"de"</span><span class="pun">,</span><span class="pln">
-            </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-              </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/user2"</span><span class="pun">,</span><span class="pln">
-              </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Person"</span><span class="pln">
-            </span><span class="pun">}</span><span class="pln">
-          </span><span class="pun">}</span><span class="pln">
-        </span><span class="pun">}</span><span class="pln">
-      </span><span class="pun">]</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">],</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"SpecificResource"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"styleClass"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"mystyle"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/document1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"state"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-      </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"HttpRequestState"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Accept: application/xml"</span><span class="pln">
-      </span><span class="pun">},</span><span class="pln">
-      </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TimeState"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"sourceDate"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-09-25T12:00:00Z"</span><span class="pln">
-      </span><span class="pun">}</span><span class="pln">
-    </span><span class="pun">],</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"FragmentSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xpointer(/doc/body/section[2]/para[1])"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"refinedBy"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-        </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextPositionSelector"</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"start"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">6</span><span class="pun">,</span><span class="pln">
-        </span><span class="str">"end"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">27</span><span class="pln">
-      </span><span class="pun">}</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</section>
+    <section id="bodies-and-targets" typeof="bibo:Chapter" resource="#bodies-and-targets" property="bibo:hasPart">
+      <h3 id="h-bodies-and-targets" resource="#h-bodies-and-targets"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2 </span>Bodies and Targets</span></h3> The Web is distributed, with different systems working together to provide access to content. Annotations can be used to link those resources together, being referenced as the Body and Target. The Target resource is always an External Web Resource, but the Body may also be embedded within the Annotation. External Web Resources may be separately dereferenced to retrieve a representation of their state, whereas the embedded Body does not need to be dereferenced as the representation is included within the Annotation's representation.
 
-<section property="bibo:hasPart" resource="#index-of-json-keys" typeof="bibo:Chapter" id="index-of-json-keys" class="appendix informative">
-  <!--OddPage--><h2 resource="#h-index-of-json-keys" id="h-index-of-json-keys"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>Index of JSON Keys</span></h2><p><em>This section is non-normative.</em></p>
+      <section id="external-web-resources" typeof="bibo:Chapter" resource="#external-web-resources" property="bibo:hasPart">
+        <h4 id="h-external-web-resources" resource="#h-external-web-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.1 </span>External Web Resources</span></h4>
 
-<table class="model">
-  <tbody><tr><th>Key</th><th>Usage</th></tr>
-<tr><td>account</td><td><a href="#agents">Agent</a></td></tr>
-<tr><td>audience</td><td><a href="#intended-audience">Audience</a></td></tr>
-<tr><td>body</td><td><a href="#annotations">Annotation</a></td></tr>
-<tr><td>bodyValue</td><td><a href="#string-body">String Body</a></td></tr>
-<tr><td>cached</td><td><a href="#time-state">Time State</a></td></tr>
-<tr><td>canonical</td><td><a href="#other-identities">Annotation, Body, Target</a></td></tr>
-<tr><td>conformsTo</td><td><a href="#fragment-selector">Fragment Selector</a></td></tr>
-<tr><td>created</td><td><a href="#lifecycle-information">Annotation, Body, Target</a></td></tr>
-<tr><td>creator</td><td><a href="#lifecycle-information">Annotation, Body, Target</a></td></tr>
-<tr><td>email</td><td><a href="#agents">Agent</a></td></tr>
-<tr><td>email_sha1</td><td><a href="#agents">Agent</a></td></tr>
-<tr><td>end</td><td><a href="#text-position-selector">Text Position Selector</a>, <a href="#data-position-selector">Data Position Selector</a></td></tr>
-<tr><td>endSelector</td><td><a href="#range-selector">Range Selector</a></td></tr>
-<tr><td>exact</td><td><a href="#text-quote-selector">Text Quote Selector</a></td></tr>
-<tr><td>first</td><td><a href="#annotation-collection">Annotation Collection</a></td></tr>
-<tr><td>format</td><td><a href="#external-web-resources">Body, Target</a>, <a href="#svg-selector">SVG Selector</a></td></tr>
-<tr><td>generated</td><td><a href="#lifecycle-information">Annotation</a></td></tr>
-<tr><td>generator</td><td><a href="#lifecycle-information">Annotation</a></td></tr>
-<tr><td>homepage</td><td><a href="#agents">Agents</a></td></tr>
-<tr><td class="top_cell">id</td><td>Note: Every object <em title="MAY" class="rfc2119">MAY</em> have an <code>id</code>.<br><a href="#annotations">Annotation</a>, <a href="#external-web-resources">Body, Target</a>, <a href="#segments-of-external-resources">Segments of External Resources</a>, <a href="#embedded-textual-body">Embedded Textual Body</a>, <a href="#agents">Agent</a>, <a href="#intended-audience">Audience</a>, <a href="#specific-resources">Specific Resource</a></td></tr>
-<tr><td>items</td><td><a href="#choice-of-bodies-and-targets">Choice</a>, <a href="#annotation-page">Annotation Page</a></td></tr>
-<tr><td>label</td><td><a href="#annotation-collection">Annotation Collection</a></td></tr>
-<tr><td>language</td><td><a href="#external-web-resources">Body, Target</a></td></tr>
-<tr><td>last</td><td><a href="#annotation-collection">Annotation Collection</a></td></tr>
-<tr><td>modified</td><td><a href="#lifecycle-information">Annotation, Body, Target</a></td></tr>
-<tr><td>motivation</td><td><a href="#motivation-and-purpose">Annotation</a></td></tr>
-<tr><td>name</td><td><a href="#agents">Agent</a></td></tr>
-<tr><td>next</td><td><a href="#annotation-page">Annotation Page</a></td></tr>
-<tr><td>partOf</td><td><a href="#annotation-page">Annotation Page</a></td></tr>
-<tr><td>prefix</td><td><a href="#text-quote-selector">Text Quote Selector</a></td></tr>
-<tr><td>prev</td><td><a href="#annotation-page">Annotation Page</a></td></tr>
-<tr><td>purpose</td><td><a href="#motivation-and-purpose">Textual Body</a>, <a href="#purpose-for-external-web-resources">Specific Resource</a></td></tr>
-<tr><td>renderedVia</td><td><a href="#rendering-software">Specific Resource</a></td></tr>
-<tr><td>rights</td><td><a href="#rights-information">Annotation, Body, Target</a></td></tr>
-<tr><td>refinedBy</td><td><a href="#refinement-of-selection">Selector</a>, <a href="#refinement-of-state">State</a></td></tr>
-<tr><td>scope</td><td><a href="#scope-of-a-resource">Specific Resource</a></td></tr>
-<tr><td>selector</td><td><a href="#selectors">Specific Resource</a></td></tr>
-<tr><td>source</td><td><a href="#specific-resources">Specific Resource</a></td></tr>
-<tr><td>sourceDate</td><td><a href="#time-state">Time State</a></td></tr>
-<tr><td>sourceDateEnd</td><td><a href="#time-state">Time State</a></td></tr>
-<tr><td>sourceDateStart</td><td><a href="#time-state">Time State</a></td></tr>
-<tr><td>start</td><td><a href="#text-position-selector">Text Position Selector</a>, <a href="#data-position-selector">Data Position Selector</a></td></tr>
-<tr><td>startIndex</td><td><a href="#annotation-page">Annotation Page</a></td></tr>
-<tr><td>startSelector</td><td><a href="#range-selector">Range Selector</a></td></tr>
-<tr><td>state</td><td><a href="#states">Specific Resource</a></td></tr>
-<tr><td>styleClass</td><td><a href="#styles">Specific Resource</a></td></tr>
-<tr><td>stylesheet</td><td><a href="#styles">Annotation</a></td></tr>
-<tr><td>suffix</td><td><a href="#text-quote-selector">Text Quote Selector</a></td></tr>
-<tr><td>target</td><td><a href="#annotations">Annotation</a></td></tr>
-<tr><td>total</td><td><a href="#annotation-collection">Annotation Collection</a></td></tr>
-<tr><td class="top_cell">type</td><td>Note: Every object <em title="MAY" class="rfc2119">MAY</em> have a <code>type</code>.<br> <a href="#annotations">Annotation</a>, <a href="#classes">Body, Target</a>, <a href="#embedded-textual-body">Embedded Textual Body</a>, <a href="#agents">Agent</a>, <a href="#intended-audience">Audience</a>, <a href="#specific-resources">Specific Resource</a>, <a href="#fragment-selector">Fragment Selector</a>, <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a>, <a href="#text-quote-selector">Text Quote Selector</a>, <a href="#text-position-selector">Text Position Selector</a>, <a href="#data-position-selector">Data Position Selector</a>, <a href="#svg-selector">SVG Selector</a>, <a href="#time-state">Time State</a>, <a href="#request-header-state">Request Header State</a>, <a href="#styles">CSS Stylesheet</a></td></tr>
-<tr><td>value</td><td> <a href="#embedded-textual-body">Textual Body</a>, <a href="#fragment-selector">Fragment Selector</a>, <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a>, <a href="#svg-selector">SVG Selector</a>, <a href="#request-header-state">Request Header State</a>, <a href="#styles">CSS Stylesheet</a></td></tr>
-<tr><td>via</td><td><a href="#other-identities">Annotation, Body, Target</a></td></tr>
-</tbody></table>
-</section>
+        <p>Web Resources are identified with a <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a> and have various properties, often including a format or language for the resource's content. This information may be recorded as part of the Annotation, even if the representation of the resource must be retrieved from the Web.</p>
 
-<section property="bibo:hasPart" resource="#acknowledgements" typeof="bibo:Chapter" id="acknowledgements" class="appendix informative">
-<!--OddPage--><h2 resource="#h-acknowledgements" id="h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">D. </span>Acknowledgements</span></h2><p><em>This section is non-normative.</em></p>
+        <p><b>Example Use Case:</b> Beatrice records a long analysis of a patent, and publishes the audio on her website as an mp3. She then creates an Annotation with the mp3 as the body, and the PDF of the patent as the target.</p>
 
-<p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>.  The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model.  In particular the editors would like to thank Herbert Van de Sompel of Los Alamos National Laboratory for his editorial contributions throughout the Community Group process.
-</p>
+        <h4 id="model-1">Model</h4>
 
-<p>The following people have been instrumental in providing thoughts, feedback, reviews, content, criticism and input in the creation of this specification:
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>id</td>
+              <td>Property</td>
+              <td>The <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a> that identifies the Body or Target resource.
+                <br>Bodies or Targets which are External Web Resources <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>id</code> with the value of the resource's <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>language</td>
+              <td>Property</td>
+              <td>The language of the Web Resource's content
+                <br>The Body or Target <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 language associated with it, but <em class="rfc2119" title="MAY">MAY</em> have 0 or more. The value of the property <em class="rfc2119" title="SHOULD">SHOULD</em> be a language code following the [<cite><a class="bibref" href="#bib-bcp47">bcp47</a></cite>] specification.</td>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Property</td>
+              <td>The format of the Web Resource's content
+                <br>The Body or Target <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 format associated with it, but <em class="rfc2119" title="MAY">MAY</em> have 0 or more. The value of the property <em class="rfc2119" title="SHOULD">SHOULD</em> be the media-type of the format, following the [<cite><a class="bibref" href="#bib-rfc6838">rfc6838</a></cite>] specification.</td>
+            </tr>
+            <tr>
+              <td>textDirection</td>
+              <td>Relationship</td>
+              <td>The direction of the text of the resource.
+                <br>The Body or Target <em class="rfc2119" title="MAY">MAY</em> have exactly 1 textDirection associated with it. The value of the property <em class="rfc2119" title="MUST">MUST</em> be one of the directions defined below (<code>ltr</code>, <code>rtl</code>, or <code>auto</code>).
+              </td>
+            </tr>
+            <tr>
+              <td>ltr</td>
+              <td>Instance</td>
+              <td>The direction that indicates the value of the resource is explicitly directionally isolated left-to-right text.</td>
+            </tr>
+            <tr>
+              <td>rtl</td>
+              <td>Instance</td>
+              <td>The direction that indicates the value of the resource is explicitly directionally isolated right-to-left text.</td>
+            </tr>
+            <tr>
+              <td>auto</td>
+              <td>Instance</td>
+              <td>The direction that indicates the value of the resource is explicitly directionally isolated text, and the direction is to be programmatically determined using the value.</td>
+            </tr>
+          </tbody>
+        </table>
 
-</p><div style="margin-left: 3em">
-Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven Capadisli, Paolo Ciccarese, Tim Cole, Ray Denenberg, TB Dinesh, Sergiu Gordea, Benjamin Goering, Amy Guy, Ivan Herman, Frederick Hirsch, Antoine Isaac, Jacob Jett, Takeshi Kanai, Gregg Kellogg, Andreas Kuckartz, Randall Leeds, Hugo Manguinhas, Ben De Meester, Luc Moreau, Addison Phillips, Davis Salisbury, Robert Sanderson, Felix Sasaki, Doug Schepers, Tzviya Siegman, Stian Soiland-Reyes, Manu Sporney, Nick Stenning, Jon Stroop, Lutz Suhrbier, Kyrce Swenson, Raphael Troncy, Simeon Warner, Erik Wilde, Dan Whaley, Benjamin Young
-</div>
-<p></p>
-</section>
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note1"><span>Note</span></div>
+          <div class="">
+            The [<cite><a class="bibref" href="#bib-iana-media-types">iana-media-types</a></cite>] document provides the official registry of media types that can be used with the <code>format</code> property. The [<cite><a class="bibref" href="#bib-w3c-language-tags">w3c-language-tags</a></cite>] article provides a good overview of the values that implementers can expect to encounter in the <code>language</code> property. The notion of text direction is taken explicity from <a href="https://www.w3.org/TR/html5/dom.html#the-dir-attribute">HTML5's</a> <code>dir</code> attribute.
+          </div>
+        </div>
 
-<section property="bibo:hasPart" resource="#changes-from-previous-draft" typeof="bibo:Chapter" id="changes-from-previous-draft" class="appendix informative">
-<!--OddPage--><h2 resource="#h-changes-from-previous-draft" id="h-changes-from-previous-draft"><span property="xhv:role" resource="xhv:heading"><span class="secno">E. </span>Changes from Previous Draft</span></h2><p><em>This section is non-normative.</em></p>
+        <h4 id="example-1">Example</h4>
 
-<p>
-</p><ul>
-<li>Addition of conformance section and media table</li>
-<li>Remove Content class as unnecessary, and reuse <code>value</code> in place of the previous distinct <code>text</code> property.</li>
-</ul>
-<p></p>
+        <div class="example">
+          <div class="example-title marker"><span>Example 2</span><span style="text-transform: none">: External Web Resources</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno2"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/analysis1.mp3"</span></span>,
+    "<span class="hljs-attribute">format</span>": <span class="hljs-value"><span class="hljs-string">"audio/mpeg"</span></span>,
+    "<span class="hljs-attribute">language</span>": <span class="hljs-value"><span class="hljs-string">"fr"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.gov/patent1.pdf"</span></span>,
+    "<span class="hljs-attribute">format</span>": <span class="hljs-value"><span class="hljs-string">"application/pdf"</span></span>,
+    "<span class="hljs-attribute">language</span>": <span class="hljs-value"><span class="hljs-string">"en"</span></span>,
+    "<span class="hljs-attribute">textDirection</span>": <span class="hljs-value"><span class="hljs-string">"ltr"</span>
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="classes" typeof="bibo:Chapter" resource="#classes" property="bibo:hasPart">
+        <h4 id="h-classes" resource="#h-classes"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.2 </span>Classes</span></h4>
+
+        <p>It is useful for clients to know the general type of a Web Resource in advance. If the client cannot render videos, then knowing that the Body is a video will allow it to avoid needlessly downloading a potentially large content stream. For resources that do not have obvious media types, such as many data formats, it is also useful for a client to know that a resource with the format <code>text/csv</code> should not simply be rendered as plain text, despite the first part of the media type, whereas <code>application/pdf</code> may be able to be rendered by the user agent despite the main type being 'application'.</p>
+
+        <p><b>Example Use Case:</b> Corina shoots a video of her comment about a website on her phone and uploads it. She associates the video with the website via an Annotation, and her client adds types as a hint to consuming systems.</p>
+
+        <h4 id="model-2">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The type of the Body resource.
+                <br>The Body or Target <em class="rfc2119" title="MAY">MAY</em> have 1 or more <code>type</code>s, and if so, the value <em class="rfc2119" title="SHOULD">SHOULD</em> be drawn from the list of classes below, but <em class="rfc2119" title="MAY">MAY</em> come from other vocabularies.</td>
+            </tr>
+            <tr>
+              <td>Dataset</td>
+              <td>Class</td>
+              <td>The class for a resource which encodes data in a defined structure</td>
+            </tr>
+            <tr>
+              <td>Image</td>
+              <td>Class</td>
+              <td>The class for image resources, primarily intended to be seen</td>
+            </tr>
+            <tr>
+              <td>Video</td>
+              <td>Class</td>
+              <td>The class for video resources, with or without audio</td>
+            </tr>
+            <tr>
+              <td>Sound</td>
+              <td>Class</td>
+              <td>The class for a resource primarily intended to be heard</td>
+            </tr>
+            <tr>
+              <td>Text</td>
+              <td>Class</td>
+              <td>The class for a resource primarily intended to be read</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h4 id="example-2">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 3</span><span style="text-transform: none">: Typing of Body and Target</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno3"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/video1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Video"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/website1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Text"</span>
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="segments-of-external-resources" typeof="bibo:Chapter" resource="#segments-of-external-resources" property="bibo:hasPart">
+        <h4 id="h-segments-of-external-resources" resource="#h-segments-of-external-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.3 </span>Segments of External Resources</span></h4>
+
+        <p>Many Annotations involve part of an External Web Resource, rather than its entirety. In the Web [<cite><a class="bibref" href="#bib-webarch">webarch</a></cite>], segments of resources are identified using <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRIs</a> with a fragment component that at the same time both describes how to extract the segment of interest from the resource, and identifies the extracted content. For simple Annotations, it is valuable to be able to use these IRIs with a fragment component as the identifier for either Body or Target.
+        </p>
+
+        <p><b>Example Use Case:</b> Dawn wants to describe a particular region of an image. She highlights that area in her client and types in the description. Her client then constructs an IRI with an appropriate fragment component as the target.</p>
+
+        <h4 id="model-3">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>id</td>
+              <td>Property</td>
+              <td>The IRI that identifies the Body or Target resource.
+                <br>Bodies or Targets which are External Web Resources <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>id</code> with the value of the resource's IRI, and that IRI <em class="rfc2119" title="MAY">MAY</em> have a fragment component.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note2"><span>Note</span></div>
+          <div class="">Note that other properties of resources such as <code>type</code>, <code>format</code> and <code>language</code>, plus those described in the <a href="#other-properties">Other Properties</a> section below, can be applied to the segment of the resource, just like for the full resource.</div>
+        </div>
+
+        <p>
+          It is important to be aware of the consequences of using an IRI with a fragment component, and the restrictions that using them places on implementations.
+
+        </p>
+        <ul>
+          <li>Fragments are defined with respect to individual media types. For example, HTML has a specific set of semantics regarding the meaning of the fragment part of the IRI.</li>
+          <li>Not every media type has a fragment specification. For example, Office documents might have a media-type and be published on the web, but not have semantics associated with the fragment part of the IRI.</li>
+          <li>Even if a media type does have a fragment definition, it is often not possible to describe the segment of interest sufficiently precisely. For example, fragments for HTML cannot be used to describe an arbitrary range of text.</li>
+          <li>It is not possible to determine with certainty what is being identified without knowing the media type, as the same fragment string might be possible in different specifications. For example, the same fragment string could identify either a rectangular area in an image, or a strangely named section of an HTML document.</li>
+          <li>IRIs with a fragment component are not compatible with other methods of describing the segment more specifically. For example, it is not possible to describe how to retrieve the correct representation, add style information, or associate a role with the resource, using such IRIs. The method to accomplish these requirements is described in the <a href="#fragment-selector">Fragment Selector</a> portion of the <a href="#specific-resources">Specific Resources</a> section.</li>
+          <li>As IRIs are considered to be opaque strings, annotation systems may not discover annotations with fragment components when searching by means of the IRI without the fragment. For example, an Annotation with the Target
+            <code>http://example.com/image.jpg#xywh=1,1,1,1</code> would not be discovered in a simple search for
+            <code>http://example.com/image.jpg</code>, even though it is part of it.</li>
+        </ul>
+
+        For more information regarding the use of IRIs with fragment components, please see the Best Practices for Fragment Identifiers and Media Type Definitions [<cite><a class="bibref" href="#bib-fragid-best-practices">fragid-best-practices</a></cite>].
+        <p></p>
+
+        <h4 id="example-3">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 4</span><span style="text-transform: none">: IRIs with Fragment Components</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno4"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/description1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/image1#xywh=100,100,300,300"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Image"</span></span>,
+    "<span class="hljs-attribute">format</span>": <span class="hljs-value"><span class="hljs-string">"image/jpeg"</span>
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="embedded-textual-body" typeof="bibo:Chapter" resource="#embedded-textual-body" property="bibo:hasPart">
+        <h4 id="h-embedded-textual-body" resource="#h-embedded-textual-body"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.4 </span>Embedded Textual Body</span></h4>
+
+        <p>In many situations, the body of the Annotation will be in a text format, and created at the same time as the Annotation and not have a separate IRI. In these cases, the Body's text can be included as part of the Annotation to avoid having to interact with multiple systems. The Body may also have the features of External Web Resources, including especially the language of the text and the format that it is conveyed in.</p>
+
+        <p><b>Example Use Case:</b> Emily writes a comment about how much she likes an image on a photo sharing website. Her client creates an Annotation with the comment embedded within it, and adds that it is in French and formatted using HTML.</p>
+
+        <h4 id="model-4">Model</h4> The fundamental features of a textual body are:
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>id</td>
+              <td>Property</td>
+              <td>The IRI that identifies the Textual Body
+                <br>The Body <em class="rfc2119" title="MAY">MAY</em> have exactly 1 IRI that identifies it.</td>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The type of the Textual Body resource.
+                <br>The Body <em class="rfc2119" title="SHOULD">SHOULD</em> have the <code>TextualBody</code> class, and <em class="rfc2119" title="MAY">MAY</em> have other classes.</td>
+            </tr>
+            <tr>
+              <td>TextualBody</td>
+              <td>Class</td>
+              <td>A class assigned to the Body for embedding textual resources within the Annotation.
+                <br>The Body <em class="rfc2119" title="SHOULD">SHOULD</em> have the <code>TextualBody</code> class.</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>Property</td>
+              <td>The character sequence of the content of the Textual Body.<br> There <em class="rfc2119" title="MUST">MUST</em> be exactly 1 <code>value</code> property associated with the TextualBody.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>Systems <em class="rfc2119" title="SHOULD">SHOULD</em> assume that Textual Bodies have the <code>Text</code> class, described in <a href="#classes">Classes</a> above, even if it is not explicitly included in the <code>type</code> property. </p>
+
+        <p>The properties of External Web Resources, such as <code>language</code> and <code>format</code> also apply to embedded Textual Body resources.</p>
+
+        <h4 id="example-4">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 5</span><span style="text-transform: none">: Textual Body</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno5"</span></span>,
+  "<span class="hljs-attribute">type</span>":<span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>" : <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>" : <span class="hljs-value"><span class="hljs-string">"&lt;p&gt;Comment text&lt;/p&gt;"</span></span>,
+    "<span class="hljs-attribute">format</span>" : <span class="hljs-value"><span class="hljs-string">"text/html"</span></span>,
+    "<span class="hljs-attribute">language</span>" : <span class="hljs-value"><span class="hljs-string">"en"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/photo1"</span>
+</span>}</pre></div>
+      </section>
+
+      <section id="string-body" typeof="bibo:Chapter" resource="#string-body" property="bibo:hasPart">
+        <h4 id="h-string-body" resource="#h-string-body"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.5 </span>String Body</span></h4>
+
+        <p>
+          The simplest type of Body is a plain text string, without additional information or properties. This type of body is useful for the simplest of Annotations only, and is <em class="rfc2119" title="NOT RECOMMENDED">NOT RECOMMENDED</em> for uses where the body may need to be referred to from outside of the Annotation.
+        </p>
+
+        <p><b>Example Use Case</b> Franceska wants to create a quick Annotation from a simple, command line client. She creates the JSON serialization in a text file and sends it to her Annotation server to maintain.</p>
+
+        <h4 id="model-5">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>bodyValue</td>
+              <td>Property</td>
+              <td>The string value of the body of the Annotation.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be exactly 1 <code>bodyValue</code> for an Annotation, and the value <em class="rfc2119" title="MUST">MUST</em> conform to the requirements below. If the <code>bodyValue</code> property is present, then the <code>body</code> relationship <em class="rfc2119" title="MUST NOT">MUST NOT</em> also be present.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>
+          There are several restrictions on when this form may be used and how it is to be interpreted.
+          <br>The string body:
+        </p>
+        <ul>
+          <li><em class="rfc2119" title="MUST">MUST</em> be a single <code>xsd:string</code> and the data type <em class="rfc2119" title="MUST NOT">MUST NOT</em> be expressed in the serialization.</li>
+          <li><em class="rfc2119" title="MUST NOT">MUST NOT</em> have a language associated with it.</li>
+          <li><em class="rfc2119" title="MUST">MUST</em> be interpreted as if it were the value of the <code>value</code> property of a Textual Body.</li>
+          <li><em class="rfc2119" title="MUST">MUST</em> be interpreted as if the Textual Body resource had a <code>format</code> property with the value <code>text/plain</code>.</li>
+          <li><em class="rfc2119" title="MUST NOT">MUST NOT</em> have the value of other properties of the Textual Body inferred from similar properties on the Annotation resource.</li>
+        </ul>
+        <p></p>
+
+        <p>If any of the interpretations above are not correct, then the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a> <em class="rfc2119" title="MUST">MUST</em> be used instead.</p>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note3"><span>Note</span></div>
+          <div class="">Systems <em class="rfc2119" title="MAY">MAY</em> rewrite Annotations to instead use the <a href="#embedded-textual-body"><code>TextualBody</code> construction</a>, rather than maintaining the <code>bodyValue</code> form. The <code>TextualBody</code> construction is preferred, as language and format information are important for clients processing the Annotation.</div>
+        </div>
+
+        <h4 id="example-5">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: String Body</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno6"</span></span>,
+  "<span class="hljs-attribute">type</span>":<span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">bodyValue</span>": <span class="hljs-value"><span class="hljs-string">"Comment text"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/target1"</span>
+</span>}</pre></div>
+
+        Which is equivalent to:
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: Equivalent Textual Body</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno7"</span></span>,
+  "<span class="hljs-attribute">type</span>":<span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"Comment text"</span></span>,
+    "<span class="hljs-attribute">format</span>": <span class="hljs-value"><span class="hljs-string">"text/plain"</span></span>,
+    "<span class="hljs-attribute">purpose</span>": <span class="hljs-value"><span class="hljs-string">"commenting"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/target1"</span>
+</span>}</pre></div>
+
+      </section>
+
+      <section id="cardinality-of-bodies-and-targets" typeof="bibo:Chapter" resource="#cardinality-of-bodies-and-targets" property="bibo:hasPart">
+        <h4 id="h-cardinality-of-bodies-and-targets" resource="#h-cardinality-of-bodies-and-targets"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.6 </span>Cardinality of Bodies and Targets</span></h4>
+
+        <p>Some Annotations may not have a Body at all, such as a simple highlight or bookmark without any accompanying text. It is also possible for an Annotation to have multiple Bodies and/or Targets. In this case, each Body is considered to be equally related to each Target individually, rather than to the set of all of the Targets.</p>
+
+        <p><b>Example Use Case:</b> Gretchen highlights a particular region of her ebook in green and, knowing what such a highlight means, she does not give a comment. Her client associates a stylesheet with the Annotation, and does not create a body at all.</p>
+
+        <p><b>Example Use Case:</b> Hannah associates a tag and a description with two images using a single annotation.</p>
+
+        <h4 id="model-6">Model</h4>
+
+        <p>The <code>body</code> relationship is omitted when there is no body for the Annotation.</p>
+        <p>The <code>body</code> and/or <code>target</code> relationships of the Annotation may be arrays rather than a single object. The values may be either strings containing the IRI of the resource or objects.</p>
+
+        <h4 id="example-6">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: Annotations without a Body</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno8"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/ebook1"</span>
+</span>}</pre></div>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: Multiple Bodies or Targets</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno9"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">[
+    <span class="hljs-string">"http://example.org/description1"</span>,
+    {
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"tag1"</span>
+    </span>}
+  ]</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">[
+    <span class="hljs-string">"http://example.org/image1"</span>,
+    <span class="hljs-string">"http://example.org/image2"</span>
+  ]
+</span>}</pre></div>
+      </section>
+
+      <section id="choice-of-bodies-and-targets" typeof="bibo:Chapter" resource="#choice-of-bodies-and-targets" property="bibo:hasPart">
+        <h4 id="h-choice-of-bodies-and-targets" resource="#h-choice-of-bodies-and-targets"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.7 </span>Choice of Bodies and Targets </span></h4>
+
+        <p>A Choice has an ordered list of resources from which an application should select only one to process or display. The order is given from the most preferable to least preferable, according to the Annotation's creator or publisher.</p>
+
+        <p><b>Example Use Case:</b> Irina writes up her discussion of a particular website in both French and English. As the two posts are equivalent, there is no need to display both, and instead she wants French speakers to see the French comment, and everyone else to see the English version. Her client creates as Choice with the English comment listed first.</p>
+
+        <h4 id="model-7">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>Choice</td>
+              <td>Class</td>
+              <td>A construction that conveys to a consuming application that it should select one of the listed resources to display to the user, and not render all of them.</td>
+            </tr>
+            <tr>
+              <td>items</td>
+              <td>Relationship</td>
+              <td>A list of resources to choose from, with the default option listed first.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note4"><span>Note</span></div>
+          <div class="">Clients <em class="rfc2119" title="MAY">MAY</em> use any algorithm to determine which resource to choose, and <em class="rfc2119" title="SHOULD">SHOULD</em> make use of the information present to do so automatically, but <em class="rfc2119" title="MAY">MAY</em> present a list and require the user to make the decision.</div>
+        </div>
+
+        <h4 id="example-7">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 10</span><span style="text-transform: none">: Choice</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno10"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Choice"</span></span>,
+    "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+      {
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/note1"</span></span>,
+        "<span class="hljs-attribute">language</span>": <span class="hljs-value"><span class="hljs-string">"en"</span>
+      </span>},
+      {
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/note2"</span></span>,
+        "<span class="hljs-attribute">language</span>": <span class="hljs-value"><span class="hljs-string">"fr"</span>
+      </span>}
+    ]
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/website1"</span>
+</span>}</pre></div>
+      </section>
+
+      <section id="sets-of-bodies-and-targets" typeof="bibo:Chapter" resource="#sets-of-bodies-and-targets" property="bibo:hasPart">
+        <h4 id="h-sets-of-bodies-and-targets" resource="#h-sets-of-bodies-and-targets"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.8 </span>Sets of Bodies and Targets</span></h4> While it is possible to annotate multiple targets, the meaning of that annotation is that each body applies independently to each of the targets. This might not be the intent of the annotator, such as when all of the targets are required for the annotation to be correctly understood. In order to allow annotators to capture these requirements, a new resource similar to Choice is used, either Composite (unordered) or List (ordered).
+
+        <p><b>Example Use Case:</b> Jane comments on a set of web pages as, together, providing evidence towards her research hypothesis. Her client creates a Composite, as there is no inherent order to the set of web pages.</p>
+
+        <p><b>Example Use Case:</b> Kelly tags a list of pages within a book as being important. As the pages have an order in the book, her client creates a List to maintain that order.</p>
+
+        <p><b>Example Use Case:</b> Lynda annotates a set of images to classify them as portraits. As the classification applies to each image independently, her client creates a Independents resource to group them.</p>
+
+        <h4 id="model-8">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>Composite</td>
+              <td>Class</td>
+              <td>A set of resources, all of which are required for the Annotation to be correctly interpreted.</td>
+            </tr>
+            <tr>
+              <td>List</td>
+              <td>Class</td>
+              <td>An ordered list of resources, all of which are required in order for the Annotation to be correctly interpreted.</td>
+            </tr>
+            <tr>
+              <td>Independents</td>
+              <td>Class</td>
+              <td>A set of resources, each of which is being annotated separately with the same interpretation as having multiple bodies or targets directly associated with the Annotation. </td>
+            </tr>
+            <tr>
+              <td>items</td>
+              <td>Relationship</td>
+              <td>The list of resources in the <code>Composite</code>, <code>List</code>, or <code>Independents</code>.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="warning">
+          <div class="warning-title marker"><span>Warning</span></div>
+          <div class="">These classes are marked At-Risk, pending implementation experience.</div>
+        </div>
+
+        <h4 id="example-8">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 11</span><span style="text-transform: none">: Composite</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno11"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">motivation</span>": <span class="hljs-value"><span class="hljs-string">"commenting"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"These pages together provide evidence of the conspiracy"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Composite"</span></span>,
+    "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+      <span class="hljs-string">"http://example.com/page1"</span>,
+      <span class="hljs-string">"http://example.org/page6"</span>,
+      <span class="hljs-string">"http://example.net/page4"</span>
+    ]
+  </span>}
+</span>}</pre></div>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 12</span><span style="text-transform: none">: List</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno12"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">motivation</span>": <span class="hljs-value"><span class="hljs-string">"tagging"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"important"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"List"</span></span>,
+    "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+      <span class="hljs-string">"http://example.com/book/page1"</span>,
+      <span class="hljs-string">"http://example.com/book/page2"</span>,
+      <span class="hljs-string">"http://example.com/book/page3"</span>,
+      <span class="hljs-string">"http://example.com/book/page4"</span>
+    ]
+  </span>}
+</span>}</pre></div>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 13</span><span style="text-transform: none">: Independents</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno13"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">motivation</span>": <span class="hljs-value"><span class="hljs-string">"classifying"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/vocab/art/portrait"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Independents"</span></span>,
+    "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+      <span class="hljs-string">"http://example.com/image1"</span>,
+      <span class="hljs-string">"http://example.net/image2"</span>,
+      <span class="hljs-string">"http://example.com/image4"</span>,
+      <span class="hljs-string">"http://example.org/image9"</span>
+    ]
+  </span>}
+</span>}</pre></div>
 
 
-  <h2 id="changes-from-the-open-annotation-draft">Changes from the Open Annotation Draft</h2>
+      </section>
 
-<p>
-Significant technical changes in this specification from the Open Annotation Community Group's draft are:
-</p><ul>
-  <li>Use intuitive, memorable and developer-friendly names for the JSON-LD keys. (<a href="#annotations">text</a>)</li>
-<li>Replace the ContentAsText construction which was not taken through the standardization process. (<a href="#embedded-textual-body">text</a>)</li>
-<li>Allow a string literal as the body via bodyText. (<a href="#string-body">text</a>)</li>
-<li>Allow an ordered list of options for Choice. (<a href="#choice-of-bodies-and-targets">text</a>)
-</li><li>Add additional core lifecycle metadata for resources, including <a href="#rights-information">rights information</a> and <a href="#intended-audience">intended audience</a>. (<a href="#lifecycle-information">text</a>)</li>
-<li>Align identity equivalence with other standards. (<a href="#other-identities">text</a>)</li>
-<li>Allow association of Motivation as roles/purposes on a per body or target basis, including alignment of Tags and Semantic Tags. (<a href="#purpose-for-external-web-resources">text</a>)</li>
-<li>Introduce <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a> and <a href="#range-selector">Range Selector</a> from implementation experience. </li>
-<li>Use structure rather than resources for multiple specificiers. (<a href="#refinement-of-selection">text</a>)</li>
-<li>Add the capability to describe rendering software. (<a href="#rendering-software">text</a>)</li>
-<li>Add <a href="#annotation-collection">Collections of Annotations</a> as a defined pattern.</li>
-<li>Separate the ontology [<cite><a href="#bib-annotation-vocab" class="bibref">annotation-vocab</a></cite>] from the model and JSON serialization.</li>
-<li>Deprecate embedded graphs as an explicit part of the model, instead just include or reference a serialized graph.</li>
-</ul>
-<p></p>
+    </section>
+    <!-- Bodies and Targets -->
 
-</section>
+    <section id="other-properties" typeof="bibo:Chapter" resource="#other-properties" property="bibo:hasPart">
+
+      <h3 id="h-other-properties" resource="#h-other-properties"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3 </span>Other Properties</span></h3> It is often important to have information about the context in which the Annotation and any External Web Resources were created, modified and used. In particular,
+
+      <ul>
+        <li>When was the resource created, modified or generated</li>
+        <li>Who created, modified or generated the serialized form of the Annotation or other resource, and who is it intended for</li>
+        <li>Why was the resource included in the annotation, or the annotation created</li>
+        <li>What other identities the resource has</li>
+        <li>How can the resource be used, according to its rights and licensing</li>
+      </ul>
+
+      <div class="note">
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note5"><span>Note</span></div>
+        <div class="">
+          Beyond the features described in this section, other properties <em class="rfc2119" title="MAY">MAY</em> be added features of the Annotation or any resource in the model. Please see the Extension section of [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>] for more information about how to do this.</div>
+      </div>
+
+      <section id="lifecycle-information" typeof="bibo:Chapter" resource="#lifecycle-information" property="bibo:hasPart">
+        <h4 id="h-lifecycle-information" resource="#h-lifecycle-information"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.1 </span>Lifecycle Information</span></h4>
+
+        <p>
+          The person, organization or machine responsible for the Annotation or referenced resource deserves credit for their contribution, and the time at which those resources are created is useful for display ordering and filtering out old, potentially irrelevant content. The creator of the Annotation is also useful for determining the trustworthiness of the Annotation. The software used to create and serialize the Annotation, along with when that activity occurred, is useful for both advertising and debugging issues.
+        </p>
+
+        <p><b>Example Use Case:</b> Megan writes a review of a restaurant online, and wishes to be associated with that review so that her friends know that it was her review and can trust it. Her client adds her account's identity, and its own identity, to the Annotation and the appropriate timestamps for when the resources were created.</p>
+
+        <h4 id="model-9">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+
+            <tr>
+              <td>creator</td>
+              <td>Relationship</td>
+              <td>The agent responsible for creating the Annotation, Body or Target. This may be either a human, an organization or a software agent.
+                <br>There <em class="rfc2119" title="SHOULD">SHOULD</em> be exactly 1 <code>creator</code> relationship per resource, but <em class="rfc2119" title="MAY">MAY</em> be 0 or more than 1, as the resource's creator may wish to remain anonymous, or multiple agents may have worked together on it.</td>
+            </tr>
+            <tr>
+              <td>created</td>
+              <td>Property</td>
+              <td>The time at which the Annotation, Body or Target was created.
+                <br>There <em class="rfc2119" title="SHOULD">SHOULD</em> be exactly 1 <code>created</code> property per resource, and <em class="rfc2119" title="MUST NOT">MUST NOT</em> be more than 1. The datetime <em class="rfc2119" title="MUST">MUST</em> be a <a href="http://www.w3.org/TR/xmlschema-2/#dateTime">xsd:dateTime</a> with the UTC timezone expressed as "Z".</td>
+            </tr>
+            <tr>
+              <td>generator</td>
+              <td>Relationship</td>
+              <td>The agent responsible for generating the serialization of the Annotation.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>generator</code> relationships per Annotation</td>
+            </tr>
+            <tr>
+              <td>generated</td>
+              <td>Property</td>
+              <td>The time at which the Annotation serialization was generated.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be exactly 1 <code>generated</code> property per Annotation, and <em class="rfc2119" title="MUST NOT">MUST NOT</em> be more than 1. The datetime <em class="rfc2119" title="MUST">MUST</em> be a <a href="http://www.w3.org/TR/xmlschema-2/#dateTime">xsd:dateTime</a> with the UTC timezone expressed as "Z".</td>
+            </tr>
+            <tr>
+              <td>modified</td>
+              <td>Property</td>
+              <td>The time at which the Annotation, Body or Target was modified, after creation.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be exactly 1 <code>modified</code> property per resource, and <em class="rfc2119" title="MUST NOT">MUST NOT</em> be more than 1. The datetime <em class="rfc2119" title="MUST">MUST</em> be a <a href="http://www.w3.org/TR/xmlschema-2/#dateTime">xsd:dateTime</a> with the UTC timezone expressed as "Z".</td>
+            </tr>
+          </tbody>
+        </table>
+
+
+        <h4 id="example-9">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 14</span><span style="text-transform: none">: Lifecycle Information</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno14"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">creator</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/user1"</span></span>,
+  "<span class="hljs-attribute">created</span>": <span class="hljs-value"><span class="hljs-string">"2015-01-28T12:00:00Z"</span></span>,
+  "<span class="hljs-attribute">modified</span>": <span class="hljs-value"><span class="hljs-string">"2015-01-29T09:00:00Z"</span></span>,
+  "<span class="hljs-attribute">generator</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/client1"</span></span>,
+  "<span class="hljs-attribute">generated</span>": <span class="hljs-value"><span class="hljs-string">"2015-02-04T12:00:00Z"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/review1"</span></span>,
+    "<span class="hljs-attribute">creator</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/user2"</span></span>,
+    "<span class="hljs-attribute">created</span>": <span class="hljs-value"><span class="hljs-string">"2014-06-02T17:00:00Z"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/restaurant1"</span>
+</span>}</pre></div>
+      </section>
+
+      <section id="agents" typeof="bibo:Chapter" resource="#agents" property="bibo:hasPart">
+        <h4 id="h-agents" resource="#h-agents"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.2 </span>Agents</span></h4>
+
+        <p>
+          More information about the agents involved in the creation of an Annotation is normally required beyond an IRI that identifies them. This includes whether they are an individual, a group or a piece of software and properties such as real name, account name, and email address.
+        </p>
+
+        <p><b>Example Use Case:</b> Noelle wants to submit an Annotation to a system that does not manage her identity, and would like a pseudonym to be displayed. Her client adds this information to the Annotation to send to the service.</p>
+
+        <h4 id="model-10">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>id</td>
+              <td>Property</td>
+              <td>The IRI that identifies the agent
+                <br>An Agent <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 IRI that identifies it, and <em class="rfc2119" title="MUST NOT">MUST NOT</em> have more than 1.</td>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The type of the Agent.
+                <br>An Agent <em class="rfc2119" title="SHOULD">SHOULD</em> have 1 or more classes, from those listed below.</td>
+            </tr>
+            <tr>
+              <td>Person</td>
+              <td>Class</td>
+              <td>The class for a human agent</td>
+            </tr>
+            <tr>
+              <td>Organization</td>
+              <td>Class</td>
+              <td>The class for an organization, as opposed to an individual.</td>
+            </tr>
+            <tr>
+              <td>Software</td>
+              <td>Class</td>
+              <td>The class for a software agent, such as a user's client or a machine learning system that creates Annotations.</td>
+            </tr>
+            <tr>
+              <td>name</td>
+              <td>Property</td>
+              <td>The name of the agent.
+                <br>Each agent <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 <code>name</code> property, and <em class="rfc2119" title="MAY">MAY</em> have 0 or more.</td>
+            </tr>
+            <tr>
+              <td>account</td>
+              <td>Property</td>
+              <td>The account name of the agent.
+                <br>Each agent <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 <code>account</code> property, and <em class="rfc2119" title="MAY">MAY</em> have 0.</td>
+            </tr>
+            <tr>
+              <td>email</td>
+              <td>Relationship</td>
+              <td>The email address associated with the agent, using the mailto: IRI scheme [<cite><a class="bibref" href="#bib-rfc6086">rfc6086</a></cite>].
+                <br>Each agent <em class="rfc2119" title="MAY">MAY</em> have 1 or more <code>email</code> addresses</td>
+            </tr>
+            <tr>
+              <td>email_sha1</td>
+              <td>Property</td>
+              <td>The text representation of the result of applying the sha1 algorithm to the email IRI of the agent, including the 'mailto:' prefix and no whitespace. This allows the mail address to be used as an identifier without publishing the address publicly.<br> Each agent <em class="rfc2119" title="MAY">MAY</em> have 1 or more values in the <code>email_sha1</code> property.</td>
+            </tr>
+            <tr>
+              <td>homepage</td>
+              <td>Relationship</td>
+              <td>The home page for the agent.<br>Each agent <em class="rfc2119" title="MAY">MAY</em> have 1 or more home pages.</td>
+            </tr>
+
+          </tbody>
+        </table>
+
+        <h4 id="example-10">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 15</span><span style="text-transform: none">: Agents</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno15"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">creator</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/user1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Person"</span></span>,
+    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"My Pseudonym"</span></span>,
+    "<span class="hljs-attribute">account</span>": <span class="hljs-value"><span class="hljs-string">"pseudo"</span></span>,
+    "<span class="hljs-attribute">email_sha1</span>": <span class="hljs-value"><span class="hljs-string">"58bad08927902ff9307b621c54716dcc5083e339"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">generator</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/client1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"SoftwareAgent"</span></span>,
+    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"Code v2.1"</span></span>,
+    "<span class="hljs-attribute">homepage</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/client1/homepage1"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/review1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/restaurant1"</span>
+</span>}</pre></div>
+      </section>
+
+      <section id="intended-audience" typeof="bibo:Chapter" resource="#intended-audience" property="bibo:hasPart">
+        <h4 id="h-intended-audience" resource="#h-intended-audience"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.3 </span>Intended Audience</span></h4>
+
+        <p>Beyond the agents that are associated with the creation and management of the Annotation and other resources, it is also useful to know the audience or class of consuming agent that the resource is intended for. This allows for roles (such as teacher versus student) or properties of the class (such as a suggested age range). </p>
+
+        <p><b>Example Use Case:</b> Ophelia writes some notes about using a particular textbook to teach a class. She adds that the intended audience of the Annotation is teachers (who are using the textbook), to distinguish from other Annotations that might have an audience of the students (who are also using the textbook, but to learn from).</p>
+
+        <h4 id="model-11">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>id</td>
+              <td>Property</td>
+              <td>The IRI that identifies the Audience.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be exactly 1 IRI given that identifies the Audience.</td>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The type of the Audience, from the schema.org class structure.<br>The Audience <em class="rfc2119" title="SHOULD">SHOULD</em> have 1 or more <code>type</code>s and they <code><em class="rfc2119" title="SHOULD">SHOULD</em></code> come from the schema.org class structure.</td>
+            </tr>
+            <tr>
+              <td>audience</td>
+              <td>Relationship</td>
+              <td>The relationship between an Annotation and its intended Audience.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more Audiences for each Annotation.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>Further properties that describe the audience are used from <a href="http://schema.org/Audience">schema.org's Audience</a> classes. The properties and class names <em class="rfc2119" title="MUST">MUST</em> be prefixed in the JSON with <code>schema:</code> to ensure that they are uniquely distinguished from any other properties or classes.</p>
+
+        <p>
+          The use of <code>audience</code> does not imply nor enable any access restriction to prevent the annotation from being seen. Systems <em class="rfc2119" title="SHOULD">SHOULD</em> use the information for filtering the display of Annotations based on their knowledge of the user, and not assume that the Annotation or other resources will require authentication and authorization.
+        </p>
+
+        <h4 id="example-11">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 16</span><span style="text-transform: none">: Audience</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno16"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">audience</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.edu/roles/teacher"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"schema:EducationalAudience"</span></span>,
+    "<span class="hljs-attribute">schema:educationalRole</span>": <span class="hljs-value"><span class="hljs-string">"teacher"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/classnotes1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/textbook1"</span>
+</span>}</pre></div>
+      </section>
+
+      <section id="accessibility-of-content" typeof="bibo:Chapter" resource="#accessibility-of-content" property="bibo:hasPart">
+        <h4 id="h-accessibility-of-content" resource="#h-accessibility-of-content"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.4 </span>Accessibility of Content</span></h4>
+
+        <p>Access to information is recognized as a basic human right by the United Nations. The Web is able to remove barriers to communication and interaction regardless of various physical impediments. This support social inclusion, but also increases the potential audience of the information. For resources that are used as the body or target of an Annotation, it is valuable to record the features of that resource that provide easier access for users with various and diverse ranges of ability.</p>
+
+        <p><b>Example Use Case:</b> Petra has very limited ability to hear sound, and prefers to read captions when interacting with videos. She uses her annotation client to make a comment on such a video, and to help others in the same situation, the client includes that the video has this accessibility feature.</p>
+
+        <h4 id="model-12">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>accessibility</td>
+              <td>Property</td>
+              <td>One or more strings from an enumerated list of values that each describes an accessibility feature that the resource has.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more accessibility features listed for each Body or Target resource.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note6"><span>Note</span></div>
+          <p class="">
+            The current list of values is referenced from the <a href="http://schema.org/accessibilityFeature">schema.org description</a> of the <code>accessibilityFeature</code> property.
+          </p>
+        </div>
+
+        <h4 id="example-12">Example</h4>
+        <div class="example">
+          <div class="example-title marker"><span>Example 17</span><span style="text-transform: none">: Accessibility</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno17"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">motivation</span>": <span class="hljs-value"><span class="hljs-string">"commenting"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/comment1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/video1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Video"</span></span>,
+    "<span class="hljs-attribute">accessibility</span>": <span class="hljs-value"><span class="hljs-string">"captions"</span>
+  </span>}
+</span>}</pre></div>
+      </section>
+
+
+      <section id="motivation-and-purpose" typeof="bibo:Chapter" resource="#motivation-and-purpose" property="bibo:hasPart">
+        <h4 id="h-motivation-and-purpose" resource="#h-motivation-and-purpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.5 </span>Motivation and Purpose</span></h4>
+
+        <p>In many cases it is important to understand the reasons why the Annotation was created, or why the Textual Body was included in the Annotation, not just the times and agents involved. These reasons are provided by declaring the motivation for the Annotation's creation or the purpose for the inclusion of the Body in the Annotation; the "why" rather than the "who" and "when" described in the previous sections.</p>
+
+        <p><b>Example Use Case:</b> Qitara annotates a resource intending to bookmark it for future reference, and provides a description and a tag to make it easier to find again. Her client adds the right motivations to the Annotation and the Body resources to capture this.</p>
+
+        <h4 id="model-13">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>motivation</td>
+              <td>Relationship</td>
+              <td>The relationship between an Annotation and a Motivation.
+                <br>There <em class="rfc2119" title="SHOULD">SHOULD</em> be exactly 1 <code>motivation</code> for each Annotation, and <em class="rfc2119" title="MAY">MAY</em> be 0 or more than 1.</td>
+            </tr>
+            <tr>
+              <td>purpose</td>
+              <td>Relationship</td>
+              <td>The reason for the inclusion of the Textual Body within the Annotation.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>purpose</code>s associated with a <code>TextualBody</code>.</td>
+            </tr>
+
+            <tr>
+              <td>Motivation</td>
+              <td>Class</td>
+              <td>The Motivation for an Annotation is a reason for its creation, and might include things like Replying to another annotation, Commenting on a resource, or Linking to a related resource. </td>
+            </tr>
+            <tr>
+              <th colspan="3"><strong>Motivations</strong></th>
+            </tr>
+            <tr>
+              <td>bookmarking</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to create a bookmark to the Target or part thereof. For example an Annotation that bookmarks the point in a text where the reader finished reading.</td>
+            </tr>
+            <tr>
+              <td>classifying</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to that classify the Target as something. For example to classify an image as a portrait.</td>
+            </tr>
+            <tr>
+              <td>commenting</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to comment about the Target. For example to provide a commentary about a particular PDF document.</td>
+            </tr>
+            <tr>
+              <td>describing</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to describe the Target, as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy.</td>
+            </tr>
+            <tr>
+              <td>editing</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to request a change or edit to the Target resource. For example an Annotation that requests a typo to be corrected. </td>
+            </tr>
+            <tr>
+              <td>highlighting</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to highlight the Target resource or segment of it. For example to draw attention to the selected text that the annotator disagrees with.</td>
+            </tr>
+            <tr>
+              <td>identifying</td>
+              <td>Instance</td>
+              <td>The motivation for when the user intends to assign an identity to the Target. For example to associate the IRI that identifies a city with a mention of the city in a web page.</td>
+            </tr>
+            <tr>
+              <td>linking</td>
+              <td>Instance</td>
+              <td>The motivation for when the user intends to link to a resource related to the Target.</td>
+            </tr>
+            <tr>
+              <td>moderating</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to assign some value or quality to the Target. For example annotating an Annotation to moderate it up in a trust network or threaded discussion.</td>
+            </tr>
+            <tr>
+              <td>questioning</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to ask a question about the Target. For example to ask for assistance with a particular section of text, or question its veracity.</td>
+            </tr>
+            <tr>
+              <td>replying</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above.</td>
+            </tr>
+            <tr>
+              <td>reviewing</td>
+              <td>Instance</td>
+              <td> The motivation for when the user intends to review the Target in some assessing fashion, rather than simply make a comment about it. For example to write a review of a Book.</td>
+            </tr>
+            <tr>
+              <td>tagging</td>
+              <td>Instance </td>
+              <td> The motivation for when the user intends to associate a tag with the Target.</td>
+            </tr>
+
+          </tbody>
+        </table>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note7"><span>Note</span></div>
+          <div class="">
+            For more information about how Motivations can be inter-related and new Motivations created, please see the Annotation Vocabulary document [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>].
+          </div>
+        </div>
+
+        <h4 id="example-13">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 18</span><span style="text-transform: none">: Motivation and Purpose</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno18"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">motivation</span>": <span class="hljs-value"><span class="hljs-string">"bookmarking"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">[
+    {
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"readme"</span></span>,
+      "<span class="hljs-attribute">purpose</span>": <span class="hljs-value"><span class="hljs-string">"tagging"</span>
+    </span>},
+    {
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"A good description of the topic that bears further investigation"</span></span>,
+      "<span class="hljs-attribute">purpose</span>": <span class="hljs-value"><span class="hljs-string">"describing"</span>
+    </span>}
+  ]</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/page1"</span>
+</span>}</pre></div>
+      </section>
+
+      <section id="rights-information" typeof="bibo:Chapter" resource="#rights-information" property="bibo:hasPart">
+        <h4 id="h-rights-information" resource="#h-rights-information"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.6 </span>Rights Information</span></h4>
+
+        <p>It is common practice to associate a licence or rights statement with a resource, in order to describe the conditions under which it may be used. This allows the user to make appropriate use of the resource, as well as allowing some automated systems to confirm that the usage is permitted.</p>
+
+        <p><b>Example Use Case:</b> Ramona writes a review of a product and wishes to be known as the author of the review, however does not mind how the Annotation that relates the review and the product together is used. She asserts these two separate rights statements with the Annotation and Body individually.</p>
+
+        <h4 id="model-14">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>rights</td>
+              <td>Relationship</td>
+              <td>The relationship between an Annotation, Body or Target and a web resource that contains the rights statement or license under which the resource may be used.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be at exactly 0 or more <code>rights</code> statements or licenses linked from each resource, and the value <em class="rfc2119" title="MUST">MUST</em> be an IRI.</td>
+            </tr>
+
+          </tbody>
+        </table>
+
+        <h4 id="example-14">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 19</span><span style="text-transform: none">: Rights</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno19"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/review1"</span></span>,
+    "<span class="hljs-attribute">rights</span>": <span class="hljs-value"><span class="hljs-string">"http://creativecommons.org/licenses/by/4.0/"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/product1"</span>
+</span>}</pre></div>
+      </section>
+
+      <section id="other-identities" typeof="bibo:Chapter" resource="#other-identities" property="bibo:hasPart">
+        <h4 id="h-other-identities" resource="#h-other-identities"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.7 </span>Other Identities</span></h4>
+
+        <p>In a massively distributed system such as the Web, information is often copied. In order to track the provenance of the Annotation and other related resources, it is possible to record additional IRIs that also identify the resource. These may be dereferencable "permalinks", identities assigned by a client offline without any knowledge of the web, or simply the location where the current harvesting system discovered the resource.</p>
+
+        <p><b>Example Use Case:</b> Sally creates an Annotation and sends it to multiple systems to maintain, one personal and one public. She wants to ensure that the copies can be aligned, and so she sets a UUID as the canonical IRI, allowing the service to assign an HTTP IRI for it. A subsequent system then harvests the public copy, maintaining the canonical UUID and moves the assigned HTTP IRI to <code>via</code>, replacing the <code>id</code> field with its own IRI. </p>
+
+        <h4 id="model-15">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>canonical</td>
+              <td>Relationship</td>
+              <td>The relationship between an Annotation, Body or Target and the IRI that <em class="rfc2119" title="SHOULD">SHOULD</em> be used to track its identity, regardless of where it is made accessible. If this property is set, then systems <em class="rfc2119" title="MUST NOT">MUST NOT</em> change or delete it. Systems <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> assign a canonical IRI without prior agreement if one is not present, as the Annotation could already have a canonical IRI elsewhere.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be exactly 1 <code>canonical</code> IRI for each resource.</td>
+            </tr>
+            <tr>
+              <td>via</td>
+              <td>Relationship</td>
+              <td>The relationship between an Annotation, Body or Target and the IRI of where that resource was obtained from by the system that is making it available.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more IRIs provided in <code>via</code> for each resource.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h4 id="example-15">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 20</span><span style="text-transform: none">: Other Identities</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno20"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">canonical</span>": <span class="hljs-value"><span class="hljs-string">"urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df"</span></span>,
+  "<span class="hljs-attribute">via</span>": <span class="hljs-value"><span class="hljs-string">"http://other.example.org/anno1"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/review1"</span></span>,
+    "<span class="hljs-attribute">rights</span>": <span class="hljs-value"><span class="hljs-string">"http://creativecommons.org/licenses/by/4.0/"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/product1"</span>
+</span>}</pre></div>
+      </section>
+
+
+    </section>
+
+  </section>
+  <!-- /Metadata -->
+  <!-- /Annotation -->
+
+  <section id="specific-resources" typeof="bibo:Chapter" resource="#specific-resources" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-specific-resources" resource="#h-specific-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Specific Resources</span></h2>
+
+    <p>
+      While it is possible using only the constructions described above to create Annotations that reference parts of resources by using IRIs with a fragment component, there are many situations when this is not sufficient. For example, even a simple circular region of an image, or a diagonal line across it, are not possible. Selecting an arbitrary span of text in an HTML page, perhaps the simplest annotation concept, is also not supported by fragments. Furthermore, there are non-segment use cases that require a client to retrieve a specific state or representation of the resource, to style it in a particular way, to associate a role with the resource that is specific to the Annotation's use of it, or for the Annotation to only apply when the resource is used in a particular context.
+    </p>
+
+    <p>The Web Annotation Data Model uses a new type of resource to capture these Annotation-specific requirements: a SpecificResource. The SpecificResource is used in between the Annotation and the Body or Target, as appropriate, to capture additional information about how it is used in the Annotation. The descriptions are typically referenced from the SpecificResource as separate entities and can be of various types to capture the different requirements. For example, if the Target of the Annotation is a circular region of an image, then the SpecificResource is the circular region, it is described by a Selector, and is also associated with the source Image resource.</p>
+
+    <p>Specific Resources and Specifiers <em class="rfc2119" title="MAY">MAY</em> be External Web Resources with their own IRIs, such as in the example for the <a href="#selectors">Selector</a> construction, however it is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that they be included in the Annotation's representation to avoid requiring unnecessary network interactions to retrieve all of the information needed to process the Annotation.</p>
+
+    <p>
+      The types of additional specificity that are defined by this document:
+
+    </p>
+    <ul>
+      <li><a href="#purpose-for-external-web-resources">Purpose:</a> Describe the purpose of including the source resource in the Annotation</li>
+      <li><a href="#selectors">Selector:</a> Describe the desired segment of the source resource for the Annotation</li>
+      <li><a href="#states">State:</a> Describe the desired representation of the source resource for the Annotation</li>
+      <li><a href="#styles">Style:</a> Describe the style in which the source resource should be presented for the Annotation</li>
+      <li><a href="#rendering-software">Rendering:</a> Describe the system used by the client for rendering the resource when the annotation was created</li>
+      <li><a href="#scope-of-a-resource">Scope:</a> Describe the scope in which the source resource applies for the Annotation</li>
+    </ul>
+    <p></p>
+
+    <h2 id="model-16">Model</h2>
+
+    <table class="model">
+      <tbody>
+        <tr>
+          <th>Term</th>
+          <th>Type</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td>id</td>
+          <td>Property</td>
+          <td>The identity of the Specific Resource
+            <br>A Specific Resource <em class="rfc2119" title="MAY">MAY</em> have exactly 1 IRI that identifies it.</td>
+        </tr>
+        <tr>
+          <td>type</td>
+          <td>Relationship</td>
+          <td>The class of the Specific Resource
+            <br>The Specific Resource <em class="rfc2119" title="SHOULD">SHOULD</em> have the <code>SpecificResource</code> class.</td>
+        </tr>
+        <tr>
+          <td>SpecificResource</td>
+          <td>Class</td>
+          <td>The class for Specific Resources
+            <br>The <code>SpecificResource</code> class <em class="rfc2119" title="SHOULD">SHOULD</em> be associated with a Specific Resource to be clear as to its role as a more specific region or state of another resource.</td>
+        </tr>
+        <tr>
+          <td>source</td>
+          <td>Relationship</td>
+          <td>The relationship between a Specific Resource and the resource that it is a more specific representation of.
+            <br>There <em class="rfc2119" title="MUST">MUST</em> be exactly 1 <code>source</code> relationship associated with a Specific Resource. The source resource <em class="rfc2119" title="MAY">MAY</em> be described in detail as in the core data model or be just the resource's IRI.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>The same Specific Resource and Specifier classes are used for both Target and Body. The examples in this section only use one of these, however the same model applies for both.</p>
+
+    <section id="purpose-for-external-web-resources" typeof="bibo:Chapter" resource="#purpose-for-external-web-resources" property="bibo:hasPart">
+      <h3 id="h-purpose-for-external-web-resources" resource="#h-purpose-for-external-web-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Purpose for External Web Resources</span></h3>
+
+      <p>As well as Textual Bodies, External Web Resources may also be given a Motivation as to their inclusion within the Annotation. This is done using the Specific Resource pattern, as the purpose specifies the way in which the resource is used in the context of the Annotation in the same way as a Selector describes the segment or a State describes the representation.</p>
+
+      <p><b>Example Use Case:</b> Teynika wants to tag a photo with an identifier for a city, rather than just type the city's name which could be ambiguous. Her client uses a well-known IRI for the city having done a search for it, and creates a Specific Resource to manage that purpose assignment.</p>
+
+
+      <h3 id="model-17">Model</h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>purpose</td>
+            <td>Relationship</td>
+            <td>The reason for including the Web Resource in the Annotation.
+              <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more Motivations associated with the SpecificResource using <code>purpose</code>.</td>
+          </tr>
+        </tbody>
+      </table>
+
+
+      <h3 id="example-16">Example</h3>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 21</span><span style="text-transform: none">: Resource with Purpose</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno21"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"SpecificResource"</span></span>,
+    "<span class="hljs-attribute">purpose</span>": <span class="hljs-value"><span class="hljs-string">"tagging"</span></span>,
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/city1"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/photo1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Image"</span>
+  </span>}
+</span>}</pre></div>
+    </section>
+
+    <section id="selectors" typeof="bibo:Chapter" resource="#selectors" property="bibo:hasPart">
+      <h3 id="h-selectors" resource="#h-selectors"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Selectors</span></h3>
+
+      <p>Many Annotations refer to part of a resource, rather than all of it, as the Target. We call that part of the resource a Segment (of Interest). A Selector is used to describe how to determine the Segment from within the Source resource. The nature of the Selector will be dependent on the type of resource, as the methods to describe Segments from various media-types will differ.</p>
+
+      <p><b>Example Use Case:</b> Ulrika wants to associate a selection of text in a web page, with a slice of a dataset. She selects both using her client, and creates the Annotation with a SpecificResource that has a Selector for each of the Body and the Target.</p>
+
+      <h3 id="model-18">Model</h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>selector</td>
+            <td>Relationship</td>
+            <td>The relationship between a Specific Resource and a Selector.
+              <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>selector</code> relationships associated with a Specific Resource.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3 id="example-17">Example</h3>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 22</span><span style="text-transform: none">: Selectors</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno22"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/paraselector1"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/dataset1"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/dataselector1"</span>
+  </span>}
+</span>}</pre></div>
+
+      <section id="fragment-selector" typeof="bibo:Chapter" resource="#fragment-selector" property="bibo:hasPart">
+        <h4 id="h-fragment-selector" resource="#h-fragment-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.1 </span>Fragment Selector</span></h4>
+
+        <p>As the most well understood mechanism for selecting a Segment is to use the fragment part of an IRI defined by the representation's media type, it is useful to allow this as a description mechanism via a Selector. This allows existing and future fragment specifications to be used with Specific Resources in a consistent way. To be clear about which fragment type is being used, the Selector may refer to the specification that defines it.</p>
+
+        <p><b>Example Use Case:</b> Valeria wants to associate part of a video as the description of an image. She selects the time range within the video and clicks that it is describing the target. Her client then creates the Annotation using a SpecificResource with a FragmentSelector and the <code>describing</code> Motivation. </p>
+
+
+        <h4 id="model-19">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the Selector.<br>FragmentSelectors <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>FragmentSelector</code>.</td>
+            </tr>
+            <tr>
+              <td>FragmentSelector</td>
+              <td>Class</td>
+              <td>A resource which describes the Segment through the use of the fragment component of an IRI.</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>Property</td>
+              <td>The contents of the fragment component of an IRI that describes the Segment.<br> The FragmentSelector <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>value</code> property.</td>
+            </tr>
+            <tr>
+              <td>conformsTo</td>
+              <td>Relationship</td>
+              <td>The relationship between the FragmentSelector and the specification that defines the syntax of the IRI fragment in the <code>value</code> property.
+                <br>The Fragment Selector <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 <code>conformsTo</code> link to the specification that defines the syntax of the fragment and <em class="rfc2119" title="MUST NOT">MUST NOT</em> have more than 1.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to use <code>FragmentSelector</code> as a consistent method compatible with other means of describing SpecificResources, rather than using the IRI with a fragment directly. Consuming applications <em class="rfc2119" title="SHOULD">SHOULD</em> be aware of both.</p>
+
+        <p class="informative">
+          The following IRIs are some of the specifications that define the semantics of fragments, and hence may be used with the <code>conformsTo</code> relationship. Other IRIs <em class="rfc2119" title="MAY">MAY</em> also be used.
+        </p>
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Name</th>
+              <th>Fragment Specification</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>HTML</td>
+              <td>http://tools.ietf.org/rfc/rfc3236</td>
+              <td>[<cite><a class="bibref" href="#bib-rfc3236">rfc3236</a></cite>] Example: <code>namedSection</code> </td>
+            </tr>
+            <tr>
+              <td>PDF</td>
+              <td>http://tools.ietf.org/rfc/rfc3778</td>
+              <td>[<cite><a class="bibref" href="#bib-rfc3778">rfc3778</a></cite>] Example: <code>page=10&amp;viewrect=50,50,640,480</code></td>
+            </tr>
+            <tr>
+              <td>Plain Text</td>
+              <td>http://tools.ietf.org/rfc/rfc5147</td>
+              <td>[<cite><a class="bibref" href="#bib-rfc5147">rfc5147</a></cite>] Example: <code>char=0,10</code></td>
+            </tr>
+            <tr>
+              <td>XML</td>
+              <td>http://tools.ietf.org/rfc/rfc3023</td>
+              <td>[<cite><a class="bibref" href="#bib-rfc3023">rfc3023</a></cite>] Example: <code>xpointer(/a/b/c)</code></td>
+            </tr>
+            <tr>
+              <td>RDF/XML</td>
+              <td>http://tools.ietf.org/rfc/rfc3870</td>
+              <td>[<cite><a class="bibref" href="#bib-rfc3870">rfc3870</a></cite>] Example: <code>namedResource</code></td>
+            </tr>
+            <tr>
+              <td>CSV</td>
+              <td>http://tools.ietf.org/rfc/rfc7111</td>
+              <td>[<cite><a class="bibref" href="#bib-rfc7111">rfc7111</a></cite>] Example: <code>row=5-7</code></td>
+            </tr>
+            <tr>
+              <td>Media</td>
+              <td>http://www.w3.org/TR/media-frags/</td>
+              <td>[<cite><a class="bibref" href="#bib-media-frags">media-frags</a></cite>] Example: <code>xywh=50,50,640,480</code></td>
+            </tr>
+            <tr>
+              <td>SVG</td>
+              <td>http://www.w3.org/TR/SVG/</td>
+              <td>[<cite><a class="bibref" href="#bib-SVG">SVG</a></cite>] Example: <code>svgView(viewBox(50,50,640,480))</code></td>
+            </tr>
+            <tr>
+              <td>EPUB3</td>
+              <td>http://www.idpf.org/epub/linking/cfi/epub-cfi.html</td>
+              <td>[<cite><a class="bibref" href="#bib-cfi">cfi</a></cite>] Example: <code>epubcfi(/6/4[chap01ref]!/4[body01]/10[para05]/3:10)</code></td>
+            </tr>
+          </tbody>
+        </table>
+        <p></p>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note8"><span>Note</span></div>
+          <div class="">
+            The IRI that uses the fragment may be reconstructed by concatenating the <code>source</code>, a <code>#</code>, and the <code>value</code>. For example, the IRI from the example below would be <code>http://example.org/video1#t=30,60</code>.
+          </div>
+        </div>
+
+        <h4 id="example-18">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 23</span><span style="text-transform: none">: Fragment Selector</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno23"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/video1"</span></span>,
+    "<span class="hljs-attribute">purpose</span>": <span class="hljs-value"><span class="hljs-string">"describing"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"FragmentSelector"</span></span>,
+      "<span class="hljs-attribute">conformsTo</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/TR/media-frags/"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"t=30,60"</span>
+    </span>}
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/image1"</span>
+</span>}</pre></div>
+      </section>
+
+
+      <section id="css-selector" typeof="bibo:Chapter" resource="#css-selector" property="bibo:hasPart">
+        <h4 id="h-css-selector" resource="#h-css-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.2 </span>CSS Selector</span></h4>
+
+        <p>One of the most common ways to select elements in the HTML Document Object Model is to use CSS Selectors [<cite><a class="bibref" href="#bib-CSS3-selectors">CSS3-selectors</a></cite>]. CSS Selectors allow for a wide variety of well supported ways to describe the path to an element in a web page, and thus cover many of the basic use cases for Web Annotation. Results are not defined for when a CSS Selector is applied to a representation that does not conform to the Document Object Model.</p>
+
+        <p>Note that CSS may also be used for <a href="#styles">styling</a> a resource within an annotation. This class is specifically to re-use the CSS Selector mechanism to select a segment of a resource that conforms to the Document Object Model.</p>
+
+        <p><b>Example Use Case:</b> Wendy selects a paragraph in a web page that she wishes to write a note about. Her client calculates a CSS path that cleanly identifies that element and adds it to the annotation.</p>
+
+        <h4 id="model-20">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the Selector.<br>CssSelectors <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>CssSelector</code>.</td>
+            </tr>
+            <tr>
+              <td>CssSelector</td>
+              <td>Class</td>
+              <td>The type of the CSS Selector resource.
+                <br>CSS Selectors <em class="rfc2119" title="MUST">MUST</em> have this class associated with them.</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>Property</td>
+              <td>The CSS selection path to the Segment.
+                <br>There <em class="rfc2119" title="MUST">MUST</em> be exactly 1 <code>value</code> associated with a CSS Selector.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note9"><span>Note</span></div>
+          <div class="">
+            Implementers <em class="rfc2119" title="SHOULD">SHOULD</em> use only commonly supported features of CSS that directly contribute to selection of an element or content, rather than styling or transformation, in order to maximize interoperability between systems.
+          </div>
+        </div>
+
+        <h4 id="example-19">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 24</span><span style="text-transform: none">: CSS Selector</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno24"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/note1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1.html"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"CssSelector"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"#elemid &gt; .elemclass + p"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="xpath-selector" typeof="bibo:Chapter" resource="#xpath-selector" property="bibo:hasPart">
+        <h4 id="h-xpath-selector" resource="#h-xpath-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.3 </span>XPath Selector</span></h4>
+
+        <p>Another common method of selecting elements and content within a resource that supports the Document Object Model (DOM), such as documents in XML or HTML, is to use an XPath selection [<cite><a class="bibref" href="#bib-DOM-Level-3-XPath">DOM-Level-3-XPath</a></cite>]. XPath allows a great deal of flexibility when describing the path through the structure to the selected content. Results are not defined for when an XPath Selector is applied to a representation that does not conform to the DOM.</p>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note10"><span>Note</span></div>
+          <div class="">
+            Implementers should note that the <a href="https://www.w3.org/TR/html5/syntax.html#optional-tags">HTML5 specification</a> allows parsers to add elements into the DOM that are considered to be missing. XPaths <em class="rfc2119" title="SHOULD">SHOULD</em> be constructed to include these elements, rather than from the element structure in the document.
+          </div>
+        </div>
+
+        <p><b>Example Use Case:</b> Xena selects a span within a table in an HTML page and writes a note about the content. To refer explicitly to this element, her client carefully constructs an XPath to identify it as the target of the Annotation.</p>
+
+        <h4 id="model-21">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the Selector.<br>XPath Selectors <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>XPathSelector</code>.</td>
+            </tr>
+            <tr>
+              <td>XPathSelector</td>
+              <td>Class</td>
+              <td>The type of the XPath Selector resource.
+                <br>XPath Selectors <em class="rfc2119" title="MUST">MUST</em> have this class associated with them.</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>Property</td>
+              <td>The xpath to the selected segment.
+                <br>There <em class="rfc2119" title="MUST">MUST</em> be exactly 1 <code>value</code> associated with an XPath Selector.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note11"><span>Note</span></div>
+          <div class="">
+            Implementers <em class="rfc2119" title="SHOULD">SHOULD</em> use only commonly supported features of XPath that directly contribute to selection of an element or content in order to maximize interoperability between systems.
+          </div>
+        </div>
+
+        <h4 id="example-20">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 25</span><span style="text-transform: none">: XPath Selector</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno25"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/note1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1.html"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"XPathSelector"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"/html/body/p[2]/table/tr[2]/td[3]/span"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="text-quote-selector" typeof="bibo:Chapter" resource="#text-quote-selector" property="bibo:hasPart">
+        <h4 id="h-text-quote-selector" resource="#h-text-quote-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.4 </span>Text Quote Selector</span></h4>
+
+        <p>This Selector describes a range of text by copying it, and including some of the text immediately before (a prefix) and after (a suffix) it to distinguish between multiple copies of the same sequence of characters.
+        </p>
+        <p>
+          For example, if the document were again "abcdefghijklmnopqrstuvwxyz", one could select "efg" by a prefix of "abcd", the match of "efg" and a suffix of "hijk".
+        </p>
+
+        <p><b>Example Use Case:</b> Yadira selects a typo ('anotation') in a web page and adds a comment that it should be replaced with the correct spelling ('annotation').</p>
+
+        <h4 id="model-22">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the Selector.<br>Text Quote Selectors <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>TextQuoteSelector</code>.</td>
+            </tr>
+            <tr>
+              <td>TextQuoteSelector</td>
+              <td>Class</td>
+              <td>The class for a Selector that describes a textual segment by means of quoting it, plus passages before or after it.
+                <br>The TextQuoteSelector <em class="rfc2119" title="MUST">MUST</em> have this class associated with it.</td>
+            </tr>
+            <tr>
+              <td>exact</td>
+              <td>Property</td>
+              <td>A copy of the text which is being selected, after normalization.
+                <br>Each TextQuoteSelector <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>exact</code> property. </td>
+            </tr>
+            <tr>
+              <td>prefix</td>
+              <td>Property</td>
+              <td>A snippet of text that occurs immediately before the text which is being selected.
+                <br>Each TextQuoteSelector <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 <code>prefix</code> property, and <em class="rfc2119" title="MUST NOT">MUST NOT</em> have more than 1.</td>
+            </tr>
+            <tr>
+              <td>suffix</td>
+              <td>Property</td>
+              <td>The snippet of text that occurs immediately after the text which is being selected.
+                <br>Each TextQuoteSelector <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 <code>suffix</code> property, and <em class="rfc2119" title="MUST NOT">MUST NOT</em> have more than 1.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>The text <em class="rfc2119" title="MUST">MUST</em> be normalized before recording. Thus HTML/XML tags should be removed, character entities should be replaced with the character that they encode, and unnecessary whitespace should be normalized. The normalization routine may be performed automatically by a browser, and other applications should implement the <a href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-5DFED1F0">DOM String Comparisons</a> method. This allows the Selector to be used with different encodings and user agents and still have the same semantics and utility. The selection <em class="rfc2119" title="MUST">MUST</em> be based on the <a href="https://www.w3.org/International/questions/qa-visual-vs-logical">logical order</a> of the text, rather than the visual order, especially for bidirectional text. The normalized value <em class="rfc2119" title="MUST">MUST</em> be recorded as UTF-8 in the JSON serialization of the Annotation.
+        </p>
+
+        <p>When generating the Text Position Selector values, it is recommended that implementations built for an environment that supports DOM Level 3 APIs use the <code>textContent</code> property of top level, user visible Node object [<cite><a class="bibref" href="#bib-DOM-Level-3-Core">DOM-Level-3-Core</a></cite>] of the resource. This content would be located at <code>document.body.textContent</code> in an HTML5 document being accessed via a JavaScript DOM implementation.</p>
+
+        <p>If, after processing the prefix, exact, and suffix, the user agent discovers multiple matching text sequences, then the selection <em class="rfc2119" title="SHOULD">SHOULD</em> be treated as matching all of the matches.</p>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note12"><span>Note</span></div>
+          <div class="">If the content is under copyright or has other rights asserted on its use, then this method of selecting text is potentially dangerous. A user might select the entire text of the document to annotate, which would not be desirable to copy into the Annotation and share. For static texts with access and/or distribution restrictions, the use of the Text Position Selector is perhaps more appropriate.
+          </div>
+        </div>
+
+        <h4 id="example-21">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 26</span><span style="text-transform: none">: Text Quote Selector</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno26"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/comment1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextQuoteSelector"</span></span>,
+      "<span class="hljs-attribute">exact</span>": <span class="hljs-value"><span class="hljs-string">"anotation"</span></span>,
+      "<span class="hljs-attribute">prefix</span>": <span class="hljs-value"><span class="hljs-string">"this is an "</span></span>,
+      "<span class="hljs-attribute">suffix</span>": <span class="hljs-value"><span class="hljs-string">" that has some"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="text-position-selector" typeof="bibo:Chapter" resource="#text-position-selector" property="bibo:hasPart">
+        <h4 id="h-text-position-selector" resource="#h-text-position-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.5 </span>Text Position Selector</span></h4>
+
+        <p>
+          This Selector describes a range of text by recording the start and end positions of the selection in the stream. Position 0 would be immediately before the first character, position 1 would be immediately before the second character, and so on. The start character is thus included in the list, but the end character is not.</p>
+        <p>
+          For example, if the document was "abcdefghijklmnopqrstuvwxyz", the start was 4, and the end was 7, then the selection would be "efg".
+        </p>
+
+        <p><b>Example Use Case:</b> Zara writes a review of an ebook that does not allow its content to be extracted and copied. Her client describes the selection using its start and end position in the content.</p>
+
+        <h4 id="model-23">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the Selector.<br>Text Position Selectors <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>TextPositionSelector</code>.</td>
+            </tr>
+            <tr>
+              <td>TextPositionSelector</td>
+              <td>Class</td>
+              <td>The class for a Selector which describes a range of text based on its start and end positions.
+                <br>The TextPositionSelector <em class="rfc2119" title="MUST">MUST</em> have this class associated with it.</td>
+            </tr>
+            <tr>
+              <td>start</td>
+              <td>Property</td>
+              <td>The starting position of the segment of text. The first character in the full text is character position 0, and the character is included within the segment.
+                <br>Each TextPositionSelector <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>start</code> property, and the value <em class="rfc2119" title="MUST">MUST</em> be a non-negative integer.</td>
+            </tr>
+            <tr>
+              <td>end</td>
+              <td>Property</td>
+              <td>The end position of the segment of text. The character is not included within the segment.
+                <br>Each TextPositionSelector <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>end</code> property, and the value <em class="rfc2119" title="MUST">MUST</em> be a non-negative integer.</td>
+            </tr>
+
+          </tbody>
+        </table>
+
+        <p>The text <em class="rfc2119" title="MUST">MUST</em> be normalized before counting the characters, in the same way as for Text Quote Selector.</p>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note13"><span>Note</span></div>
+          <div class="">
+            The use of this Selector does not require text to be copied from the Source document into the Annotation graph, unlike the Text Quote Selector, but is very brittle with regards to changes to the resource. Any edits or dynamically transcluded content may change the selection, and thus it is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that a <a href="#states">State</a> be additionally used to help identify the correct representation.
+          </div>
+        </div>
+
+        <h4 id="example-22">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 27</span><span style="text-transform: none">: Text Position Selector</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno27"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/review1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/ebook1"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextPositionSelector"</span></span>,
+      "<span class="hljs-attribute">start</span>": <span class="hljs-value"><span class="hljs-number">412</span></span>,
+      "<span class="hljs-attribute">end</span>": <span class="hljs-value"><span class="hljs-number">795</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="data-position-selector" typeof="bibo:Chapter" resource="#data-position-selector" property="bibo:hasPart">
+        <h4 id="h-data-position-selector" resource="#h-data-position-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.6 </span>Data Position Selector</span></h4>
+
+        <p>
+          Similar to the Text Position Selector, the Data Position Selector uses the same properties but works at the byte in bitstream level rather than the character in text level.</p>
+
+        <p><b>Example Use Case:</b> Alexandra writes comments about regions of online disk images for forensic purposes and describing emulation requirements. Her client generates the start and end positions from the binary stream, rather than the more human readable display she is using.</p>
+
+
+        <h4 id="model-24">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the Selector.<br>Data Position Selectors <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>DataPositionSelector</code>.</td>
+            </tr>
+            <tr>
+              <td>DataPositionSelector</td>
+              <td>Class</td>
+              <td>The class for a Selector which describes a range of data based on its start and end positions within the byte stream.
+                <br>The DataPositionSelector <em class="rfc2119" title="MUST">MUST</em> have this class associated with it.</td>
+            </tr>
+            <tr>
+              <td>start</td>
+              <td>Property</td>
+              <td>The starting position of the segment of data. The first byte is character position 0.
+                <br>Each DataPositionSelector <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>start</code> property.</td>
+            </tr>
+            <tr>
+              <td>end</td>
+              <td>Property</td>
+              <td>The end position of the segment of data. The last character is not included within the segment.
+                <br>Each DataPositionSelector <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>end</code> property.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h4 id="example-23">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 28</span><span style="text-transform: none">: Data Position Selector</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno28"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/note1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/diskimg1"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"DataPositionSelector"</span></span>,
+      "<span class="hljs-attribute">start</span>": <span class="hljs-value"><span class="hljs-number">4096</span></span>,
+      "<span class="hljs-attribute">end</span>": <span class="hljs-value"><span class="hljs-number">4104</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="svg-selector" typeof="bibo:Chapter" resource="#svg-selector" property="bibo:hasPart">
+        <h4 id="h-svg-selector" resource="#h-svg-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.7 </span>SVG Selector</span></h4>
+
+        <p>An SvgSelector defines an area through the use of the Scalable Vector Graphics [<cite><a class="bibref" href="#bib-SVG">SVG</a></cite>] standard. This allows the user to select a non-rectangular area of the content, such as a circle or polygon by describing the region using SVG. The SVG may be either embedded within the Annotation or referenced as an External Web Resource.</p>
+
+        <p>Note that the SvgSelector uses SVG to select an area of a resource. Segments of an SVG representation may also be selected using selectors, including the FragmentSelector or even an SvgSelector.</p>
+
+        <p><b>Example Use Case:</b> Britney is tagging an old map online with a diagonal region for a historical road. Her client creates SVG polygon to describe the region, relative to the image content.</p>
+
+        <h4 id="model-25">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the Selector.<br>SVG Selectors <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> include <code>SvgSelector</code>. It <em class="rfc2119" title="MUST">MUST</em> also include the <code>Content</code> class if the SVG representation is embedded within the Annotation document.</td>
+            </tr>
+            <tr>
+              <td>SvgSelector</td>
+              <td>Class</td>
+              <td>The class for a Selector which defines a shape for the selected area using the SVG standard.
+                <br>The Selector <em class="rfc2119" title="MUST">MUST</em> have this class associated with it and <em class="rfc2119" title="MAY">MAY</em> also have the <code>Content</code> class associated with it.
+              </td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>Property</td>
+              <td>The character sequence of the SVG content.<br> There <em class="rfc2119" title="MAY">MAY</em> be exactly 1 <code>value</code> property associated with the Selector, and if so the value of the property <em class="rfc2119" title="MUST">MUST</em> be well-formed SVG XML.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>The dimensions of the SVG shape or canvas <em class="rfc2119" title="MUST">MUST</em> be relative to the dimensions of the Source resource, such that scaling the shape's size to the full size of the image correctly describes the desired area.</p>
+
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note14"><span>Note</span></div>
+          <div class="">
+            Implementers <em class="rfc2119" title="SHOULD">SHOULD</em> use only commonly supported features of SVG that directly contribute to describing a region, rather than styling or transformation, in order to maximize interoperability between systems. It is <em class="rfc2119" title="NOT RECOMMENDED">NOT RECOMMENDED</em> to include style information within the SVG element, nor Javascript, animation, text or other non-shape oriented information. Clients <em class="rfc2119" title="SHOULD">SHOULD</em> ignore such information if present.
+          </div>
+        </div>
+
+        <h4 id="example-24">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 29</span><span style="text-transform: none">: SVG Selector</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno29"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/road1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/map1"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/svg1"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"SvgSelector"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 30</span><span style="text-transform: none">: SVG Selector, embedded</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno30"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/road1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/map1"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"SvgSelector"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"&lt;svg:svg&gt; ... &lt;/svg:svg&gt;"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="range-selector" typeof="bibo:Chapter" resource="#range-selector" property="bibo:hasPart">
+        <h4 id="h-range-selector" resource="#h-range-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.8 </span>Range Selector</span></h4>
+
+        <p>Selections made by users may be extensive and/or cross over internal boundaries in the representation, making it difficult to construct a single selector that robustly describes the correct content. A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors. In this way, two points can be accurately identified using the most appropriate selection mechanisms, and then linked together to form the selection. The selection consists of everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it.</p>
+
+        <p><b>Example Use Case:</b> Carla wants to comment on two adjacent cells in a table that is part of a web page. She selects the two cells and her client constructs XPaths to the the first cell, and the cell that immediately follows the second. Her client then creates a Range Selector with the first XPath Selector as the start, and the second XPath selector as the end.</p>
+
+        <h4 id="model-26">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the Selector.<br>Range Selectors <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>RangeSelector</code>.</td>
+            </tr>
+            <tr>
+              <td>RangeSelector</td>
+              <td>Class</td>
+              <td>The type of the Range Selector resource.
+                <br>Range Selectors <em class="rfc2119" title="MUST">MUST</em> have this class associated with them.</td>
+            </tr>
+            <tr>
+              <td>startSelector</td>
+              <td>Relationship</td>
+              <td>The Selector which describes the inclusive starting point of the range.
+                <br>There <em class="rfc2119" title="MUST">MUST</em> be exactly 1 <code>startSelector</code> associated with a Range Selector.</td>
+            </tr>
+            <tr>
+              <td>endSelector</td>
+              <td>Relationship</td>
+              <td>The Selector which describes the exclusive ending point of the range.
+                <br>There <em class="rfc2119" title="MUST">MUST</em> be exactly 1 <code>endSelector</code> associated with a Range Selector. Both <code>startSelector</code> and <code>endSelector</code> <em class="rfc2119" title="SHOULD">SHOULD</em> be of the same class.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h4 id="example-25">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 31</span><span style="text-transform: none">: Range Selector</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno31"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/comment1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1.html"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"RangeSelector"</span></span>,
+      "<span class="hljs-attribute">startSelector</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"XPathSelector"</span></span>,
+        "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"//table[1]/tr[1]/td[2]"</span>
+      </span>}</span>,
+      "<span class="hljs-attribute">endSelector</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"XPathSelector"</span></span>,
+        "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"//table[1]/tr[1]/td[4]"</span>
+      </span>}
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="refinement-of-selection" typeof="bibo:Chapter" resource="#refinement-of-selection" property="bibo:hasPart">
+        <h4 id="h-refinement-of-selection" resource="#h-refinement-of-selection"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.9 </span>Refinement of Selection</span></h4>
+
+        <p>It may be easier, more reliable or more accurate to specify the segment of interest of a resource as a selection of a selection, rather than as a selection of the complete resource. Particularly for resources that contain other resources, such as various packaging formats, this also allows decomposition of the selection mechanisms when the components do not have unique identifiers. This is accomplished by having selectors chained together, where each refines the results of the previous one.</p>
+
+        <p><b>Example Use Case:</b> Devina selects a paragraph of text and then a short phrase within it to comment on. Her client records the phrase as a TextQuoteSelector that further modifies a FragmentSelector used to identify the paragraph that the phrase is part of.</p>
+
+        <h4 id="model-27">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>refinedBy</td>
+              <td>Relationship</td>
+              <td>The relationship between a broader selector and the more specific selector that should be applied to the results of the first.
+                <br>A Selector <em class="rfc2119" title="MAY">MAY</em> be <code>refinedBy</code> 1 or more other Selectors. If more than 1 is given, then they are considered to be alternatives that will result in the same selection.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h4 id="example-26">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 32</span><span style="text-transform: none">: Refinement of Selection</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno32"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/comment1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"FragmentSelector"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"para5"</span></span>,
+      "<span class="hljs-attribute">refinedBy</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextQuoteSelector"</span></span>,
+        "<span class="hljs-attribute">exact</span>": <span class="hljs-value"><span class="hljs-string">"Selected Text"</span></span>,
+        "<span class="hljs-attribute">prefix</span>": <span class="hljs-value"><span class="hljs-string">"text before the "</span></span>,
+        "<span class="hljs-attribute">suffix</span>": <span class="hljs-value"><span class="hljs-string">" and text after it"</span>
+      </span>}
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+    </section>
+    <!-- /Selectors -->
+
+    <section id="states" typeof="bibo:Chapter" resource="#states" property="bibo:hasPart">
+      <h3 id="h-states" resource="#h-states"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3 </span>States</span></h3>
+
+      <p>A State describes the intended state of a resource as applied to the particular Annotation, and thus provides the information needed to retrieve the correct representation of that resource. Web resources change over time, and a State might be used to describe how to recover the intended previous version. Web resources also have multiple formats, and a State might equally be used to describe how to retrieve that particular format.</p>
+
+      <p><b>Example Use Case:</b> Erin makes a comment about a web page that changes frequently. Her client records information to allow other clients to hopefully reconstruct the original target of the annotation.</p>
+
+      <h3 id="model-28">Model</h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>state</td>
+            <td>Relationship</td>
+            <td>The relationship between the SpecificResource and the State.
+              <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>state</code> relationships for each SpecificResource.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>States <em class="rfc2119" title="MUST">MUST</em> be processed before processing Selector or Style information.</p>
+
+      <h3 id="example-27">Example</h3>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 33</span><span style="text-transform: none">: State</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno33"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/note1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span></span>,
+    "<span class="hljs-attribute">state</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/state1"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+
+      <section id="time-state" typeof="bibo:Chapter" resource="#time-state" property="bibo:hasPart">
+        <h4 id="h-time-state" resource="#h-time-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3.1 </span>Time State</span></h4>
+
+        <p>A Time State resource records the time at which the resource is appropriate for the Annotation, typically the time that the Annotation was created and/or a link to a persistent copy of the current version. The timestamp for the resource could be resolved via the Memento protocol, described in RFC 7089 [<cite><a class="bibref" href="#bib-rfc7089">rfc7089</a></cite>].</p>
+
+        <p><b>Example Use Case:</b> Felicity makes a note about the current state of the front page of a news website, and flags that the page is likely to change often. Her client adds in a State with the current time to describe the version of the page being annotated.</p>
+
+
+        <h4 id="model-29">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the State.<br>Time States <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>TimeState</code>.</td>
+            </tr>
+            <tr>
+              <td>TimeState</td>
+              <td>Class</td>
+              <td>A description of how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.
+                <br>The State <em class="rfc2119" title="MUST">MUST</em> have this class associated with it.
+              </td>
+            </tr>
+            <tr>
+              <td>sourceDate</td>
+              <td>Property</td>
+              <td>The timestamp at which the Source resource should be interpreted for the Annotation.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>sourceDate</code> properties per TimeState. If there is more than 1, each gives an alternative timestamp at which the Source may be interpreted. The timestamp <em class="rfc2119" title="MUST">MUST</em> be expressed in the <code>xsd:dateTime</code> format, and <em class="rfc2119" title="MUST">MUST</em> use the UTC timezone expressed as "Z". If <code>sourceDate</code> is provided, then <code>sourceDateStart</code> and <code>sourceDateEnd</code> <em class="rfc2119" title="MUST NOT">MUST NOT</em> be provided.</td>
+            </tr>
+            <tr>
+              <td>sourceDateStart</td>
+              <td>Property</td>
+              <td>The timestamp that begins the interval over which the Source resource should be interpreted for the Annotation.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be exactly 1 <code>sourceDateStart</code> property per TimeState. The timestamp <em class="rfc2119" title="MUST">MUST</em> be expressed in the <code>xsd:dateTime</code> format, and <em class="rfc2119" title="MUST">MUST</em> use the UTC timezone expressed as "Z". If <code>sourceDateStart</code> is provided then <code>sourceDateEnd</code> <em class="rfc2119" title="MUST">MUST</em> also be provided.</td>
+            </tr>
+            <tr>
+              <td>sourceDateEnd</td>
+              <td>Property</td>
+              <td>The timestamp that ends the interval over which the Source resource should be interpreted for the Annotation.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be exactly 1 <code>sourceDateEnd</code> property per TimeState. The timestamp <em class="rfc2119" title="MUST">MUST</em> be expressed in the <code>xsd:dateTime</code> format, and <em class="rfc2119" title="MUST">MUST</em> use the UTC timezone expressed as "Z". If <code>sourceDateEnd</code> is provided then <code>sourceDateStart</code> <em class="rfc2119" title="MUST">MUST</em> also be provided.</td>
+            </tr>
+            <tr>
+              <td>cached</td>
+              <td>Relationship</td>
+              <td>A link to a copy of the Source resource's representation, appropriate for the Annotation.
+                <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>cached</code> relationships per TimeState. If there is more than 1, each gives an alternative copy of the representation.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+
+        <h4 id="example-28">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 34</span><span style="text-transform: none">: Time State</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno34"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/note1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span></span>,
+    "<span class="hljs-attribute">state</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TimeState"</span></span>,
+      "<span class="hljs-attribute">cached</span>": <span class="hljs-value"><span class="hljs-string">"http://archive.example.org/copy1"</span></span>,
+      "<span class="hljs-attribute">sourceDate</span>": <span class="hljs-value"><span class="hljs-string">"2015-07-20T13:30:00Z"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="request-header-state" typeof="bibo:Chapter" resource="#request-header-state" property="bibo:hasPart">
+        <h4 id="h-request-header-state" resource="#h-request-header-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3.2 </span>Request Header State</span></h4>
+
+        <p>As there are potentially many representations that can be delivered from a resource with a single IRI, and a Specific Resource may only apply to one of them, it is important to be able to record the HTTP Request headers that need to be sent to retrieve the correct representation. The HttpRequestState resource maintains a copy of the headers to be replayed when obtaining the representation. </p>
+
+        <p><b>Example Use Case:</b> Gabrielle retrieves a PDF representation of a web resource that can deliver HTML, PDF or plain text and then writes a description about it. She signals that her description is only about the PDF representation. Her client then includes a State to describe how to retrieve the target representation.</p>
+
+        <h4 id="model-30">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>Relationship</td>
+              <td>The class of the State.<br>Request Header States <em class="rfc2119" title="MUST">MUST</em> have a <code>type</code> and the value <em class="rfc2119" title="MUST">MUST</em> be <code>HttpRequestState</code>.</td>
+            </tr>
+            <tr>
+              <td>HttpRequestState</td>
+              <td>Class</td>
+              <td>A description of how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send on the request.
+                <br>The State <em class="rfc2119" title="MUST">MUST</em> have this class associated with it.</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>Property</td>
+              <td>The HTTP request headers to send as a single, complete string.
+                <br>An HttpRequestState <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>value</code> property.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h4 id="example-29">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 35</span><span style="text-transform: none">: HTTP Request State</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno35"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/description1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/resource1"</span></span>,
+    "<span class="hljs-attribute">state</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"HttpRequestState"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"Accept: application/pdf"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+      <section id="refinement-of-state" typeof="bibo:Chapter" resource="#refinement-of-state" property="bibo:hasPart">
+        <h4 id="h-refinement-of-state" resource="#h-refinement-of-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3.3 </span>Refinement of State</span></h4>
+
+        <p>Similar to the <a href="#refinement-of-selection">refinement of selection</a>, it may be easier, more reliable or more accurate to specify the appropriate state of the resource as a hierarchy of atomic State resources. This is particularly appropriate for representing the combination of a State that reflects an internal transformation along with the results of a State that describes an external request. This decomposition is accomplished by having the states chained together in the same way as Selectors.</p>
+
+        <p>Further, given that the State(s) will likely result in a specific representation, there may be specific Selectors that are appropriate for describing the segment of the representation. In order to accomodate this, States may also be refined by Selectors.</p>
+
+        <p><b>Example Use Case:</b> Heather writes a comment about a travel e-book which has many versions available over time, and is available in different formats. She is particularly commenting on a specific version and format, so her client adds both a TimeState to capture the time and an HttpRequestState to capture the format, and then a particular FragmentSelector that is appropriate to that format.</p>
+
+        <h4 id="model-31">Model</h4>
+
+        <table class="model">
+          <tbody>
+            <tr>
+              <th>Term</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>refinedBy</td>
+              <td>Relationship</td>
+              <td>The relationship between a broader State and either a more specific State or a Selector that should be applied to the results of the first.
+                <br>Each State <em class="rfc2119" title="MAY">MAY</em> be <code>refinedBy</code> 1 or more other States or Selectors. If more than 1 is given, then they are considered to be alternatives that will result in the same result.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h4 id="example-30">Example</h4>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 36</span><span style="text-transform: none">: Refinement of States</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno36"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/comment1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/ebook1"</span></span>,
+    "<span class="hljs-attribute">state</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TimeState"</span></span>,
+      "<span class="hljs-attribute">sourceDate</span>": <span class="hljs-value"><span class="hljs-string">"2016-02-01T12:05:23Z"</span></span>,
+      "<span class="hljs-attribute">refinedBy</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"HttpRequestState"</span></span>,
+        "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"Accept: application/pdf"</span></span>,
+        "<span class="hljs-attribute">refinedBy</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"FragmentSelector"</span></span>,
+          "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"page=10"</span></span>,
+          "<span class="hljs-attribute">conformsTo</span>": <span class="hljs-value"><span class="hljs-string">"http://tools.ietf.org/rfc/rfc3778"</span>
+        </span>}
+      </span>}
+    </span>}
+  </span>}
+</span>}</pre></div>
+      </section>
+
+    </section>
+    <!-- /States -->
+
+    <section id="styles" typeof="bibo:Chapter" resource="#styles" property="bibo:hasPart">
+      <h3 id="h-styles" resource="#h-styles"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.4 </span>Styles</span></h3>
+
+      <p>The interpretation of a particular Annotation, or the Annotation's body, may rely on the rendering style of the Annotation being consistent across implementations. For Annotations on binary content such as Images or Video, the background color of the target may not be accessible to the annotation client, and the default coloring may be difficult to perceive, such as a black rectangle rendered as the target area on an image of the night sky. Rendering information is recorded using CSS stylesheets and references to classes defined in those stylesheets.</p>
+
+      <p><b>Example Use Case:</b> Ingeborg highlights two paragraphs in a document, and selects in her client that one should be highlighted in red and the other in yellow. She then makes a comment that the yellow part contradicts the red part. Her client records that she selected the red and yellow coloration of the targets. </p>
+
+      <h3 id="model-32">Model</h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>type</td>
+            <td>Relationship</td>
+            <td>The class of the Style.<br>CSS Stylesheets <em class="rfc2119" title="MAY">MAY</em> have a <code>type</code> and if included the value <em class="rfc2119" title="MUST">MUST</em> be <code>CssStylesheet</code>.</td>
+          </tr>
+          <tr>
+            <td>CssStylesheet</td>
+            <td>Class</td>
+            <td>A resource which describes styles for resources participating in the Annotation using CSS.
+              <br>The class <em class="rfc2119" title="MAY">MAY</em> be associated with the stylesheet resource.</td>
+          </tr>
+          <tr>
+            <td>stylesheet</td>
+            <td>Relationship</td>
+            <td>The relationship between an <b>Annotation</b> and the Style.
+              <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or 1 <code>stylesheet</code> relationships for each Annotation.</td>
+          </tr>
+          <tr>
+            <td>styleClass</td>
+            <td>Property</td>
+            <td>The name of the class used in the CSS description that should be applied to the Specific Resource.<br> There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>styleClass</code> properties on a Specific Resource.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>The CSS Stylesheet is associated with the Annotation itself, and the content provides the rendering hints about the Annotation's constituent resources. It <em class="rfc2119" title="MAY">MAY</em> have its own dereferenceable IRI that provides the information, or it may be embedded within the Annotation. This is to avoid having single line stylesheets each associated with different resources, and instead to allow reference to a single IRI that governs the full set of styles for a particular implementation.</p>
+
+      <p>Publishing systems <em class="rfc2119" title="MUST NOT">MUST NOT</em> assume that they will be processed; they are only provided as hints rather than requirements.</p>
+
+      <p>When rendering a Specific Resource, consuming applications <em class="rfc2119" title="SHOULD">SHOULD</em> check to see if it has a <code>styleClass</code> property. If it does, then the application <em class="rfc2119" title="SHOULD">SHOULD</em> attempt to locate the appropriate selector in the CSS document, and then apply the css-value block. If a Specific Resource has a <code>styleClass</code> value, but no such class is described by a <code>stylesheet</code> attached to the Annotation, then the <code>styleClass</code> <em class="rfc2119" title="MUST">MUST</em> be ignored.</p>
+
+      <h3 id="example-31">Example</h3>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 37</span><span style="text-transform: none">: CSS Style</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno37"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">stylesheet</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/style1"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/comment1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/document1"</span></span>,
+    "<span class="hljs-attribute">styleClass</span>": <span class="hljs-value"><span class="hljs-string">"red"</span>
+  </span>}
+</span>}</pre></div>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 38</span><span style="text-transform: none">: CSS Style, embedded</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno38"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">stylesheet</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"CssStylesheet"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">".red { color: red }"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/body1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/target1"</span></span>,
+    "<span class="hljs-attribute">styleClass</span>": <span class="hljs-value"><span class="hljs-string">"red"</span>
+  </span>}
+</span>}</pre></div>
+    </section>
+
+    <section id="rendering-software" typeof="bibo:Chapter" resource="#rendering-software" property="bibo:hasPart">
+      <h3 id="h-rendering-software" resource="#h-rendering-software"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.5 </span>Rendering Software</span></h3>
+      <p>It may be valuable to know the software that was used to process and/or render the target resource when the annotation was created. This information can be used by later systems to potentially recreate the environment to ensure that the annotation can be more easily and more accurately reconnected with the appropriate part of the target's representation. This life cycle information is associated with the Specific Resource, as it is very likely to change between Annotations for the same target, and thus cannot be associated with the target resource directly.</p>
+
+      <p><b>Example Use Case:</b> Juliet is using a browser based client to render a PDF of a scholarly article. Her browser uses a particular library to render the PDF as HTML. She annotates a paragraph in the view that she sees, the HTML rendering, and her client records that the library that was used for rendering in the annotation, along with her comment and the target PDF.</p>
+
+      <h3 id="model-33">Model</h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>renderedVia</td>
+            <td>Relationship</td>
+            <td>
+              The relationship between the Specific Resource that represents the target in the annotation, and the piece of software or other system that was used to render the target when the annotation was created.
+              <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>renderedVia</code> relationships for each Specific Resource.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="note">
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note15"><span>Note</span></div>
+        <div class="">Other properties may be associated with the rendering system, including such things as schema:softwareVersion, accessibility functions, labels, references to the actual code, and so forth. These extensions are beyond the scope of this specification, but please see the Extensions section of [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>].</div>
+      </div>
+
+      <h3 id="example-32">Example</h3>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 39</span><span style="text-transform: none">: Rendering Software</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno39"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/comment1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.edu/article.pdf"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/selectors/html-selector1"</span></span>,
+    "<span class="hljs-attribute">renderedVia</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/pdf-to-html-library"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Software"</span></span>,
+      "<span class="hljs-attribute">schema:softwareVersion</span>": <span class="hljs-value"><span class="hljs-string">"2.5"</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+
+    </section>
+
+    <section id="scope-of-a-resource" typeof="bibo:Chapter" resource="#scope-of-a-resource" property="bibo:hasPart">
+      <h3 id="h-scope-of-a-resource" resource="#h-scope-of-a-resource"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.6 </span>Scope of a Resource</span></h3>
+      <p>It is sometimes important for an Annotation to capture the context in which it was made, in terms of the resources that the annotator was viewing or using at the time. This does not imply an assertion that the annotation is only valid for the image in the context of that page, it just records that the page was being viewed.</p>
+
+      <p><b>Example Use Case:</b> Karin makes a comment about an image in a particular web page to say that it is not the right organization's logo. Her client includes the page that the image is being rendered in, however the annotation is associated with the image resource itself.</p>
+
+      <h3 id="model-34">Model</h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>scope</td>
+            <td>Relationship</td>
+            <td>The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.
+              <br>There <em class="rfc2119" title="MAY">MAY</em> be 0 or more <code>scope</code> relationships for each Specific Resource.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3 id="example-33">Example</h3>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 40</span><span style="text-transform: none">: Scope</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno40"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/note1"</span></span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/image1"</span></span>,
+    "<span class="hljs-attribute">scope</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span>
+  </span>}
+</span>}</pre></div>
+    </section>
+  </section>
+  <!-- /Specific Resources -->
+
+  <section id="collections" typeof="bibo:Chapter" resource="#collections" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-collections" resource="#h-collections"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Collections</span></h2>
+
+    <p>It is often useful to be able to collect Annotations together into a list, called an Annotation Collection. This list, which is always ordered, serves as a means to refer to the Annotations that are contained within it, and to maintain any information about the Collection itself.</p>
+
+    <p>The Collection model is divided into two sections: the Annotation Collection that manages the identity of the list and its description, and Annotation Pages that list the Annotations which are members of the Collection.</p>
+
+    <p><b>Example Use Case:</b> Lana works for a publishing house and has transformed the author's commentary on their steampunk novel into a set of annotations for sale. The company wishes to have them available as an add-on for customers that have already bought the novel, and also in a bundle for new sales.</p>
+
+    <section id="annotation-collection" typeof="bibo:Chapter" resource="#annotation-collection" property="bibo:hasPart">
+      <h3 id="h-annotation-collection" resource="#h-annotation-collection"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Annotation Collection</span></h3>
+
+      <p>As Annotation Collections might get very large, the model distinguishes between the Collection itself and sequence of component pages that in turn list the Annotations. The Collection maintains information about itself, including creation or descriptive information to aid with discovery and understanding of the Collection, and also references to at least the first Page of Annotations. By starting with the first Annotation in the first Page, and traversing the Pages to the last Annotation of the last Page, all Annotations in the Collection will have been discovered.</p>
+
+      <p>Annotations <em class="rfc2119" title="MAY">MAY</em> be within multiple Collections at the same time, and the Collection <em class="rfc2119" title="MAY">MAY</em> be created or maintained by agents other than those that create or maintain the included Annotations.</p>
+
+      <h3 id="model-35">Model</h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>@context</td>
+            <td>Property</td>
+            <td>The context that determines the meaning of the JSON as an Annotation Collection.
+              <br>The Collection <em class="rfc2119" title="MUST">MUST</em> have 1 or more <code>@context</code> values and <code>http://www.w3.org/ns/anno.jsonld</code> <em class="rfc2119" title="MUST">MUST</em> be one of them.</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            <td>Property</td>
+            <td>The identity of the Collection.<br>The Collection <em class="rfc2119" title="MUST">MUST</em> have exactly 1 IRI that identifies it.</td>
+          </tr>
+          <tr>
+            <td>type</td>
+            <td>Property</td>
+            <td>The type of the Collection.<br>The Collection <em class="rfc2119" title="MUST">MUST</em> have 1 or more types, and the <code>AnnotationCollection</code> class <em class="rfc2119" title="MUST">MUST</em> be one of them.</td>
+          </tr>
+          <tr>
+            <td>AnnotationCollection</td>
+            <td>Class</td>
+            <td>The class for ordered Collections of Annotations.<br>This class <em class="rfc2119" title="MUST">MUST</em> be associated with the Collection using <code>type</code></td>
+          </tr>
+          <tr>
+            <td>label</td>
+            <td>Property</td>
+            <td>A human readable label intended as the name of the Collection.<br>Collections <em class="rfc2119" title="SHOULD">SHOULD</em> have 1 or more <code>label</code>, and the value <em class="rfc2119" title="MUST">MUST</em> be a string.</td>
+          </tr>
+          <tr>
+            <td>total</td>
+            <td>Property</td>
+            <td>The total number of Annotations in the Collection.<br>Collections <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 <code>total</code>, and if present it <em class="rfc2119" title="MUST">MUST</em> be an <code>xsd:nonNegativeInteger</code>. </td>
+          </tr>
+          <tr>
+            <td>first</td>
+            <td>Relationship</td>
+            <td>The first page of Annotations that are included within the Collection.<br>A Collection that has a total number of Annotations greater than 0 <em class="rfc2119" title="MUST">MUST</em> have exactly 1 <code>first</code> page of Annotations. The first Page <em class="rfc2119" title="MAY">MAY</em> be embedded within the representation of the Collection, or it <em class="rfc2119" title="MAY">MAY</em> be given as an IRI.</td>
+          </tr>
+          <tr>
+            <td>last</td>
+            <td>Relationship</td>
+            <td>The last page of Annotations that are included within the Collection.<br>A Collection that has a total number of Annotations greater than 0 <em class="rfc2119" title="SHOULD">SHOULD</em> have a reference to the IRI of the <code>last</code> page of Annotations.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>Other properties <em class="rfc2119" title="MAY">MAY</em> be added to the Collection to describe its use, intellectual property rights, provenance and any other features that are considered useful. These properties <em class="rfc2119" title="SHOULD">SHOULD</em> come from those described in this specification if possible, but <em class="rfc2119" title="MAY">MAY</em> come from any appropriate vocabulary.</p>
+
+      <h3 id="example-34">Example</h3>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 41</span><span style="text-transform: none">: Annotation Collection</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/collection1"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"AnnotationCollection"</span></span>,
+  "<span class="hljs-attribute">label</span>": <span class="hljs-value"><span class="hljs-string">"Steampunk Annotations"</span></span>,
+  "<span class="hljs-attribute">creator</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/publisher"</span></span>,
+  "<span class="hljs-attribute">total</span>": <span class="hljs-value"><span class="hljs-number">42023</span></span>,
+  "<span class="hljs-attribute">first</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span></span>,
+  "<span class="hljs-attribute">last</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page42"</span>
+</span>}</pre></div>
+    </section>
+
+    <section id="annotation-page" typeof="bibo:Chapter" resource="#annotation-page" property="bibo:hasPart">
+      <h3 id="h-annotation-page" resource="#h-annotation-page"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.2 </span>Annotation Page</span></h3>
+
+      <p>An Annotation Page is part of an Annotation Collection, and has an ordered list of some or all of the Annotations that are within the Collection. Each Collection may have multiple pages, and these are traversed by following the <code>next</code> and <code>prev</code> links between the pages.</p>
+
+      <h3 id="model-36">Model</h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Term</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>@context</td>
+            <td>Property</td>
+            <td>The context that determines the meaning of the JSON as an Annotation Collection Page.
+              <br>If the Page is NOT embedded within a Collection, it <em class="rfc2119" title="MUST">MUST</em> have 1 or more <code>@context</code> values and <code>http://www.w3.org/ns/anno.jsonld</code> <em class="rfc2119" title="MUST">MUST</em> be one of them. If it is embedded, then it <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> have an <code>@context</code> property.</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            <td>Property</td>
+            <td>The identity of the Page.<br>The Page <em class="rfc2119" title="MUST">MUST</em> have exactly 1 IRI that provides its identity.</td>
+          </tr>
+          <tr>
+            <td>type</td>
+            <td>Property</td>
+            <td>The type of the Page.<br>The Page <em class="rfc2119" title="MUST">MUST</em> have 1 or more types, and the <code>AnnotationPage</code> class <em class="rfc2119" title="MUST">MUST</em> be one of them.</td>
+          </tr>
+          <tr>
+            <td>AnnotationPage</td>
+            <td>Class</td>
+            <td>The class of Annotation Pages.<br>This class <em class="rfc2119" title="MUST">MUST</em> be associated with the Page using <code>type</code>.</td>
+          </tr>
+          <tr>
+            <td>partOf</td>
+            <td>Relationship</td>
+            <td>The relationship between the Page and the Annotation Collection that it is part of.<br>Each Page <em class="rfc2119" title="SHOULD">SHOULD</em> have a exactly 1 <code>partOf</code> relationship to the Collection. Properties of the Collection, such as the total, <em class="rfc2119" title="MAY">MAY</em> be included in the representation of the Page.</td>
+          </tr>
+          <tr>
+            <td>items</td>
+            <td>Relationship</td>
+            <td>The list of Annotations that are the members of the Page.<br>Each Page <em class="rfc2119" title="MUST">MUST</em> have an array of 1 or more Annotations as the value of <code>items</code>.</td>
+          </tr>
+          <tr>
+            <td>next</td>
+            <td>Relationship</td>
+            <td>A reference to the next Page in the sequence of pages that make up the Collection.<br>If the current page is not the last page in the Collection, it <em class="rfc2119" title="MUST">MUST</em> have a reference to the IRI of the page that follows it.</td>
+          </tr>
+          <tr>
+            <td>prev</td>
+            <td>Relationship</td>
+            <td>A reference to the previous Page in the sequence of pages that make up the Collection.<br>If the current page is not the first page in the Collection, it <em class="rfc2119" title="SHOULD">SHOULD</em> have a reference to the IRI of the page that it follows.</td>
+          </tr>
+          <tr>
+            <td>startIndex</td>
+            <td>Property</td>
+            <td>The relative position of the first Annotation in the <code>items</code> list, relative to the Annotation Collection. The first entry in the first page is considered to be entry 0.<br>Each Page <em class="rfc2119" title="SHOULD">SHOULD</em> have exactly 1 <code>startIndex</code>, and <em class="rfc2119" title="MUST NOT">MUST NOT</em> have more than 1. The value <em class="rfc2119" title="MUST">MUST</em> be an <code>xsd:nonNegativeInteger</code>.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3 id="example-35">Example</h3>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 42</span><span style="text-transform: none">: Annotation Page</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"AnnotationPage"</span></span>,
+  "<span class="hljs-attribute">partOf</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/collection1"</span></span>,
+  "<span class="hljs-attribute">next</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page2"</span></span>,
+  "<span class="hljs-attribute">startIndex</span>": <span class="hljs-value"><span class="hljs-number">0</span></span>,
+  "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+    {
+      "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno1"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+      "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/comment1"</span></span>,
+      "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/book/chapter1"</span>
+    </span>},
+    {
+      "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno2"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+      "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/comment2"</span></span>,
+      "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/book/chapter2"</span>
+    </span>}
+  ]
+</span>}</pre></div>
+
+      <div class="example">
+        <div class="example-title marker"><span>Example 43</span><span style="text-transform: none">: Annotation Collection with Embedded Page</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/collection1"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"AnnotationCollection"</span></span>,
+  "<span class="hljs-attribute">label</span>": <span class="hljs-value"><span class="hljs-string">"Two Annotations"</span></span>,
+  "<span class="hljs-attribute">total</span>": <span class="hljs-value"><span class="hljs-number">2</span></span>,
+  "<span class="hljs-attribute">first</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/page1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"AnnotationPage"</span></span>,
+    "<span class="hljs-attribute">startIndex</span>": <span class="hljs-value"><span class="hljs-number">0</span></span>,
+    "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+      {
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno1"</span></span>,
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+        "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/comment1"</span></span>,
+        "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/book/chapter1"</span>
+      </span>},
+      {
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno2"</span></span>,
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+        "<span class="hljs-attribute">body</span>": <span class="hljs-value"><span class="hljs-string">"http://example.net/comment2"</span></span>,
+        "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/book/chapter2"</span>
+      </span>}
+    ]
+  </span>}
+</span>}</pre></div>
+
+    </section>
+  </section>
+  <!-- /Lists -->
+
+  <section id="media_selector" class="appendix" typeof="bibo:Chapter" resource="#media_selector" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-media_selector" resource="#h-media_selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Correspondance Among Media Types and Selectors</span></h2>
+
+    <p>The table below shows the relationships among major media types and selector types. It is relevant to the <a href="#conformance" class="sec-ref"><span class="secno">1.3</span> <span class="sec-title">Conformance</span></a> section of this document.
+    </p>
+
+    <div class="overlarge">
+      <table id="media_table" class="data">
+        <thead>
+          <tr>
+            <td> </td>
+            <th>Fragment</th>
+            <th>CSS</th>
+            <th>XPath</th>
+            <th>Text Quote</th>
+            <th>Text Position</th>
+            <th>Data Position</th>
+            <th>Svg</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>HTML (text/html)</th>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+          </tr>
+          <tr>
+            <th>CSV (text/csv)</th>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+          </tr>
+          <tr>
+            <th>Plain Text (text/plain)</th>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+          </tr>
+          <tr>
+            <th>Other text files (text/*) </th>
+            <td>?</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+          </tr>
+          <tr>
+            <th>EPUB2, EPUB3 (application/epub+zip)</th>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✘</td>
+          </tr>
+          <tr>
+            <th>PDF (application/pdf) </th>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+          </tr>
+          <tr>
+            <th>XML (application/xml, application/*+xml) </th>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+          </tr>
+          <tr>
+            <th>SVG (image/svg+xml)</th>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✔︎</td>
+          </tr>
+          <tr>
+            <th>Image, other than SVG (image/gif, image/jpeg, image/png, image/tiff)
+            </th>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>?</td>
+            <td>✔︎</td>
+          </tr>
+          <tr>
+            <th>Video (video/*)</th>
+            <td>✔︎</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>?</td>
+            <td>✔︎</td>
+          </tr>
+          <tr>
+            <th>Binary Data Files</th>
+            <td>?</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✘</td>
+            <td>✔︎</td>
+            <td>✘</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <section class="informative" id="additional-media-types-selector-combination" typeof="bibo:Chapter" resource="#additional-media-types-selector-combination" property="bibo:hasPart">
+      <h3 id="h-additional-media-types-selector-combination" resource="#h-additional-media-types-selector-combination"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Additional Media Types/Selector Combination</span></h3>
+      <p><em>This section is non-normative.</em></p>
+
+      <p>The table below contains some other, possible combinations of media types and selector types, which <em class="rfc2119" title="MAY">MAY</em> be implemented but are not mandated by this specification. Some of these combinations may also form the basis for defining new, implementation-specific selector extensions.</p>
+
+      <div class="overlarge">
+        <table class="data">
+          <caption>Additional relationships among other media types and selector types</caption>
+          <thead>
+            <tr>
+              <td> </td>
+              <th>Fragment</th>
+              <th>CSS</th>
+              <th>XPath</th>
+              <th>Text Quote</th>
+              <th>Text Position</th>
+              <th>Data Position</th>
+              <th>Svg</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>CSS (text/css)</th>
+              <td>✘</td>
+              <td>✘</td>
+              <td>✘</td>
+              <td>✔︎</td>
+              <td>✔︎</td>
+              <td>✘</td>
+              <td>✘</td>
+            </tr>
+            <tr>
+              <th>TSV (text/tab-separated-values)</th>
+              <td>✔︎<sup>✝</sup></td>
+              <td>✘</td>
+              <td>✘</td>
+              <td>✔︎</td>
+              <td>✔︎</td>
+              <td>✘</td>
+              <td>✘</td>
+            </tr>
+            <tr>
+              <th>RDF/Turtle (text/turtle)</th>
+              <td>✔︎<sup>✝</sup></td>
+              <td>✘</td>
+              <td>✘</td>
+              <td>?</td>
+              <td>?</td>
+              <td>✘</td>
+              <td>✘</td>
+            </tr>
+            <tr>
+              <th>JSON (application/json, application/*+json)</th>
+              <td>✘</td>
+              <td>✘</td>
+              <td>✘</td>
+              <td>✔︎</td>
+              <td>?</td>
+              <td>✘</td>
+              <td>✘</td>
+            </tr>
+            <tr>
+              <th>Programming languages (application/javascript, python files, etc.)</th>
+              <td>✘</td>
+              <td>✘</td>
+              <td>✘</td>
+              <td>✔︎</td>
+              <td>?</td>
+              <td>✘</td>
+              <td>✘</td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="8" style="font-size:70%">
+                <sup>✝</sup>Fragments are not formally defined through IETF, though there are well-known connections to existing fragments or practices
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </section>
+  </section>
+
+  <section class="appendix informative" id="complete-example" typeof="bibo:Chapter" resource="#complete-example" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-complete-example" resource="#h-complete-example"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>Complete Example</span></h2>
+    <p><em>This section is non-normative.</em></p>
+
+    <p><b>Entirely Contrived Example Use Case:</b> Melanie wants to associate a comment that she wrote in English within the annotation or a external mp3 of the same content in German by someone else, plus a tag, with a range of characters from a particular element in an XML representation of a document as it was at a certain point in time, and for it to be displayed in a particular way.</p>
+
+    <div class="example">
+      <div class="example-title marker"><span>Example 44</span><span style="text-transform: none">: Complete Example</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno41"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">motivation</span>": <span class="hljs-value"><span class="hljs-string">"commenting"</span></span>,
+  "<span class="hljs-attribute">creator</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/user1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Person"</span></span>,
+    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"A. Person"</span></span>,
+    "<span class="hljs-attribute">account</span>": <span class="hljs-value"><span class="hljs-string">"user1"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">created</span>": <span class="hljs-value"><span class="hljs-string">"2015-10-13T13:00:00Z"</span></span>,
+  "<span class="hljs-attribute">generator</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/client1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"SoftwareAgent"</span></span>,
+    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"Code v2.1"</span></span>,
+    "<span class="hljs-attribute">homepage</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/homepage1"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">generated</span>": <span class="hljs-value"><span class="hljs-string">"2015-10-14T15:13:28Z"</span></span>,
+  "<span class="hljs-attribute">stylesheet</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/stylesheet1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"CssStylesheet"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">[
+    {
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+      "<span class="hljs-attribute">purpose</span>": <span class="hljs-value"><span class="hljs-string">"tagging"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"love"</span>
+    </span>},
+    {
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Choice"</span></span>,
+      "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+          "<span class="hljs-attribute">purpose</span>": <span class="hljs-value"><span class="hljs-string">"describing"</span></span>,
+          "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I really love this particular bit of text in this XML. No really."</span></span>,
+          "<span class="hljs-attribute">format</span>": <span class="hljs-value"><span class="hljs-string">"text/plain"</span></span>,
+          "<span class="hljs-attribute">language</span>": <span class="hljs-value"><span class="hljs-string">"en"</span></span>,
+          "<span class="hljs-attribute">creator</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/user1"</span>
+        </span>},
+        {
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"SpecificResource"</span></span>,
+          "<span class="hljs-attribute">purpose</span>": <span class="hljs-value"><span class="hljs-string">"describing"</span></span>,
+          "<span class="hljs-attribute">source</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/comment1"</span></span>,
+            "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Audio"</span></span>,
+            "<span class="hljs-attribute">format</span>": <span class="hljs-value"><span class="hljs-string">"audio/mpeg"</span></span>,
+            "<span class="hljs-attribute">language</span>": <span class="hljs-value"><span class="hljs-string">"de"</span></span>,
+            "<span class="hljs-attribute">creator</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/user2"</span></span>,
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Person"</span>
+            </span>}
+          </span>}
+        </span>}
+      ]
+    </span>}
+  ]</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"SpecificResource"</span></span>,
+    "<span class="hljs-attribute">styleClass</span>": <span class="hljs-value"><span class="hljs-string">"mystyle"</span></span>,
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/document1"</span></span>,
+    "<span class="hljs-attribute">state</span>": <span class="hljs-value">[
+      {
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"HttpRequestState"</span></span>,
+        "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"Accept: application/xml"</span>
+      </span>},
+      {
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TimeState"</span></span>,
+        "<span class="hljs-attribute">sourceDate</span>": <span class="hljs-value"><span class="hljs-string">"2015-09-25T12:00:00Z"</span>
+      </span>}
+    ]</span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"FragmentSelector"</span></span>,
+      "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"xpointer(/doc/body/section[2]/para[1])"</span></span>,
+      "<span class="hljs-attribute">refinedBy</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextPositionSelector"</span></span>,
+        "<span class="hljs-attribute">start</span>": <span class="hljs-value"><span class="hljs-number">6</span></span>,
+        "<span class="hljs-attribute">end</span>": <span class="hljs-value"><span class="hljs-number">27</span>
+      </span>}
+    </span>}
+  </span>}
+</span>}</pre></div>
+  </section>
+
+  <section class="appendix informative" id="index-of-json-keys" typeof="bibo:Chapter" resource="#index-of-json-keys" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-index-of-json-keys" resource="#h-index-of-json-keys"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>Index of JSON Keys</span></h2>
+    <p><em>This section is non-normative.</em></p>
+
+    <table class="model">
+      <tbody>
+        <tr>
+          <th>Key</th>
+          <th>Usage</th>
+        </tr>
+        <tr>
+          <td>accessibility</td>
+          <td><a href="#accessibility-of-content">Body, Target</a></td>
+        </tr>
+        <tr>
+          <td>account</td>
+          <td><a href="#agents">Agent</a></td>
+        </tr>
+        <tr>
+          <td>audience</td>
+          <td><a href="#intended-audience">Audience</a></td>
+        </tr>
+        <tr>
+          <td>body</td>
+          <td><a href="#annotations">Annotation</a></td>
+        </tr>
+        <tr>
+          <td>bodyValue</td>
+          <td><a href="#string-body">String Body</a></td>
+        </tr>
+        <tr>
+          <td>cached</td>
+          <td><a href="#time-state">Time State</a></td>
+        </tr>
+        <tr>
+          <td>canonical</td>
+          <td><a href="#other-identities">Annotation, Body, Target</a></td>
+        </tr>
+        <tr>
+          <td>conformsTo</td>
+          <td><a href="#fragment-selector">Fragment Selector</a></td>
+        </tr>
+        <tr>
+          <td>created</td>
+          <td><a href="#lifecycle-information">Annotation, Body, Target</a></td>
+        </tr>
+        <tr>
+          <td>creator</td>
+          <td><a href="#lifecycle-information">Annotation, Body, Target</a></td>
+        </tr>
+        <tr>
+          <td>email</td>
+          <td><a href="#agents">Agent</a></td>
+        </tr>
+        <tr>
+          <td>email_sha1</td>
+          <td><a href="#agents">Agent</a></td>
+        </tr>
+        <tr>
+          <td>end</td>
+          <td><a href="#text-position-selector">Text Position Selector</a>, <a href="#data-position-selector">Data Position Selector</a></td>
+        </tr>
+        <tr>
+          <td>endSelector</td>
+          <td><a href="#range-selector">Range Selector</a></td>
+        </tr>
+        <tr>
+          <td>exact</td>
+          <td><a href="#text-quote-selector">Text Quote Selector</a></td>
+        </tr>
+        <tr>
+          <td>first</td>
+          <td><a href="#annotation-collection">Annotation Collection</a></td>
+        </tr>
+        <tr>
+          <td>format</td>
+          <td><a href="#external-web-resources">Body, Target</a>, <a href="#svg-selector">SVG Selector</a></td>
+        </tr>
+        <tr>
+          <td>generated</td>
+          <td><a href="#lifecycle-information">Annotation</a></td>
+        </tr>
+        <tr>
+          <td>generator</td>
+          <td><a href="#lifecycle-information">Annotation</a></td>
+        </tr>
+        <tr>
+          <td>homepage</td>
+          <td><a href="#agents">Agents</a></td>
+        </tr>
+        <tr>
+          <td class="top_cell">id</td>
+          <td>Note: Every object <em class="rfc2119" title="MAY">MAY</em> have an <code>id</code>.<br><a href="#annotations">Annotation</a>, <a href="#external-web-resources">Body, Target</a>, <a href="#segments-of-external-resources">Segments of External Resources</a>, <a href="#embedded-textual-body">Embedded Textual Body</a>, <a href="#agents">Agent</a>, <a href="#intended-audience">Audience</a>, <a href="#specific-resources">Specific Resource</a></td>
+        </tr>
+        <tr>
+          <td>items</td>
+          <td><a href="#choice-of-bodies-and-targets">Choice</a>, <a href="#annotation-page">Annotation Page</a></td>
+        </tr>
+        <tr>
+          <td>label</td>
+          <td><a href="#annotation-collection">Annotation Collection</a></td>
+        </tr>
+        <tr>
+          <td>language</td>
+          <td><a href="#external-web-resources">Body, Target</a></td>
+        </tr>
+        <tr>
+          <td>last</td>
+          <td><a href="#annotation-collection">Annotation Collection</a></td>
+        </tr>
+        <tr>
+          <td>modified</td>
+          <td><a href="#lifecycle-information">Annotation, Body, Target</a></td>
+        </tr>
+        <tr>
+          <td>motivation</td>
+          <td><a href="#motivation-and-purpose">Annotation</a></td>
+        </tr>
+        <tr>
+          <td>name</td>
+          <td><a href="#agents">Agent</a></td>
+        </tr>
+        <tr>
+          <td>next</td>
+          <td><a href="#annotation-page">Annotation Page</a></td>
+        </tr>
+        <tr>
+          <td>partOf</td>
+          <td><a href="#annotation-page">Annotation Page</a></td>
+        </tr>
+        <tr>
+          <td>prefix</td>
+          <td><a href="#text-quote-selector">Text Quote Selector</a></td>
+        </tr>
+        <tr>
+          <td>prev</td>
+          <td><a href="#annotation-page">Annotation Page</a></td>
+        </tr>
+        <tr>
+          <td>purpose</td>
+          <td><a href="#motivation-and-purpose">Textual Body</a>, <a href="#purpose-for-external-web-resources">Specific Resource</a></td>
+        </tr>
+        <tr>
+          <td>renderedVia</td>
+          <td><a href="#rendering-software">Specific Resource</a></td>
+        </tr>
+        <tr>
+          <td>rights</td>
+          <td><a href="#rights-information">Annotation, Body, Target</a></td>
+        </tr>
+        <tr>
+          <td>refinedBy</td>
+          <td><a href="#refinement-of-selection">Selector</a>, <a href="#refinement-of-state">State</a></td>
+        </tr>
+        <tr>
+          <td>scope</td>
+          <td><a href="#scope-of-a-resource">Specific Resource</a></td>
+        </tr>
+        <tr>
+          <td>selector</td>
+          <td><a href="#selectors">Specific Resource</a></td>
+        </tr>
+        <tr>
+          <td>source</td>
+          <td><a href="#specific-resources">Specific Resource</a></td>
+        </tr>
+        <tr>
+          <td>sourceDate</td>
+          <td><a href="#time-state">Time State</a></td>
+        </tr>
+        <tr>
+          <td>sourceDateEnd</td>
+          <td><a href="#time-state">Time State</a></td>
+        </tr>
+        <tr>
+          <td>sourceDateStart</td>
+          <td><a href="#time-state">Time State</a></td>
+        </tr>
+        <tr>
+          <td>start</td>
+          <td><a href="#text-position-selector">Text Position Selector</a>, <a href="#data-position-selector">Data Position Selector</a></td>
+        </tr>
+        <tr>
+          <td>startIndex</td>
+          <td><a href="#annotation-page">Annotation Page</a></td>
+        </tr>
+        <tr>
+          <td>startSelector</td>
+          <td><a href="#range-selector">Range Selector</a></td>
+        </tr>
+        <tr>
+          <td>state</td>
+          <td><a href="#states">Specific Resource</a></td>
+        </tr>
+        <tr>
+          <td>styleClass</td>
+          <td><a href="#styles">Specific Resource</a></td>
+        </tr>
+        <tr>
+          <td>stylesheet</td>
+          <td><a href="#styles">Annotation</a></td>
+        </tr>
+        <tr>
+          <td>suffix</td>
+          <td><a href="#text-quote-selector">Text Quote Selector</a></td>
+        </tr>
+        <tr>
+          <td>target</td>
+          <td><a href="#annotations">Annotation</a></td>
+        </tr>
+        <tr>
+          <td>textDirection</td>
+          <td><a href="#external-web-resources">Body, Target</a></td>
+        </tr>
+        <tr>
+          <td>total</td>
+          <td><a href="#annotation-collection">Annotation Collection</a></td>
+        </tr>
+        <tr>
+          <td class="top_cell">type</td>
+          <td>Note: Every object <em class="rfc2119" title="MAY">MAY</em> have a <code>type</code>.<br> <a href="#annotations">Annotation</a>, <a href="#classes">Body, Target</a>, <a href="#embedded-textual-body">Embedded Textual Body</a>, <a href="#agents">Agent</a>, <a href="#intended-audience">Audience</a>, <a href="#specific-resources">Specific Resource</a>, <a href="#fragment-selector">Fragment Selector</a>, <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a>, <a href="#text-quote-selector">Text Quote Selector</a>, <a href="#text-position-selector">Text Position Selector</a>, <a href="#data-position-selector">Data Position Selector</a>, <a href="#svg-selector">SVG Selector</a>, <a href="#time-state">Time State</a>, <a href="#request-header-state">Request Header State</a>, <a href="#styles">CSS Stylesheet</a></td>
+        </tr>
+        <tr>
+          <td>value</td>
+          <td> <a href="#embedded-textual-body">Textual Body</a>, <a href="#fragment-selector">Fragment Selector</a>, <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a>, <a href="#svg-selector">SVG Selector</a>, <a href="#request-header-state">Request Header State</a>, <a href="#styles">CSS Stylesheet</a></td>
+        </tr>
+        <tr>
+          <td>via</td>
+          <td><a href="#other-identities">Annotation, Body, Target</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="appendix informative" id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">D. </span>Acknowledgements</span></h2>
+    <p><em>This section is non-normative.</em></p>
+
+    <p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>. The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model. In particular the editors would like to thank Herbert Van de Sompel of Los Alamos National Laboratory for his editorial contributions throughout the Community Group process.
+    </p>
+
+    <p>The following people have been instrumental in providing thoughts, feedback, reviews, content, criticism and input in the creation of this specification:
+
+    </p>
+    <div style="margin-left: 3em">
+      Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven Capadisli, Paolo Ciccarese, Tim Cole, Ray Denenberg, TB Dinesh, Sergiu Gordea, Benjamin Goering, Amy Guy, Ivan Herman, Frederick Hirsch, Antoine Isaac, Jacob Jett, Takeshi Kanai, Gregg Kellogg, Andreas Kuckartz, Randall Leeds, Hugo Manguinhas, Ben De Meester, Luc Moreau, Addison Phillips, Davis Salisbury, Robert Sanderson, Felix Sasaki, Doug Schepers, Tzviya Siegman, Stian Soiland-Reyes, Manu Sporney, Nick Stenning, Jon Stroop, Lutz Suhrbier, Kyrce Swenson, Raphael Troncy, Simeon Warner, Erik Wilde, Dan Whaley, Benjamin Young
+    </div>
+    <p></p>
+  </section>
+
+  <section class="appendix informative" id="changes-from-previous-draft" typeof="bibo:Chapter" resource="#changes-from-previous-draft" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-changes-from-previous-draft" resource="#h-changes-from-previous-draft"><span property="xhv:role" resource="xhv:heading"><span class="secno">E. </span>Changes from Previous Draft</span></h2>
+    <p><em>This section is non-normative.</em></p>
+
+    <p>
+    </p>
+    <ul>
+      <li>Addition of conformance section and media table</li>
+      <li>Remove Content class as unnecessary, and reuse <code>value</code> in place of the previous distinct <code>text</code> property.</li>
+    </ul>
+    <p></p>
+
+
+    <h2 id="changes-from-the-open-annotation-draft">Changes from the Open Annotation Draft</h2>
+
+    <p>
+      Significant technical changes in this specification from the Open Annotation Community Group's draft are:
+    </p>
+    <ul>
+      <li>Use intuitive, memorable and developer-friendly names for the JSON-LD keys. (<a href="#annotations">text</a>)</li>
+      <li>Replace the ContentAsText construction which was not taken through the standardization process. (<a href="#embedded-textual-body">text</a>)</li>
+      <li>Allow a string literal as the body via bodyText. (<a href="#string-body">text</a>)</li>
+      <li>Allow an ordered list of options for Choice. (<a href="#choice-of-bodies-and-targets">text</a>)
+      </li>
+      <li>Add additional core lifecycle metadata for resources, including <a href="#rights-information">rights information</a> and <a href="#intended-audience">intended audience</a>. (<a href="#lifecycle-information">text</a>)</li>
+      <li>Align identity equivalence with other standards. (<a href="#other-identities">text</a>)</li>
+      <li>Allow association of Motivation as roles/purposes on a per body or target basis, including alignment of Tags and Semantic Tags. (<a href="#purpose-for-external-web-resources">text</a>)</li>
+      <li>Introduce <a href="#css-selector">CSS Selector</a>, <a href="#xpath-selector">XPath Selector</a> and <a href="#range-selector">Range Selector</a> from implementation experience. </li>
+      <li>Use structure rather than resources for multiple specificiers. (<a href="#refinement-of-selection">text</a>)</li>
+      <li>Add the capability to describe rendering software. (<a href="#rendering-software">text</a>)</li>
+      <li>Add <a href="#annotation-collection">Collections of Annotations</a> as a defined pattern.</li>
+      <li>Separate the ontology [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>] from the model and JSON serialization.</li>
+      <li>Deprecate embedded graphs as an explicit part of the model, instead just include or reference a serialized graph.</li>
+    </ul>
+    <p></p>
+
+  </section>
 
 
 
 
-<section property="bibo:hasPart" resource="#references" typeof="bibo:Chapter" id="references" class="appendix"><!--OddPage--><h2 resource="#h-references" id="h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">F. </span>References</span></h2><section property="bibo:hasPart" resource="#normative-references" typeof="bibo:Chapter" id="normative-references"><h3 resource="#h-normative-references" id="h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">F.1 </span>Normative references</span></h3><dl resource="" class="bibliography"><dt id="bib-CSS3-selectors">[CSS3-selectors]</dt><dd>Tantek Çelik; Elika Etemad; Daniel Glazman; Ian Hickson; Peter Linss; John Williams et al. W3C. <a property="dc:requires" href="http://www.w3.org/TR/css3-selectors/"><cite>Selectors Level 3</cite></a>. 29 September 2011. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/css3-selectors/">http://www.w3.org/TR/css3-selectors/</a>
-</dd><dt id="bib-DOM-Level-3-Core">[DOM-Level-3-Core]</dt><dd>Arnaud Le Hors; Philippe Le Hégaret; Lauren Wood; Gavin Nicol; Jonathan Robie; Mike Champion; Steven B Byrne et al. W3C. <a property="dc:requires" href="http://www.w3.org/TR/DOM-Level-3-Core/"><cite>Document Object Model (DOM) Level 3 Core Specification</cite></a>. 7 April 2004. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/DOM-Level-3-Core/">http://www.w3.org/TR/DOM-Level-3-Core/</a>
-</dd><dt id="bib-DOM-Level-3-XPath">[DOM-Level-3-XPath]</dt><dd>Ray Whitmer. W3C. <a property="dc:requires" href="http://www.w3.org/TR/DOM-Level-3-XPath/"><cite>Document Object Model (DOM) Level 3 XPath Specification</cite></a>. 26 February 2004. W3C Note. URL: <a property="dc:requires" href="http://www.w3.org/TR/DOM-Level-3-XPath/">http://www.w3.org/TR/DOM-Level-3-XPath/</a>
-</dd><dt id="bib-JSON-LD">[JSON-LD]</dt><dd>Manu Sporny; Gregg Kellogg; Markus Lanthaler. W3C. <a property="dc:requires" href="http://www.w3.org/TR/json-ld/"><cite>JSON-LD 1.0</cite></a>. 16 January 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/json-ld/">http://www.w3.org/TR/json-ld/</a>
-</dd><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-</dd><dt id="bib-SVG">[SVG]</dt><dd>Jon Ferraiolo. W3C. <a property="dc:requires" href="http://www.w3.org/TR/SVG/"><cite>Scalable Vector Graphics (SVG) 1.0 Specification</cite></a>. 4 September 2001. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/SVG/">http://www.w3.org/TR/SVG/</a>
-</dd><dt id="bib-annotation-protocol">[annotation-protocol]</dt><dd>Robert Sanderson. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/"><cite>Web Annotation Protocol</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a>
-</dd><dt id="bib-annotation-vocab">[annotation-vocab]</dt><dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/"><cite>Web Annotation Vocabulary</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/">http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/</a>
-</dd><dt id="bib-bcp47">[bcp47]</dt><dd>A. Phillips; M. Davis. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/bcp47"><cite>Tags for Identifying Languages</cite></a>. September 2009. IETF Best Current Practice. URL: <a property="dc:requires" href="https://tools.ietf.org/html/bcp47">https://tools.ietf.org/html/bcp47</a>
-</dd><dt id="bib-cfi">[cfi]</dt><dd>Peter Sorotokin; Garth Conboy; Brady Duga; John Rivlin; Don Beaver; Kevin Ballard; Alastair Fettes; Daniel Weck. IDPF. <a property="dc:requires" href="http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html"><cite>EPUB Canonical Fragment Identifiers</cite></a>. Recommended Specification. URL: <a property="dc:requires" href="http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html">http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html</a>
-</dd><dt id="bib-fragid-best-practices">[fragid-best-practices]</dt><dd>Jeni Tennison. W3C. <a property="dc:requires" href="http://www.w3.org/TR/fragid-best-practices/"><cite>Best Practices for Fragment Identifiers and Media Type Definitions</cite></a>. 25 October 2012. W3C Last Call Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/fragid-best-practices/">http://www.w3.org/TR/fragid-best-practices/</a>
-</dd><dt id="bib-media-frags">[media-frags]</dt><dd>Raphaël Troncy; Erik Mannens; Silvia Pfeiffer; Davy Van Deursen. W3C. <a property="dc:requires" href="http://www.w3.org/TR/media-frags/"><cite>Media Fragments URI 1.0 (basic)</cite></a>. 25 September 2012. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/media-frags/">http://www.w3.org/TR/media-frags/</a>
-</dd><dt id="bib-rfc3023">[rfc3023]</dt><dd>M. Murata; S. St. Laurent; D. Kohn. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc3023"><cite>XML Media Types</cite></a>. January 2001. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc3023">https://tools.ietf.org/html/rfc3023</a>
-</dd><dt id="bib-rfc3236">[rfc3236]</dt><dd>M. Baker; P. Stark. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc3236"><cite>The 'application/xhtml+xml' Media Type</cite></a>. January 2002. Informational. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc3236">https://tools.ietf.org/html/rfc3236</a>
-</dd><dt id="bib-rfc3778">[rfc3778]</dt><dd>E. Taft; J. Pravetz; S. Zilles; L. Masinter. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc3778"><cite>The application/pdf Media Type</cite></a>. May 2004. Informational. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc3778">https://tools.ietf.org/html/rfc3778</a>
-</dd><dt id="bib-rfc3870">[rfc3870]</dt><dd>A. Swartz. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc3870"><cite>application/rdf+xml Media Type Registration</cite></a>. September 2004. Informational. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc3870">https://tools.ietf.org/html/rfc3870</a>
-</dd><dt id="bib-rfc3987">[rfc3987]</dt><dd>M. Duerst; M. Suignard. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc3987"><cite>Internationalized Resource Identifiers (IRIs)</cite></a>. January 2005. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc3987">https://tools.ietf.org/html/rfc3987</a>
-</dd><dt id="bib-rfc5147">[rfc5147]</dt><dd>E. Wilde; M. Duerst. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc5147"><cite>URI Fragment Identifiers for the text/plain Media Type</cite></a>. April 2008. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc5147">https://tools.ietf.org/html/rfc5147</a>
-</dd><dt id="bib-rfc6086">[rfc6086]</dt><dd>C. Holmberg; E. Burger; H. Kaplan. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc6086"><cite>Session Initiation Protocol (SIP) INFO Method and Package Framework</cite></a>. January 2011. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc6086">https://tools.ietf.org/html/rfc6086</a>
-</dd><dt id="bib-rfc6838">[rfc6838]</dt><dd>N. Freed; J. Klensin; T. Hansen. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc6838"><cite>Media Type Specifications and Registration Procedures</cite></a>. January 2013. Best Current Practice. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc6838">https://tools.ietf.org/html/rfc6838</a>
-</dd><dt id="bib-rfc7089">[rfc7089]</dt><dd>H. Van de Sompel; M. Nelson; R. Sanderson. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc7089"><cite>HTTP Framework for Time-Based Access to Resource States -- Memento</cite></a>. December 2013. Informational. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc7089">https://tools.ietf.org/html/rfc7089</a>
-</dd><dt id="bib-rfc7111">[rfc7111]</dt><dd>M. Hausenblas; E. Wilde; J. Tennison. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc7111"><cite>URI Fragment Identifiers for the text/csv Media Type</cite></a>. January 2014. Informational. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc7111">https://tools.ietf.org/html/rfc7111</a>
-</dd><dt id="bib-webarch">[webarch]</dt><dd>Ian Jacobs; Norman Walsh. W3C. <a property="dc:requires" href="http://www.w3.org/TR/webarch/"><cite>Architecture of the World Wide Web, Volume One</cite></a>. 15 December 2004. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/webarch/">http://www.w3.org/TR/webarch/</a>
-</dd></dl></section><section property="bibo:hasPart" resource="#informative-references" typeof="bibo:Chapter" id="informative-references"><h3 resource="#h-informative-references" id="h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">F.2 </span>Informative references</span></h3><dl resource="" class="bibliography"><dt id="bib-iana-media-types">[iana-media-types]</dt><dd>IANA (Internet Assigned Numbers Authority). <a property="dc:references" href="http://www.iana.org/assignments/media-types/"><cite>Media Types</cite></a>. URL: <a property="dc:references" href="http://www.iana.org/assignments/media-types/">http://www.iana.org/assignments/media-types/</a>
-</dd><dt id="bib-w3c-language-tags">[w3c-language-tags]</dt><dd>W3C. <a property="dc:references" href="https://www.w3.org/International/articles/language-tags/"><cite>Language Tags in HTML and XML</cite></a>. URL: <a property="dc:references" href="https://www.w3.org/International/articles/language-tags/">https://www.w3.org/International/articles/language-tags/</a>
-</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js" defer="" async=""></script></body></html>
+  <section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">F. </span>References</span></h2>
+
+    <section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart">
+      <h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">F.1 </span>Normative references</span></h3>
+      <dl class="bibliography" resource=""><dt id="bib-CSS3-selectors">[CSS3-selectors]</dt>
+        <dd>Tantek Çelik; Elika Etemad; Daniel Glazman; Ian Hickson; Peter Linss; John Williams et al. W3C. <a href="http://www.w3.org/TR/css3-selectors/" property="dc:requires"><cite>Selectors Level 3</cite></a>. 29 September 2011. W3C Recommendation. URL: <a href="http://www.w3.org/TR/css3-selectors/" property="dc:requires">http://www.w3.org/TR/css3-selectors/</a>
+        </dd><dt id="bib-DOM-Level-3-Core">[DOM-Level-3-Core]</dt>
+        <dd>Arnaud Le Hors; Philippe Le Hégaret; Lauren Wood; Gavin Nicol; Jonathan Robie; Mike Champion; Steven B Byrne et al. W3C. <a href="http://www.w3.org/TR/DOM-Level-3-Core/" property="dc:requires"><cite>Document Object Model (DOM) Level 3 Core Specification</cite></a>. 7 April 2004. W3C Recommendation. URL: <a href="http://www.w3.org/TR/DOM-Level-3-Core/" property="dc:requires">http://www.w3.org/TR/DOM-Level-3-Core/</a>
+        </dd><dt id="bib-DOM-Level-3-XPath">[DOM-Level-3-XPath]</dt>
+        <dd>Ray Whitmer. W3C. <a href="http://www.w3.org/TR/DOM-Level-3-XPath/" property="dc:requires"><cite>Document Object Model (DOM) Level 3 XPath Specification</cite></a>. 26 February 2004. W3C Note. URL: <a href="http://www.w3.org/TR/DOM-Level-3-XPath/" property="dc:requires">http://www.w3.org/TR/DOM-Level-3-XPath/</a>
+        </dd><dt id="bib-JSON-LD">[JSON-LD]</dt>
+        <dd>Manu Sporny; Gregg Kellogg; Markus Lanthaler. W3C. <a href="http://www.w3.org/TR/json-ld/" property="dc:requires"><cite>JSON-LD 1.0</cite></a>. 16 January 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/json-ld/" property="dc:requires">http://www.w3.org/TR/json-ld/</a>
+        </dd><dt id="bib-RFC2119">[RFC2119]</dt>
+        <dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+        </dd><dt id="bib-SVG">[SVG]</dt>
+        <dd>Jon Ferraiolo. W3C. <a href="http://www.w3.org/TR/SVG/" property="dc:requires"><cite>Scalable Vector Graphics (SVG) 1.0 Specification</cite></a>. 4 September 2001. W3C Recommendation. URL: <a href="http://www.w3.org/TR/SVG/" property="dc:requires">http://www.w3.org/TR/SVG/</a>
+        </dd><dt id="bib-annotation-protocol">[annotation-protocol]</dt>
+        <dd>Robert Sanderson. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/" property="dc:requires"><cite>Web Annotation Protocol</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a>
+        </dd><dt id="bib-annotation-vocab">[annotation-vocab]</dt>
+        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/" property="dc:requires"><cite>Web Annotation Vocabulary</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/</a>
+        </dd><dt id="bib-bcp47">[bcp47]</dt>
+        <dd>A. Phillips; M. Davis. IETF. <a href="https://tools.ietf.org/html/bcp47" property="dc:requires"><cite>Tags for Identifying Languages</cite></a>. September 2009. IETF Best Current Practice. URL: <a href="https://tools.ietf.org/html/bcp47" property="dc:requires">https://tools.ietf.org/html/bcp47</a>
+        </dd><dt id="bib-cfi">[cfi]</dt>
+        <dd>Peter Sorotokin; Garth Conboy; Brady Duga; John Rivlin; Don Beaver; Kevin Ballard; Alastair Fettes; Daniel Weck. IDPF. <a href="http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html" property="dc:requires"><cite>EPUB Canonical Fragment Identifiers</cite></a>. Recommended Specification. URL: <a href="http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html" property="dc:requires">http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html</a>
+        </dd><dt id="bib-fragid-best-practices">[fragid-best-practices]</dt>
+        <dd>Jeni Tennison. W3C. <a href="http://www.w3.org/TR/fragid-best-practices/" property="dc:requires"><cite>Best Practices for Fragment Identifiers and Media Type Definitions</cite></a>. 25 October 2012. W3C Last Call Working Draft. URL: <a href="http://www.w3.org/TR/fragid-best-practices/" property="dc:requires">http://www.w3.org/TR/fragid-best-practices/</a>
+        </dd><dt id="bib-media-frags">[media-frags]</dt>
+        <dd>Raphaël Troncy; Erik Mannens; Silvia Pfeiffer; Davy Van Deursen. W3C. <a href="http://www.w3.org/TR/media-frags/" property="dc:requires"><cite>Media Fragments URI 1.0 (basic)</cite></a>. 25 September 2012. W3C Recommendation. URL: <a href="http://www.w3.org/TR/media-frags/" property="dc:requires">http://www.w3.org/TR/media-frags/</a>
+        </dd><dt id="bib-rfc3023">[rfc3023]</dt>
+        <dd>M. Murata; S. St. Laurent; D. Kohn. IETF. <a href="https://tools.ietf.org/html/rfc3023" property="dc:requires"><cite>XML Media Types</cite></a>. January 2001. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc3023" property="dc:requires">https://tools.ietf.org/html/rfc3023</a>
+        </dd><dt id="bib-rfc3236">[rfc3236]</dt>
+        <dd>M. Baker; P. Stark. IETF. <a href="https://tools.ietf.org/html/rfc3236" property="dc:requires"><cite>The 'application/xhtml+xml' Media Type</cite></a>. January 2002. Informational. URL: <a href="https://tools.ietf.org/html/rfc3236" property="dc:requires">https://tools.ietf.org/html/rfc3236</a>
+        </dd><dt id="bib-rfc3778">[rfc3778]</dt>
+        <dd>E. Taft; J. Pravetz; S. Zilles; L. Masinter. IETF. <a href="https://tools.ietf.org/html/rfc3778" property="dc:requires"><cite>The application/pdf Media Type</cite></a>. May 2004. Informational. URL: <a href="https://tools.ietf.org/html/rfc3778" property="dc:requires">https://tools.ietf.org/html/rfc3778</a>
+        </dd><dt id="bib-rfc3870">[rfc3870]</dt>
+        <dd>A. Swartz. IETF. <a href="https://tools.ietf.org/html/rfc3870" property="dc:requires"><cite>application/rdf+xml Media Type Registration</cite></a>. September 2004. Informational. URL: <a href="https://tools.ietf.org/html/rfc3870" property="dc:requires">https://tools.ietf.org/html/rfc3870</a>
+        </dd><dt id="bib-rfc3987">[rfc3987]</dt>
+        <dd>M. Duerst; M. Suignard. IETF. <a href="https://tools.ietf.org/html/rfc3987" property="dc:requires"><cite>Internationalized Resource Identifiers (IRIs)</cite></a>. January 2005. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc3987" property="dc:requires">https://tools.ietf.org/html/rfc3987</a>
+        </dd><dt id="bib-rfc5147">[rfc5147]</dt>
+        <dd>E. Wilde; M. Duerst. IETF. <a href="https://tools.ietf.org/html/rfc5147" property="dc:requires"><cite>URI Fragment Identifiers for the text/plain Media Type</cite></a>. April 2008. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5147" property="dc:requires">https://tools.ietf.org/html/rfc5147</a>
+        </dd><dt id="bib-rfc6086">[rfc6086]</dt>
+        <dd>C. Holmberg; E. Burger; H. Kaplan. IETF. <a href="https://tools.ietf.org/html/rfc6086" property="dc:requires"><cite>Session Initiation Protocol (SIP) INFO Method and Package Framework</cite></a>. January 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6086" property="dc:requires">https://tools.ietf.org/html/rfc6086</a>
+        </dd><dt id="bib-rfc6838">[rfc6838]</dt>
+        <dd>N. Freed; J. Klensin; T. Hansen. IETF. <a href="https://tools.ietf.org/html/rfc6838" property="dc:requires"><cite>Media Type Specifications and Registration Procedures</cite></a>. January 2013. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc6838" property="dc:requires">https://tools.ietf.org/html/rfc6838</a>
+        </dd><dt id="bib-rfc7089">[rfc7089]</dt>
+        <dd>H. Van de Sompel; M. Nelson; R. Sanderson. IETF. <a href="https://tools.ietf.org/html/rfc7089" property="dc:requires"><cite>HTTP Framework for Time-Based Access to Resource States -- Memento</cite></a>. December 2013. Informational. URL: <a href="https://tools.ietf.org/html/rfc7089" property="dc:requires">https://tools.ietf.org/html/rfc7089</a>
+        </dd><dt id="bib-rfc7111">[rfc7111]</dt>
+        <dd>M. Hausenblas; E. Wilde; J. Tennison. IETF. <a href="https://tools.ietf.org/html/rfc7111" property="dc:requires"><cite>URI Fragment Identifiers for the text/csv Media Type</cite></a>. January 2014. Informational. URL: <a href="https://tools.ietf.org/html/rfc7111" property="dc:requires">https://tools.ietf.org/html/rfc7111</a>
+        </dd><dt id="bib-webarch">[webarch]</dt>
+        <dd>Ian Jacobs; Norman Walsh. W3C. <a href="http://www.w3.org/TR/webarch/" property="dc:requires"><cite>Architecture of the World Wide Web, Volume One</cite></a>. 15 December 2004. W3C Recommendation. URL: <a href="http://www.w3.org/TR/webarch/" property="dc:requires">http://www.w3.org/TR/webarch/</a>
+        </dd>
+      </dl>
+    </section>
+
+    <section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart">
+      <h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">F.2 </span>Informative references</span></h3>
+      <dl class="bibliography" resource=""><dt id="bib-iana-media-types">[iana-media-types]</dt>
+        <dd>IANA (Internet Assigned Numbers Authority). <a href="http://www.iana.org/assignments/media-types/" property="dc:references"><cite>Media Types</cite></a>. URL: <a href="http://www.iana.org/assignments/media-types/" property="dc:references">http://www.iana.org/assignments/media-types/</a>
+        </dd><dt id="bib-w3c-language-tags">[w3c-language-tags]</dt>
+        <dd>W3C. <a href="https://www.w3.org/International/articles/language-tags/" property="dc:references"><cite>Language Tags in HTML and XML</cite></a>. URL: <a href="https://www.w3.org/International/articles/language-tags/" property="dc:references">https://www.w3.org/International/articles/language-tags/</a>
+        </dd>
+      </dl>
+    </section>
+  </section>
+  <p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p>
+  <script async="" defer="" src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+</body>
+</html>

--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -26,8 +26,6 @@
  text-align: left;
  font-family: sans-serif;
 }
-
-
 </style>
         <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async='true' class='remove'></script>
         <script class='remove'>
@@ -184,7 +182,7 @@ The Web Annotation Protocol is defined using the following basic principles:
   <h2>Annotation Retrieval</h2>
 
 <p>
-  The Annotation Server MUST support the following HTTP methods on the Annotation's URI:
+  The Annotation Server MUST support the following HTTP methods on the Annotation's IRI:
 
 <ul>
   <li><code>GET</code> (retrieve the description of the Annotation), </li>
@@ -192,12 +190,16 @@ The Web Annotation Protocol is defined using the following basic principles:
   <li><code>OPTIONS</code> (enable CORS pre-flight requests [[!cors]]).</li>
 </ul>
 
-<p>Servers MUST support the JSON-LD representation using the Web Annotation profile. These responses MUST have a <code>Content-Type</code> header with the <code>application/ld+json</code> media type, and it SHOULD have the Web Annotation profile URI of <code>http://www.w3.org/ns/anno.jsonld</code> in the <code>profile</code> parameter.</p>
+<p>Servers SHOULD use HTTPS rather than HTTP for all interactions, including retrieval of Annotations.</p>
+
+<p>Servers MUST support the JSON-LD representation using the Web Annotation profile. These responses MUST have a <code>Content-Type</code> header with the <code>application/ld+json</code> media type, and it SHOULD have the Web Annotation profile IRI of <code>http://www.w3.org/ns/anno.jsonld</code> in the <code>profile</code> parameter.</p>
 
 <p>Servers SHOULD support a Turtle representation, and MAY support other formats.  If more than one representation of the Annotation is available, then the server SHOULD support content negotiation. Content negotiation for different serializations is performed by including the desired media type in the HTTP <code>Accept</code> header of the request, however clients cannot assume that the server will honor their preferences [[!rfc7231]].</p>
 
 <p>
 Servers MAY support different JSON-LD profiles. Content negotiation for different JSON-LD profiles is performed by adding a <code>profile</code> parameter to the JSON-LD media type in a space separated, quoted list as part of the <code>Accept</code> header.</p>
+
+<p>Servers SHOULD use the 200 HTTP status code when no errors occured while processing the request to retrieve an Annotation, and MAY use 3XX HTTP status codes to redirect to a new location.</p>
 
 <p>The response from the Annotation Server MUST have a <code>Link</code> header entry <!-- LDP 4.2.1.4 --> where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>.  The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> MAY also be added with the same <code>rel</code> type.</p>
 
@@ -251,8 +253,10 @@ If the Annotation Server supports the management of Annotations, including one o
 <p>An Annotation Server MUST provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [[!ldp]] (a service for managing Annotations) and a Collection [[!activitystreams-core]] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.<p>
 
 <p>
-Annotation Containers SHOULD implement the LDP Basic Container specification, but implementers MAY instead implement it as one of the other types of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers MAY have any URI, but MUST end in a <code>"/"</code> character. The Annotations MUST be assigned URIs with an additional path component below the Container's URI.
+Annotation Containers SHOULD implement the LDP Basic Container specification, but implementers MAY instead implement it as one of the other types of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers MAY have any IRI, but MUST end in a <code>"/"</code> character. The Annotations MUST be assigned IRIs with an additional path component below the Container's IRI.
 </p>
+
+<p>Servers SHOULD use HTTPS rather than HTTP for all interactions with Annotation Containers.</p>
 
 <p>
   The creation, management and structure of Annotation Containers are beyond the scope of this specification.  Please see the Linked Data Platform specification [[!ldp]] for additional information in this regard.
@@ -262,7 +266,7 @@ Annotation Containers SHOULD implement the LDP Basic Container specification, bu
   <h3>Container Retrieval</h3>
 
 <p>
-  The Annotation Server MUST support the following HTTP methods on the Annotation Container's URI:
+  The Annotation Server MUST support the following HTTP methods on the Annotation Container's IRI:
 
 <ul>
   <li><code>GET</code> (retrieve the description of the Container and the list of its contents, described below), </li>
@@ -274,17 +278,19 @@ Annotation Containers SHOULD implement the LDP Basic Container specification, bu
   When an HTTP GET request is issued against the Annotation Container, the server MUST return a description of the container.  That description MUST be available in JSON-LD, SHOULD be available in Turtle, and MAY be available in other formats. The JSON-LD serialization of the Container's description SHOULD use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [[!annotation-model]], unless the request would determine otherwise.
 </p>
 
+<p>Servers SHOULD use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences.  If redirection is required, then the server SHOULD use a 3XX HTTP status code instead.</p>
+
 <p>
   Clients that have a preference for JSON-LD SHOULD explicitly request it using an <code>Accept</code> header on the request. If the <code>Accept</code> header is absent from the request, then Annotation Servers MUST respond with the JSON-LD representation of the Annotation Container.
 </p>
 
 <p>
-  All supported methods for interacting with the Annotation Container MUST be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's URI <!-- LDP --> . The <code>Allow</code> header MAY also be included on any other responses.</p>
+  All supported methods for interacting with the Annotation Container MUST be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's IRI <!-- LDP --> . The <code>Allow</code> header MAY also be included on any other responses.</p>
 
 <p>Annotation Containers MUST return a <code>Link</code> header [[!rfc5988]] on all responses with the following components:
   <ul>
     <li>It MUST advertise its type by including a link where the <code>rel</code> parameter value is <code>type</code> and the target IRI is the appropriate Container Type, such as <code>http://www.w3.org/ns/ldp#BasicContainer</code> for Basic Containers.</li>
-    <li>It MUST advertise that it imposes Annotation protocol specific constraints by including a link where the target IRI is <code>http://www.w3.org/TR/annotation-protocol/</code>, and the <code>rel</code> parameter value is the URI <code>http://www.w3.org/ns/ldp#constrainedBy</code>.</li>
+    <li>It MUST advertise that it imposes Annotation protocol specific constraints by including a link where the target IRI is <code>http://www.w3.org/TR/annotation-protocol/</code>, and the <code>rel</code> parameter value is the IRI <code>http://www.w3.org/ns/ldp#constrainedBy</code>.</li>
   </ul>
 </p>
 
@@ -313,7 +319,7 @@ There are three possibilities for the request that will govern the server's resp
 
 <ol>
   <li>If the client prefers to only receive the Container description and no annotations, then it MUST include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
-  <li>If the client prefers to receive the list of annotations only as URIs, then it MUST include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedURIs"</code>.</li>
+  <li>If the client prefers to receive the list of annotations only as IRIs, then it MUST include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
   <li>If the client prefers to receive the complete annotation description, then it MUST include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
 </ol>
 
@@ -369,14 +375,14 @@ Content-Length: 221
 
   <h3>Responses with Annotations</h3>
 
-<p>If the client requests a response that would include the Annotations, either by URI or embedded in the response, then the server MUST use the paged collection model. Each page, described below, will contain an ordered list with a subset of the managed annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container.  The number of URIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages.  The feature or features by which the annotations are sorted are not explicit in the response.
+<p>If the client requests a response that would include the Annotations, either by IRI or embedded in the response, then the server MUST use the paged collection model. Each page, described below, will contain an ordered list with a subset of the managed annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container.  The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages.  The feature or features by which the annotations are sorted are not explicit in the response.
 </p>
 
 <p>
 The Collection SHOULD include the <code>total</code> property with the total number of annotations in the container. It MUST also have a link to the first page of its contents using <code>first</code>, and SHOULD have a link to the last page of its contents using <code>last</code>.
 </p>
 
-<p>The URI of the Collection in the response should differentiate between whether the pages contain just the URIs, or the full descriptions of the Annotations.  It is RECOMMENDED that this be done with a query parameter.  The server MAY redirect the client to this URI and deliver the response there, otherwise it MUST include a <code>Content-Location</code> header with the URI as its value. The server SHOULD include <code>Prefer</code> in the <code>Vary</code> response header to assist with caching.</p>
+<p>The IRI of the Collection in the response should differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations.  It is RECOMMENDED that this be done with a query parameter.  The server MAY redirect the client to this IRI and deliver the response there, otherwise it MUST include a <code>Content-Location</code> header with the IRI as its value. The server SHOULD include <code>Prefer</code> in the <code>Vary</code> response header to assist with caching.</p>
 
 <div>
 
@@ -385,7 +391,7 @@ Request:
 GET /annotations/ HTTP/1.1
 Host: example.org
 Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
-Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferContainedURIs"
+Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferContainedIRIs"
 </pre>
 
 Response:
@@ -417,7 +423,7 @@ Content-Length: 221
 
 <h4>Page Response</h4>
 <p>
-Individual pages are instances of <code>CollectionPage</code>.  The page contains the Annotations, either via their URIs or full descriptions, in the <code>items</code> property.</p>
+Individual pages are instances of <code>CollectionPage</code>.  The page contains the Annotations, either via their IRIs or full descriptions, in the <code>items</code> property.</p>
 
 <p>Each page MUST have a link to the container that it is part of, using the <code>partOf</code> property.  If it is not the first page, it MUST have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it MUST have a link to the next page in the sequence, using the <code>next</code> property. The response MAY include properties of the Collection in the response, including the total number of items or first and last page links.
 </p>
@@ -428,7 +434,7 @@ The client SHOULD NOT send the <code>Prefer</code> header when requesting the pa
 
 <p>This specification does not require any particular functionality when a client makes requests other than GET, HEAD or OPTIONS to a page.</p>
 
-<p>As the <code>CollectionPage</code> is not a Container, it does not have the requirement to include a <code>Link</code> header with a type. That the URLs can be constructed with query parameters added to the Container's URI is an implementation convenience, and does not imply the type of the resource.</p>
+<p>As the <code>CollectionPage</code> is not a Container, it does not have the requirement to include a <code>Link</code> header with a type. That the URLs can be constructed with query parameters added to the Container's IRI is an implementation convenience, and does not imply the type of the resource.</p>
 
 <div>
 
@@ -475,7 +481,7 @@ Content-Length: 221
 <section>
   <h3>Discovery of Annotation Containers</h3>
 
-<p>As the URI for Annotation Containers MAY be any URI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
+<p>As the IRI for Annotation Containers MAY be any IRI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
 
 <p>Any resource MAY link to an Annotation Container when Annotations on the resource SHOULD be created within the referenced Container.  This link is carried in an HTTP <code>Link</code> header and the value of the <code>rel</code> parameter MUST be <code>http://www.w3.org/ns/oa#annotationService</code>.</p>
 
@@ -511,16 +517,16 @@ Content-Length: 76983
 <section>
 <h3>Create a New Annotation</h3>
 
-<p>New Annotations are created via a POST request of a JSON-LD serialization of the Annotation to an Annotation Container.  The Annotation's data is sent in the body of the request. All of the known information about the Annotation SHOULD be sent, and if there are already URIs associated with the resources, they MAY be included. The serialization SHOULD use the Web Annotation JSON-LD profile, and servers MAY reject other contexts even if they would otherwise produce the same model. The server MAY reject content that is not an Annotation according to the Web Annotation specification.</p>
+<p>New Annotations are created via a POST request of a JSON-LD serialization of the Annotation to an Annotation Container.  The Annotation's data is sent in the body of the request. All of the known information about the Annotation SHOULD be sent, and if there are already IRIs associated with the resources, they MAY be included. The serialization SHOULD use the Web Annotation JSON-LD profile, and servers MAY reject other contexts even if they would otherwise produce the same model. The server MAY reject content that is not an Annotation according to the Web Annotation specification.</p>
 
-<p>Upon receipt of an Annotation, the server SHOULD assign HTTP URIs to all resources and blank nodes in the Annotation, and MUST assign a URI to the Annotation resource, even if it aleady has one provided in the entity body description.  The server MAY also add additional information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, additional types and formats.</p>
+<p>Upon receipt of an Annotation, the server SHOULD assign HTTPS IRIs to all resources and blank nodes in the Annotation, and MUST assign a IRI to the Annotation resource, even if it aleady has one provided in the entity body description.  The server MAY also add additional information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, additional types and formats.</p>
 
-<p>If the Annotation contains a <code>canonical</code> link, then it MUST be maintained without change.  If the Annotation has a URI in the <code>id</code> property, then it SHOULD be copied to the <code>via</code> property, and the URI assigned by the server at which the Annotation is available MUST be put in the <code>id</code> field to replace it.</p>
+<p>If the Annotation contains a <code>canonical</code> link, then it MUST be maintained without change.  If the Annotation has a IRI in the <code>id</code> property, then it SHOULD be copied to the <code>via</code> property, and the IRI assigned by the server at which the Annotation is available MUST be put in the <code>id</code> field to replace it.</p>
 
-<p>The server MUST respond with a <code>201</code> Created response if the creation is successful, and an appropriate error code otherwise.  The response MUST have a <code>Location</code> header with the Annotation's new URI.</p>
+<p>The server MUST respond with a <code>201</code> Created response if the creation is successful, and an appropriate error code otherwise.  The response MUST have a <code>Location</code> header with the Annotation's new IRI.</p>
 
-<p>The body of the response MUST be the Annotation as now managed by the server, including any additional URIs or data created in the process or without any information that was sent but not stored. Barring content negotiation, the response SHOULD be serialized in JSON-LD following the Annotation Data Model specification.</p>
-<p>The response MUST include a <code>Link</code> header with the target IRI of <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value of <code>type</code> to advertise that this is an RDF Source, according to the LDP specification.  It MAY also include the URI <code>http://www.w3.org/ns/oa#Annotation</code> with the same <code>rel</code> parameter of <code>type</code> to also assert that it is an Annotation following the Web Annotation specifications.</p>
+<p>The body of the response MUST be the Annotation as now managed by the server, including any additional IRIs or data created in the process or without any information that was sent but not stored. Barring content negotiation, the response SHOULD be serialized in JSON-LD following the Annotation Data Model specification.</p>
+<p>The response MUST include a <code>Link</code> header with the target IRI of <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value of <code>type</code> to advertise that this is an RDF Source, according to the LDP specification.  It MAY also include the IRI <code>http://www.w3.org/ns/oa#Annotation</code> with the same <code>rel</code> parameter of <code>type</code> to also assert that it is an Annotation following the Web Annotation specifications.</p>
 
 <p>The response MUST include a <code>Vary</code> header with the value that includes <code>Accept</code>, as the representation is negotiable based on the client's Accept header. If the container preferences described above are supported, this MUST also include <code>Prefer</code> <!-- HTTP -->.
 
@@ -573,8 +579,8 @@ ETag: "_87e52ce126126"
 </section>
 
 <section>
-<h3>Suggesting a URI for an Annotation</h3>
-<p>The URI path segment that is appended to the Container URI for a resource MAY be suggested by the Annotation Client by using the <code>Slug</code> HTTP header on the request when the resource is created.  The server SHOULD use this name, so long as it does not already identify an existing resource, but MAY ignore it and use an automatically assigned name. </p>
+<h3>Suggesting an IRI for an Annotation</h3>
+<p>The IRI path segment that is appended to the Container IRI for a resource MAY be suggested by the Annotation Client by using the <code>Slug</code> HTTP header on the request when the resource is created.  The server SHOULD use this name, so long as it does not already identify an existing resource, but MAY ignore it and use an automatically assigned name. </p>
 
 <div>
 Request:
@@ -635,7 +641,7 @@ Content-Length: 257
 
 <p>If successful, the server MUST return a 200 OK status with the Annotation as the body according to the content-type requested.</p>
 
-<p>Servers MUST advertise the availability of updating via PUT on requests to the Annotation's URI using the <code>Allow</code> response header.</p>
+<p>Servers MUST advertise the availability of updating via PUT on requests to the Annotation's IRI using the <code>Allow</code> response header.</p>
 
 <div>
 Request:
@@ -693,7 +699,7 @@ Content-Length: 243
 
 <p>Clients use the DELETE method to request that an Annotation be deleted.  Annotation Servers SHOULD support this method. Clients SHOULD send the ETag of the Annotation in the <code>If-Match</code> header to ensure that it is operating against the most recent version of the Annotation.</p>
 
-<p>If the DELETE request is successfully processed, then the server MUST return a 200 or 204 status response.  The URIs of deleted Annotations SHOULD NOT be re-used for subsequent Annotations. <!-- LDP -->  The URI of the deleted Annotation MUST be removed from the Annotation Container it was created in. <!-- LDP --> </p>
+<p>If the DELETE request is successfully processed, then the server MUST return a 204 status response.  The IRIs of deleted Annotations SHOULD NOT be re-used for subsequent Annotations. <!-- LDP -->  The IRI of the deleted Annotation MUST be removed from the Annotation Container it was created in. <!-- LDP --> </p>
 
 <div>
 Request:
@@ -736,9 +742,9 @@ Content-Length: 0
 <section>
   <h3>Containers for Related Resources</h3>
 
-<p>Annotations may have related resources that are required for their correct interpretation and rendering, such as content resources used in or as the Body, CSS stylesheets that determine the rendering of the annotation, SVG documents describing a non-rectangular region of a resource, and so forth.  If these resources do not already have URIs, then they need to be made available somewhere so that they can be refered to.</p>
+<p>Annotations may have related resources that are required for their correct interpretation and rendering, such as content resources used in or as the Body, CSS stylesheets that determine the rendering of the annotation, SVG documents describing a non-rectangular region of a resource, and so forth.  If these resources do not already have IRIs, then they need to be made available somewhere so that they can be refered to.</p>
 
-<p>Annotation Servers MAY support the management of related resources independently from the Annotations. If a server supports the management of these resources, it SHOULD do this with one or more separate Containers.  Resources that are not Annotations SHOULD NOT be included in an Annotation Container, as Annotation Clients would not expect to find arbitrary content when dereferencing the URIs. <!-- Additional but insanity reducing constraint -->  Containers for related resources MAY contain both RDF Sources and Non-RDF Sources.  No restrictions are placed on the type or configuration of the Container beyond those of the Linked Data Platform [[!ldp]].</p>
+<p>Annotation Servers MAY support the management of related resources independently from the Annotations. If a server supports the management of these resources, it SHOULD do this with one or more separate Containers.  Resources that are not Annotations SHOULD NOT be included in an Annotation Container, as Annotation Clients would not expect to find arbitrary content when dereferencing the IRIs. <!-- Additional but insanity reducing constraint -->  Containers for related resources MAY contain both RDF Sources and Non-RDF Sources.  No restrictions are placed on the type or configuration of the Container beyond those of the Linked Data Platform [[!ldp]].</p>
 <p>Containers for related resources MUST support the same HTTP methods as described above for the Annotation Container, and MUST support identifying their type with a <code>Link</code> header. The <code>constrainedBy</code> link header on the response when dereferencing the Container SHOULD refer to a server specific set of constraints listing the types of content that are acceptable. <!-- LDP --> </p>
 
 </section>

--- a/protocol/wd/index.html
+++ b/protocol/wd/index.html
@@ -1,267 +1,424 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr" typeof="bibo:Document w3p:WD" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
-<head><meta lang="" property="dc:language" content="en">
-        <title>Web Annotation Protocol</title>
-        <meta charset="utf-8">
-        <style>
+<head>
+  <meta lang="" property="dc:language" content="en">
+  <style>
+    /*
 
-.model {
- empty-cells: show;
- border-collapse: collapse;
- margin-bottom: .5ex;
- border: 1px solid black;
-}
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
-.model th {
- padding: 3px;
- border: 1px solid #404040;
- text-align: center;
- font-weight: bold;
- font-family: sans-serif;
-}
-
-.model td {
- padding: 5px;
- border: 1px solid #404040;
- text-align: left;
- font-family: sans-serif;
-}
-
-
-</style>
-        
-        
-<style>/*****************************************************************
+*/
+    
+    .hljs {
+      display: block;
+      overflow-x: auto;
+      padding: 0.5em;
+      color: #333;
+      background: #f8f8f8;
+      -webkit-text-size-adjust: none;
+    }
+    
+    .hljs-comment,
+    .diff .hljs-header {
+      color: #998;
+      font-style: italic;
+    }
+    
+    .hljs-keyword,
+    .css .rule .hljs-keyword,
+    .hljs-winutils,
+    .nginx .hljs-title,
+    .hljs-subst,
+    .hljs-request,
+    .hljs-status {
+      color: #333;
+      font-weight: bold;
+    }
+    
+    .hljs-number,
+    .hljs-hexcolor,
+    .ruby .hljs-constant {
+      color: #008080;
+    }
+    
+    .hljs-string,
+    .hljs-tag .hljs-value,
+    .hljs-doctag,
+    .tex .hljs-formula {
+      color: #d14;
+    }
+    
+    .hljs-title,
+    .hljs-id,
+    .scss .hljs-preprocessor {
+      color: #900;
+      font-weight: bold;
+    }
+    
+    .hljs-list .hljs-keyword,
+    .hljs-subst {
+      font-weight: normal;
+    }
+    
+    .hljs-class .hljs-title,
+    .hljs-type,
+    .vhdl .hljs-literal,
+    .tex .hljs-command {
+      color: #458;
+      font-weight: bold;
+    }
+    
+    .hljs-tag,
+    .hljs-tag .hljs-title,
+    .hljs-rule .hljs-property,
+    .django .hljs-tag .hljs-keyword {
+      color: #000080;
+      font-weight: normal;
+    }
+    
+    .hljs-attribute,
+    .hljs-variable,
+    .lisp .hljs-body,
+    .hljs-name {
+      color: #008080;
+    }
+    
+    .hljs-regexp {
+      color: #009926;
+    }
+    
+    .hljs-symbol,
+    .ruby .hljs-symbol .hljs-string,
+    .lisp .hljs-keyword,
+    .clojure .hljs-keyword,
+    .scheme .hljs-keyword,
+    .tex .hljs-special,
+    .hljs-prompt {
+      color: #990073;
+    }
+    
+    .hljs-built_in {
+      color: #0086b3;
+    }
+    
+    .hljs-preprocessor,
+    .hljs-pragma,
+    .hljs-pi,
+    .hljs-doctype,
+    .hljs-shebang,
+    .hljs-cdata {
+      color: #999;
+      font-weight: bold;
+    }
+    
+    .hljs-deletion {
+      background: #fdd;
+    }
+    
+    .hljs-addition {
+      background: #dfd;
+    }
+    
+    .diff .hljs-change {
+      background: #0086b3;
+    }
+    
+    .hljs-chunk {
+      color: #aaa;
+    }
+  </style>
+  <style id="respec-mainstyle">
+    /*****************************************************************
  * ReSpec 3 CSS
  * Robin Berjon - http://berjon.com/
  *****************************************************************/
-
-/* Override code highlighter background */
-.hljs {
-    background: transparent !important;
-}
-
-/* --- INLINES --- */
-em.rfc2119 {
-    text-transform:     lowercase;
-    font-variant:       small-caps;
-    font-style:         normal;
-    color:              #900;
-}
-
-h1 acronym, h2 acronym, h3 acronym, h4 acronym, h5 acronym, h6 acronym, a acronym,
-h1 abbr, h2 abbr, h3 abbr, h4 abbr, h5 abbr, h6 abbr, a abbr {
-    border: none;
-}
-
-dfn {
-    font-weight:    bold;
-}
-
-a.internalDFN {
-    color:  inherit;
-    border-bottom:  1px solid #99c;
-    text-decoration:    none;
-}
-
-a.externalDFN {
-    color:  inherit;
-    border-bottom:  1px dotted #ccc;
-    text-decoration:    none;
-}
-
-a.bibref {
-    text-decoration:    none;
-}
-
-cite .bibref {
-    font-style: normal;
-}
-
-code {
-    color:  #C83500;
-}
-
-/* --- TOC --- */
-.toc a, .tof a {
-    text-decoration:    none;
-}
-
-a .secno, a .figno {
-    color:  #000;
-}
-
-ul.tof, ol.tof {
-    list-style: none outside none;
-}
-
-.caption {
-    margin-top: 0.5em;
-    font-style:   italic;
-}
-
-/* --- TABLE --- */
-table.simple {
-    border-spacing: 0;
-    border-collapse:    collapse;
-    border-bottom:  3px solid #005a9c;
-}
-
-.simple th {
-    background: #005a9c;
-    color:  #fff;
-    padding:    3px 5px;
-    text-align: left;
-}
-
-.simple th[scope="row"] {
-    background: inherit;
-    color:  inherit;
-    border-top: 1px solid #ddd;
-}
-
-.simple td {
-    padding:    3px 10px;
-    border-top: 1px solid #ddd;
-}
-
-.simple tr:nth-child(even) {
-    background: #f0f6ff;
-}
-
-/* --- DL --- */
-.section dd > p:first-child {
-    margin-top: 0;
-}
-
-.section dd > p:last-child {
-    margin-bottom: 0;
-}
-
-.section dd {
-    margin-bottom:  1em;
-}
-
-.section dl.attrs dd, .section dl.eldef dd {
-    margin-bottom:  0;
-}
-
-.respec-hidden {
-    display: none;
-}
-
-@media print {
-    .removeOnSave {
+    /* Override code highlighter background */
+    
+    .hljs {
+      background: transparent !important;
+    }
+    /* --- INLINES --- */
+    
+    em.rfc2119 {
+      text-transform: lowercase;
+      font-variant: small-caps;
+      font-style: normal;
+      color: #900;
+    }
+    
+    h1 acronym,
+    h2 acronym,
+    h3 acronym,
+    h4 acronym,
+    h5 acronym,
+    h6 acronym,
+    a acronym,
+    h1 abbr,
+    h2 abbr,
+    h3 abbr,
+    h4 abbr,
+    h5 abbr,
+    h6 abbr,
+    a abbr {
+      border: none;
+    }
+    
+    dfn {
+      font-weight: bold;
+    }
+    
+    a.internalDFN {
+      color: inherit;
+      border-bottom: 1px solid #99c;
+      text-decoration: none;
+    }
+    
+    a.externalDFN {
+      color: inherit;
+      border-bottom: 1px dotted #ccc;
+      text-decoration: none;
+    }
+    
+    a.bibref {
+      text-decoration: none;
+    }
+    
+    cite .bibref {
+      font-style: normal;
+    }
+    
+    code {
+      color: #C83500;
+    }
+    /* --- TOC --- */
+    
+    .toc a,
+    .tof a {
+      text-decoration: none;
+    }
+    
+    a .secno,
+    a .figno {
+      color: #000;
+    }
+    
+    ul.tof,
+    ol.tof {
+      list-style: none outside none;
+    }
+    
+    .caption {
+      margin-top: 0.5em;
+      font-style: italic;
+    }
+    /* --- TABLE --- */
+    
+    table.simple {
+      border-spacing: 0;
+      border-collapse: collapse;
+      border-bottom: 3px solid #005a9c;
+    }
+    
+    .simple th {
+      background: #005a9c;
+      color: #fff;
+      padding: 3px 5px;
+      text-align: left;
+    }
+    
+    .simple th[scope="row"] {
+      background: inherit;
+      color: inherit;
+      border-top: 1px solid #ddd;
+    }
+    
+    .simple td {
+      padding: 3px 10px;
+      border-top: 1px solid #ddd;
+    }
+    
+    .simple tr:nth-child(even) {
+      background: #f0f6ff;
+    }
+    /* --- DL --- */
+    
+    .section dd > p:first-child {
+      margin-top: 0;
+    }
+    
+    .section dd > p:last-child {
+      margin-bottom: 0;
+    }
+    
+    .section dd {
+      margin-bottom: 1em;
+    }
+    
+    .section dl.attrs dd,
+    .section dl.eldef dd {
+      margin-bottom: 0;
+    }
+    
+    .respec-hidden {
+      display: none;
+    }
+    
+    @media print {
+      .removeOnSave {
         display: none;
+      }
     }
-}
-</style><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><style>/* --- EXAMPLES --- */
-div.example-title {
-    min-width: 7.5em;
-    color: #b9ab2d;
-}
-div.example-title span {
-    text-transform: uppercase;
-}
-aside.example, div.example, div.illegal-example {
-    padding: 0.5em;
-    margin: 1em 0;
-    position: relative;
-    clear: both;
-}
-div.illegal-example { color: red }
-div.illegal-example p { color: black }
-aside.example, div.example {
-    padding: .5em;
-    border-left-width: .5em;
-    border-left-style: solid;
-    border-color: #e0cb52;
-    background: #fcfaee;
-}
+  </style>
+  <title>Web Annotation Protocol</title>
+  <meta charset="utf-8">
+  <style>
+    .model {
+      empty-cells: show;
+      border-collapse: collapse;
+      margin-bottom: .5ex;
+      border: 1px solid black;
+    }
+    
+    .model th {
+      padding: 3px;
+      border: 1px solid #404040;
+      text-align: center;
+      font-weight: bold;
+      font-family: sans-serif;
+    }
+    
+    .model td {
+      padding: 5px;
+      border: 1px solid #404040;
+      text-align: left;
+      font-family: sans-serif;
+    }
+  </style>
 
-aside.example div.example {
-    border-left-width: .1em;
-    border-color: #999;
-    background: #fff;
-}
-aside.example div.example div.example-title {
-    color: #999;
-}
-</style><style>/* HIGHLIGHTS */
-code.prettyprint {
-    color:  inherit;
-}
 
-/* this from google-code-prettify */
-.pln{color:#000}@media screen{.str{color:#080}.kwd{color:#008}.com{color:#800}.typ{color:#606}.lit{color:#066}.pun,.opn,.clo{color:#660}.tag{color:#008}.atn{color:#606}.atv{color:#080}.dec,.var{color:#606}.fun{color:red}}@media print,projection{.str{color:#060}.kwd{color:#006;font-weight:bold}.com{color:#600;font-style:italic}.typ{color:#404;font-weight:bold}.lit{color:#044}.pun,.opn,.clo{color:#440}.tag{color:#006;font-weight:bold}.atn{color:#404}.atv{color:#060}}ol.linenums{margin-top:0;margin-bottom:0}li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8{list-style-type:none}li.L1,li.L3,li.L5,li.L7,li.L9{background:#eee}
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
-  "specStatus": "WD",
-  "shortName": "annotation-protocol",
-  "editors": [
-    {
-      "name": "Robert Sanderson",
-      "url": "http://www.stanford.edu/~azaroth/",
-      "company": "Stanford University",
-      "companyURL": "http://www.stanford.edu/",
-      "mailto": "azaroth42@gmail.com"
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style>
+    /* --- EXAMPLES --- */
+    
+    div.example-title {
+      min-width: 7.5em;
+      color: #b9ab2d;
     }
-  ],
-  "previousMaturity": "FPWD",
-  "previousPublishDate": "2015-07-02",
-  "previousURI": "http://www.w3.org/TR/2015/WD-annotation-protocol-20150702/",
-  "publishDate": "2016-03-31",
-  "edDraftURI": "http://w3c.github.io/web-annotation/protocol/wd/",
-  "wg": "Web Annotation Working Group",
-  "wgURI": "http://www.w3.org/annotation/",
-  "wgPublicList": "public-annotation",
-  "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/73180/status",
-  "noRecTrack": false,
-  "localBiblio": {
-    "annotation-vocab": {
-      "authors": [
-        "Robert Sanderson",
-        "Paolo Ciccarese",
-        "Benjamin Young"
-      ],
-      "title": "Web Annotation Vocabulary",
-      "href": "http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/",
-      "publisher": "W3C",
-      "rawDate": "2016-03-31",
-      "status": "WD"
-    },
-    "annotation-model": {
-      "authors": [
-        "Robert Sanderson",
-        "Paolo Ciccarese",
-        "Benjamin Young"
-      ],
-      "title": "Web Annotation Data Model",
-      "href": "http://www.w3.org/TR/2016/WD-annotation-model-20160331/",
-      "publisher": "W3C",
-      "rawDate": "2016-03-31",
-      "status": "WD"
+    
+    div.example-title span {
+      text-transform: uppercase;
     }
-  },
-  "otherLinks": [
+    
+    aside.example,
+    div.example,
+    div.illegal-example {
+      padding: 0.5em;
+      margin: 1em 0;
+      position: relative;
+      clear: both;
+    }
+    
+    div.illegal-example {
+      color: red
+    }
+    
+    div.illegal-example p {
+      color: black
+    }
+    
+    aside.example,
+    div.example {
+      padding: .5em;
+      border-left-width: .5em;
+      border-left-style: solid;
+      border-color: #e0cb52;
+      background: #fcfaee;
+    }
+    
+    aside.example div.example {
+      border-left-width: .1em;
+      border-color: #999;
+      background: #fff;
+    }
+    
+    aside.example div.example div.example-title {
+      color: #999;
+    }
+  </style>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD">
+  <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
+  <script id="initialUserConfig" type="application/json">
     {
-      "key": "Repository",
-      "data": [
+      "specStatus": "WD",
+      "shortName": "annotation-protocol",
+      "editors": [
+      {
+        "name": "Robert Sanderson",
+        "url": "http://www.stanford.edu/~azaroth/",
+        "company": "Stanford University",
+        "companyURL": "http://www.stanford.edu/",
+        "mailto": "azaroth42@gmail.com"
+      }],
+      "previousMaturity": "FPWD",
+      "previousPublishDate": "2015-07-02",
+      "previousURI": "http://www.w3.org/TR/2015/WD-annotation-protocol-20150702/",
+      "publishDate": "2016-03-31",
+      "edDraftURI": "http://w3c.github.io/web-annotation/protocol/wd/",
+      "wg": "Web Annotation Working Group",
+      "wgURI": "http://www.w3.org/annotation/",
+      "wgPublicList": "public-annotation",
+      "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/73180/status",
+      "noRecTrack": false,
+      "localBiblio":
+      {
+        "annotation-vocab":
+        {
+          "authors": [
+            "Robert Sanderson",
+            "Paolo Ciccarese",
+            "Benjamin Young"
+          ],
+          "title": "Web Annotation Vocabulary",
+          "href": "http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/",
+          "publisher": "W3C",
+          "rawDate": "2016-03-31",
+          "status": "WD"
+        },
+        "annotation-model":
+        {
+          "authors": [
+            "Robert Sanderson",
+            "Paolo Ciccarese",
+            "Benjamin Young"
+          ],
+          "title": "Web Annotation Data Model",
+          "href": "http://www.w3.org/TR/2016/WD-annotation-model-20160331/",
+          "publisher": "W3C",
+          "rawDate": "2016-03-31",
+          "status": "WD"
+        }
+      },
+      "otherLinks": [
+      {
+        "key": "Repository",
+        "data": [
         {
           "value": "Github Repository",
           "href": "https://github.com/w3c/web-annotation"
-        }
-      ]
+        }]
+      }]
     }
-  ]
-}</script></head>
+  </script>
+</head>
 
-<body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
-  <p>
-            <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
-  </p>
-  <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Protocol</h1>
-  <h2 id="w3c-working-draft-31-march-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-03-31">31 March 2016</time></h2>
-  <dl>
+<body class="h-entry" role="document" id="respecDocument">
+  <div class="head" role="contentinfo" id="respecHeader">
+    <p>
+      <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
+    </p>
+    <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Protocol</h1>
+    <h2 id="w3c-working-draft-31-march-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-03-31">31 March 2016</time></h2>
+    <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a></dd>
       <dt>Latest published version:</dt>
@@ -270,719 +427,847 @@ code.prettyprint {
       <dd><a href="http://w3c.github.io/web-annotation/protocol/wd/">http://w3c.github.io/web-annotation/protocol/wd/</a></dd>
       <dt>Previous version:</dt>
       <dd><a rel="dcterms:replaces" href="http://www.w3.org/TR/2015/WD-annotation-protocol-20150702/">http://www.w3.org/TR/2015/WD-annotation-protocol-20150702/</a></dd>
-    <dt>Editor:</dt>
-    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Robert Sanderson"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.stanford.edu/~azaroth/">Robert Sanderson</a>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
-<span property="rdf:rest" resource="rdf:nil"></span>
-</dd>
+      <dt>Editor:</dt>
+      <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Robert Sanderson"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.stanford.edu/~azaroth/">Robert Sanderson</a>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
+        <span property="rdf:rest" resource="rdf:nil"></span>
+      </dd>
 
-          <dt>Repository:</dt>
-                  <dd>
-                    <a href="https://github.com/w3c/web-annotation">
+      <dt>Repository:</dt>
+      <dd>
+        <a href="https://github.com/w3c/web-annotation">
                       Github Repository
                     </a>
-                  </dd>
-  </dl>
-      <p class="copyright">
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2016
-        
-        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
-        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). 
-        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
-        rules apply.
-      </p>
-  <hr title="Separator for header">
-</div>
+      </dd>
+    </dl>
+    <p class="copyright">
+      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016
 
-<section id="abstract" class="introductory" property="dc:abstract"><h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+      <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (
+      <a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+      <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+      <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+      <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+    </p>
+    <hr title="Separator for header">
+  </div>
 
-<p>Annotations are typically used to convey information about a resource or associations between resources. Simple examples include a comment or tag on a single web page or image, or a blog post about a news article.  </p>
+  <section id="abstract" class="introductory" property="dc:abstract">
+    <h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
 
-<p>The Web Annotation Protocol describes the transport mechanisms for creating and managing annotations in a method that is consistent with the Web Architecture and REST best practices.</p>
+    <p>Annotations are typically used to convey information about a resource or associations between resources. Simple examples include a comment or tag on a single web page or image, or a blog post about a news article. </p>
 
-</section><section id="sotd" class="introductory"><h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
-        <p>
-          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
-        </p>
-          
-<p>
-  <b>This is a work in progress. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future. If you feel something should be covered, please <a href="mailto:public-annotation@w3.org">tell us!</a></b>
-</p>
+    <p>The Web Annotation Protocol describes the transport mechanisms for creating and managing annotations in a method that is consistent with the Web Architecture and REST best practices.</p>
+
+  </section>
+
+  <section id="sotd" class="introductory">
+    <h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+    <p>
+      <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
+    </p>
+
+    <p>
+      <b>This is a work in progress. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future. If you feel something should be covered, please <a href="mailto:public-annotation@w3.org">tell us!</a></b>
+    </p>
 
 
-          <p>
-            This document was published by the <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> as a Working Draft.
-              This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
-              If you wish to make comments regarding this document, please send them to
-              <a href="mailto:public-annotation@w3.org">public-annotation@w3.org</a>
-              (<a href="mailto:public-annotation-request@w3.org?subject=subscribe">subscribe</a>,
-              <a href="http://lists.w3.org/Archives/Public/public-annotation/">archives</a>).
-            
-              All comments are welcome.
-          </p>
-            <p>
-              Publication as a Working Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
-              Membership. This is a draft document and may be updated, replaced or obsoleted by other
-              documents at any time. It is inappropriate to cite this document as other than work in
-              progress.
-            </p>
-          <p>
-              This document was produced by
-              a group
-               operating under the
-              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+    <p>
+      This document was published by the <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> as a Working Draft. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation. If you wish to make comments regarding this document, please send them to
+      <a href="mailto:public-annotation@w3.org">public-annotation@w3.org</a> (
+      <a href="mailto:public-annotation-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="http://lists.w3.org/Archives/Public/public-annotation/">archives</a>). All comments are welcome.
+    </p>
+    <p>
+      Publication as a Working Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.
+    </p>
+    <p>
+      This document was produced by a group operating under the
+      <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
               Policy</a>.
-                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/73180/status" rel="disclosure">public list of any patent
-                disclosures</a>
-              made in connection with the deliverables of
-              the group; that page also includes
-              instructions for disclosing a patent. An individual who has actual knowledge of a patent
-              which the individual believes contains
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+      <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/73180/status" rel="disclosure">public list of any patent
+                disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
               Claim(s)</a> must disclose the information in accordance with
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
               6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-          </p>
-            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
-            </p>
-          
-</section><nav id="toc"><h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a><ul class="toc"><li class="tocline"><a href="#aims-of-the-protocol" class="tocxref"><span class="secno">1.1 </span>Aims of the Protocol</a></li><li class="tocline"><a href="#summary" class="tocxref"><span class="secno">1.2 </span>Summary</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">1.3 </span>Conformance</a></li></ul></li><li class="tocline"><a href="#web-annotation-protocol-principles" class="tocxref"><span class="secno">2. </span>Web Annotation Protocol Principles</a></li><li class="tocline"><a href="#terminology" class="tocxref"><span class="secno">3. </span>Terminology</a></li><li class="tocline"><a href="#annotation-retrieval" class="tocxref"><span class="secno">4. </span>Annotation Retrieval</a></li><li class="tocline"><a href="#annotation-containers" class="tocxref"><span class="secno">5. </span>Annotation Containers</a><ul class="toc"><li class="tocline"><a href="#container-retrieval" class="tocxref"><span class="secno">5.1 </span>Container Retrieval</a><ul class="toc"><li class="tocline"><a href="#client-preferences" class="tocxref"><span class="secno">5.1.1 </span>Client Preferences</a></li><li class="tocline"><a href="#responses-without-annotations" class="tocxref"><span class="secno">5.1.2 </span>Responses without Annotations</a></li><li class="tocline"><a href="#responses-with-annotations" class="tocxref"><span class="secno">5.1.3 </span>Responses with Annotations</a></li></ul></li><li class="tocline"><a href="#discovery-of-annotation-containers" class="tocxref"><span class="secno">5.2 </span>Discovery of Annotation Containers</a></li></ul></li><li class="tocline"><a href="#creation-updating-and-deletion-of-annotations" class="tocxref"><span class="secno">6. </span>Creation, Updating and Deletion of Annotations</a><ul class="toc"><li class="tocline"><a href="#create-a-new-annotation" class="tocxref"><span class="secno">6.1 </span>Create a New Annotation</a></li><li class="tocline"><a href="#suggesting-a-uri-for-an-annotation" class="tocxref"><span class="secno">6.2 </span>Suggesting a URI for an Annotation</a></li><li class="tocline"><a href="#update-an-existing-annotation" class="tocxref"><span class="secno">6.3 </span>Update an Existing Annotation</a></li><li class="tocline"><a href="#delete-an-existing-annotation" class="tocxref"><span class="secno">6.4 </span>Delete an Existing Annotation</a></li></ul></li><li class="tocline"><a href="#error-conditions" class="tocxref"><span class="secno">7. </span>Error Conditions</a></li><li class="tocline"><a href="#containers-for-related-resources" class="tocxref"><span class="secno">8. </span>Containers for Related Resources</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">A. </span>Acknowledgements</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">B. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">B.1 </span>Normative references</a></li></ul></li></ul></nav>
-
-
-
-<section class="informative" id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2><p><em>This section is non-normative.</em></p>
-
-<p>Interoperability between systems has two basic aspects: the syntax and semantics of the data that is moved between the systems, and the transport mechanism for that movement. The HTTP protocol and the Web architecture provides us with a great starting point for a standardized transport layer, and can be used to move content between systems easily and effectively.  Building upon these foundations allows us to make use of existing technology and patterns to ensure consistency and ease of development.</p>
-
-<p>The Web Annotation Protocol describes a transport mechanism for creating, managing, and retrieving Annotations. Annotations in this specification are assumed to follow the requirements of the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>] and Web Annotation Vocabulary [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>]. This specification builds upon REST principles and the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] recommendation, and familiarity with it is recommended.</p>
-
-
-<section id="aims-of-the-protocol" typeof="bibo:Chapter" resource="#aims-of-the-protocol" property="bibo:hasPart">
-	<h3 id="h-aims-of-the-protocol" resource="#h-aims-of-the-protocol"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Aims of the Protocol</span></h3>
-
-	<p>
-The primary aim of the Web Annotation Protocol is to provide a standard set of interactions that allow annotation clients and servers to interoperate seamlessly.  By being able to discover annotation protocol end-points and how to interact with them, clients can be configured either automatically or by the user to store annotations in any compatible remote system, rather than being locked in to a single client and server pair.
-</p>
-
-</section>
-
-<section id="summary" typeof="bibo:Chapter" resource="#summary" property="bibo:hasPart">
-  <h3 id="h-summary" resource="#h-summary"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Summary</span></h3>
-
-<p>For those familiar with the Web Annotation model, LDP and REST, much of the Annotation Protocol will be very obvious.  The following aspects are the most important new requirements.
-</p>
-
-<ul>
-  <li>The media type to use for Annotations is: <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code></li>
-  <li>Annotation Containers are constrained by the set of constraints described in this specification, and thus the <code>ldp:constrainedBy</code> URL is <code>http://www.w3.org/TR/annotation-protocol/</code></li>
-  <li>The link header can refer from any resource to an Annotation Container using a <code>rel</code> type of: <code>http://www.w3.org/ns/oa#annotationService</code></li>
-  <li>The response from a Container after creating an Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> include a representation of the Annotation, after any changes have been made to it, in the JSON-LD serialization.</li>
-  <li>Annotation Containers <em class="rfc2119" title="SHOULD">SHOULD</em> only contain Annotations, and not other resources.</li>
-  <li>LDP-Paging [<cite><a class="bibref" href="#bib-ldp-paging">ldp-paging</a></cite>] is not used, as in-page ordering is an important requirement. Instead, the Activity Streams Collection model is used [<cite><a class="bibref" href="#bib-activitystreams-core">activitystreams-core</a></cite>].</li>
-</ul>
-
-</section>
-
-<section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart"><h3 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
-<p>
-  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
-  and notes in this specification are non-normative. Everything else in this specification is
-  normative.
-</p>
-<p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are 
-  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
-</p>
-
-</section>
-
-</section>
-
-<!-- End Introduction -->
-
-<section id="web-annotation-protocol-principles" typeof="bibo:Chapter" resource="#web-annotation-protocol-principles" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-web-annotation-protocol-principles" resource="#h-web-annotation-protocol-principles"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Protocol Principles</span></h2>
-
-<p>
-The Web Annotation Protocol is defined using the following basic principles:
-
-</p><ul>
-<li>The protocol is developed within the framework laid out by the Web Architecture.</li>
-<li>Interactions will follow the REST best practice guidelines when there is a resource being acted upon.</li>
-<li>Interactions are designed to take place over HTTP.</li>
-<li>Existing specifications and systems will be re-used whenever possible, constrained further when necessary, with invention of new specifications only as a last resort</li>
-<li>Simplicity and ease of implementation are important design criteria, but ultimately subjective and less important than the above principles.</li>
-</ul>
-<p></p>
-
-
-</section>
-
-<section id="terminology" typeof="bibo:Chapter" resource="#terminology" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-terminology" resource="#h-terminology"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Terminology</span></h2>
-
-<p>
-</p><dl>
-  <dt>Web Server</dt><dd>A program that accepts connections in order to service HTTP requests by sending HTTP responses.</dd>
-  <dt>Annotation</dt><dd>A web resource that follows the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>]</dd>
-  <dt>Annotation Server</dt><dd>A Web Server that also makes available and allows the management of Annotations via the protocol described in this document</dd>
-  <dt>Annotation Client</dt><dd>A program that establishes connections to Annotation Servers for the purpose of retrieving and managing Annotations via the protocol described in this document</dd>
-  <dt>Annotation Container</dt><dd>An LDP Container [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] used to manage Annotations</dd>
-</dl>
-<p></p>
-</section>
-
-<section id="annotation-retrieval" typeof="bibo:Chapter" resource="#annotation-retrieval" property="bibo:hasPart">
-  <!--OddPage--><h2 id="h-annotation-retrieval" resource="#h-annotation-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Annotation Retrieval</span></h2>
-
-<p>
-  The Annotation Server <em class="rfc2119" title="MUST">MUST</em> support the following HTTP methods on the Annotation's URI:
-
-</p><ul>
-  <li><code>GET</code> (retrieve the description of the Annotation), </li>
-  <li><code>HEAD</code> (retrieve the headers of the Annotation without an entity-body),</li>
-  <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a class="bibref" href="#bib-cors">cors</a></cite>]).</li>
-</ul>
-
-<p>Servers <em class="rfc2119" title="MUST">MUST</em> support the JSON-LD representation using the Web Annotation profile. These responses <em class="rfc2119" title="MUST">MUST</em> have a <code>Content-Type</code> header with the <code>application/ld+json</code> media type, and it <em class="rfc2119" title="SHOULD">SHOULD</em> have the Web Annotation profile URI of <code>http://www.w3.org/ns/anno.jsonld</code> in the <code>profile</code> parameter.</p>
-
-<p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support a Turtle representation, and <em class="rfc2119" title="MAY">MAY</em> support other formats.  If more than one representation of the Annotation is available, then the server <em class="rfc2119" title="SHOULD">SHOULD</em> support content negotiation. Content negotiation for different serializations is performed by including the desired media type in the HTTP <code>Accept</code> header of the request, however clients cannot assume that the server will honor their preferences [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>].</p>
-
-<p>
-Servers <em class="rfc2119" title="MAY">MAY</em> support different JSON-LD profiles. Content negotiation for different JSON-LD profiles is performed by adding a <code>profile</code> parameter to the JSON-LD media type in a space separated, quoted list as part of the <code>Accept</code> header.</p>
-
-<p>The response from the Annotation Server <em class="rfc2119" title="MUST">MUST</em> have a <code>Link</code> header entry <!-- LDP 4.2.1.4 --> where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>.  The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> <em class="rfc2119" title="MAY">MAY</em> also be added with the same <code>rel</code> type.</p>
-
-<p>The response <em class="rfc2119" title="MUST">MUST</em> have an <code>ETag</code> header <!-- LDP 4.2.1.3 --> with an entity reference value that implements the notion of entity tags from HTTP [<cite><a class="bibref" href="#bib-rfc7232">rfc7232</a></cite>].</p>
-
-<p>The response <em class="rfc2119" title="MUST">MUST</em> have an <code>Allow</code> header <!-- LDP 4.2.8.2 from 4.2.2.2 --> that lists the HTTP methods available for the Annotation [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>].</p>
-
-<p>The response <em class="rfc2119" title="MUST">MUST</em> have a <code>Vary</code> header with <code>Accept</code> in the value. [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>]<!-- HTTP + LDP 4.3.2.1 --> </p>
-
-<div>
-Request:
-<div class="example"><div class="example-title marker"><span>Example 1</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">GET </span><span class="pun">/</span><span class="pln">annotations</span><span class="pun">/</span><span class="pln">anno1 HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">org
-</span><span class="typ">Accept</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span></pre></div>
-Response:
-<div class="example"><div class="example-title marker"><span>Example 2</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">200</span><span class="pln"> OK
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Link</span><span class="pun">:</span><span class="pln"> </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/ns/ldp#Resource&gt;; rel="type"</span><span class="pln">
-</span><span class="typ">ETag</span><span class="pun">:</span><span class="pln"> </span><span class="str">"_87e52ce126126"</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> PUT</span><span class="pun">,</span><span class="pln">GET</span><span class="pun">,</span><span class="pln">OPTIONS</span><span class="pun">,</span><span class="pln">HEAD</span><span class="pun">,</span><span class="pln">DELETE</span><span class="pun">,</span><span class="pln">PATCH
-</span><span class="typ">Vary</span><span class="pun">:</span><span class="pln"> </span><span class="typ">Accept</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">243</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/anno1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-01-31T12:03:45Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I like this page!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.example.com/index.html"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</div>
-
-</section>
-
-<section id="annotation-containers" typeof="bibo:Chapter" resource="#annotation-containers" property="bibo:hasPart">
-	<!--OddPage--><h2 id="h-annotation-containers" resource="#h-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Annotation Containers</span></h2>
-
-<p>
-If the Annotation Server supports the management of Annotations, including one or more of creating, updating and deleting them, then the following section's requirements apply. The Annotation Protocol is a use of the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] specification, with some additional constraints derived from the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>].
-</p>
-
-<p>An Annotation Server <em class="rfc2119" title="MUST">MUST</em> provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] (a service for managing Annotations) and a Collection [<cite><a class="bibref" href="#bib-activitystreams-core">activitystreams-core</a></cite>] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.</p><p>
-
-</p><p>
-Annotation Containers <em class="rfc2119" title="SHOULD">SHOULD</em> implement the LDP Basic Container specification, but implementers <em class="rfc2119" title="MAY">MAY</em> instead implement it as one of the other types of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers <em class="rfc2119" title="MAY">MAY</em> have any URI, but <em class="rfc2119" title="MUST">MUST</em> end in a <code>"/"</code> character. The Annotations <em class="rfc2119" title="MUST">MUST</em> be assigned URIs with an additional path component below the Container's URI.
-</p>
-
-<p>
-  The creation, management and structure of Annotation Containers are beyond the scope of this specification.  Please see the Linked Data Platform specification [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] for additional information in this regard.
-  </p>
-
-<section id="container-retrieval" typeof="bibo:Chapter" resource="#container-retrieval" property="bibo:hasPart">
-  <h3 id="h-container-retrieval" resource="#h-container-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Container Retrieval</span></h3>
-
-<p>
-  The Annotation Server <em class="rfc2119" title="MUST">MUST</em> support the following HTTP methods on the Annotation Container's URI:
-
-</p><ul>
-  <li><code>GET</code> (retrieve the description of the Container and the list of its contents, described below), </li>
-  <li><code>HEAD</code> (retrieve the headers of the Container without an entity-body),</li>
-  <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a class="bibref" href="#bib-cors">cors</a></cite>]).</li>
-</ul>  <!-- LDP -->
-
-<p>
-  When an HTTP GET request is issued against the Annotation Container, the server <em class="rfc2119" title="MUST">MUST</em> return a description of the container.  That description <em class="rfc2119" title="MUST">MUST</em> be available in JSON-LD, <em class="rfc2119" title="SHOULD">SHOULD</em> be available in Turtle, and <em class="rfc2119" title="MAY">MAY</em> be available in other formats. The JSON-LD serialization of the Container's description <em class="rfc2119" title="SHOULD">SHOULD</em> use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>], unless the request would determine otherwise.
-</p>
-
-<p>
-  Clients that have a preference for JSON-LD <em class="rfc2119" title="SHOULD">SHOULD</em> explicitly request it using an <code>Accept</code> header on the request. If the <code>Accept</code> header is absent from the request, then Annotation Servers <em class="rfc2119" title="MUST">MUST</em> respond with the JSON-LD representation of the Annotation Container.
-</p>
-
-<p>
-  All supported methods for interacting with the Annotation Container <em class="rfc2119" title="MUST">MUST</em> be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's URI <!-- LDP --> . The <code>Allow</code> header <em class="rfc2119" title="MAY">MAY</em> also be included on any other responses.</p>
-
-<p>Annotation Containers <em class="rfc2119" title="MUST">MUST</em> return a <code>Link</code> header [<cite><a class="bibref" href="#bib-rfc5988">rfc5988</a></cite>] on all responses with the following components:
-  </p><ul>
-    <li>It <em class="rfc2119" title="MUST">MUST</em> advertise its type by including a link where the <code>rel</code> parameter value is <code>type</code> and the target IRI is the appropriate Container Type, such as <code>http://www.w3.org/ns/ldp#BasicContainer</code> for Basic Containers.</li>
-    <li>It <em class="rfc2119" title="MUST">MUST</em> advertise that it imposes Annotation protocol specific constraints by including a link where the target IRI is <code>http://www.w3.org/TR/annotation-protocol/</code>, and the <code>rel</code> parameter value is the URI <code>http://www.w3.org/ns/ldp#constrainedBy</code>.</li>
-  </ul>
-<p></p>
-
-<p>
-  All HTTP responses from Annotation Containers <em class="rfc2119" title="MUST">MUST</em> include an <code>ETag</code> header, that implements the notion of entity tags from HTTP [<cite><a class="bibref" href="#bib-rfc7230">rfc7230</a></cite>].</p>
-
-<p>
-Responses from Annotation Containers <em class="rfc2119" title="MUST">MUST</em> include a <code>Vary</code> header <!-- HTTP + LDP -->.  The value <em class="rfc2119" title="MUST">MUST</em> include <code>Accept</code>, and <em class="rfc2119" title="MAY">MAY</em> include any other headers used to determine the representation provided in the response.</p>
-
-<p>Responses from Annotation Containers that support the use of the POST method to create Annotations <em class="rfc2119" title="SHOULD">SHOULD</em> include an <code>Accept-Post</code> header on responses to GET, HEAD and OPTIONS requests.  The value is a comma separated list of media-types that are acceptable for the client to send via POST [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>].</p>
-
-<div>
-  <div class="example"><div class="example-title marker"><span>Example 3</span><span style="text-transform: none">: Example Annotation Container Headers</span></div><pre class="highlight prettyprint prettyprinted"><span class="typ">Link</span><span class="pun">:</span><span class="pln"> </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/ns/ldp#BasicContainer&gt;; rel="type",</span><span class="pln">
-      </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/TR/annotation-protocol/&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"</span><span class="pln">
-</span><span class="typ">ETag</span><span class="pun">:</span><span class="pln"> </span><span class="str">"0f6b5cd8dc1f754a1738a53b1da34f6b"</span><span class="pln">
-</span><span class="typ">Vary</span><span class="pun">:</span><span class="pln"> </span><span class="typ">Accept</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> POST</span><span class="pun">,</span><span class="pln"> GET</span><span class="pun">,</span><span class="pln"> OPTIONS</span><span class="pun">,</span><span class="pln"> HEAD</span></pre></div>
-</div>
-
-<section id="client-preferences" typeof="bibo:Chapter" resource="#client-preferences" property="bibo:hasPart">
-  <h4 id="h-client-preferences" resource="#h-client-preferences"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1.1 </span>Client Preferences</span></h4>
-
-There are three possibilities for the request that will govern the server's response:
-
-<ol>
-  <li>If the client prefers to only receive the Container description and no annotations, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
-  <li>If the client prefers to receive the list of annotations only as URIs, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedURIs"</code>.</li>
-  <li>If the client prefers to receive the complete annotation description, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
-</ol>
-
-If no preference is given by the client, the server <em class="rfc2119" title="SHOULD">SHOULD</em> return the full annotation descriptions. The server <em class="rfc2119" title="MAY">MAY</em> ignore the client's preference.
-
-</section>
-
-<section id="responses-without-annotations" typeof="bibo:Chapter" resource="#responses-without-annotations" property="bibo:hasPart">
-  <h4 id="h-responses-without-annotations" resource="#h-responses-without-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1.2 </span>Responses without Annotations</span></h4>
-
-<p>The Client may request the description of the Annotation Container without any included Annotations.</p>
-
-Collection <em class="rfc2119" title="SHOULD">SHOULD</em> include links to the first and last CollectionPages.
-
-<div>
-
-Request:
-<div class="example"><div class="example-title marker"><span>Example 4</span><span style="text-transform: none">: Container Request without Annotations</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">GET </span><span class="pun">/</span><span class="pln">annotations</span><span class="pun">/</span><span class="pln"> HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">org
-</span><span class="typ">Accept</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Prefer</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">return</span><span class="pun">=</span><span class="pln">representation</span><span class="pun">;</span><span class="pln">include</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/ldp#PreferMinimalContainer"</span></pre></div>
-
-Response:
-<div class="example"><div class="example-title marker"><span>Example 5</span><span style="text-transform: none">: Container Response without Annotations</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">200</span><span class="pln"> OK
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">ETag</span><span class="pun">:</span><span class="pln"> </span><span class="str">"_87e52ce123123"</span><span class="pln">
-</span><span class="typ">Link</span><span class="pun">:</span><span class="pln"> </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"</span><span class="pln">
-      </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/TR/annotation-protocol/&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> POST</span><span class="pun">,</span><span class="pln">GET</span><span class="pun">,</span><span class="pln">OPTIONS</span><span class="pun">,</span><span class="pln">HEAD
-</span><span class="typ">Vary</span><span class="pun">:</span><span class="pln"> </span><span class="typ">Accept</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">221</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"http://www.w3.org/ns/ldp.jsonld"</span><span class="pln">
-  </span><span class="pun">],</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="str">"BasicContainer"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"AnnotationCollection"</span><span class="pun">],</span><span class="pln">
-  </span><span class="str">"total"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">42023</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"label"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"A Container for Web Annotations"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"first"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/?page=0"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"last"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/?page=42"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</div>
-</section>
-
-<section id="responses-with-annotations" typeof="bibo:Chapter" resource="#responses-with-annotations" property="bibo:hasPart">
-
-  <h4 id="h-responses-with-annotations" resource="#h-responses-with-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1.3 </span>Responses with Annotations</span></h4>
-
-<p>If the client requests a response that would include the Annotations, either by URI or embedded in the response, then the server <em class="rfc2119" title="MUST">MUST</em> use the paged collection model. Each page, described below, will contain an ordered list with a subset of the managed annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container.  The number of URIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages.  The feature or features by which the annotations are sorted are not explicit in the response.
-</p>
-
-<p>
-The Collection <em class="rfc2119" title="SHOULD">SHOULD</em> include the <code>total</code> property with the total number of annotations in the container. It <em class="rfc2119" title="MUST">MUST</em> also have a link to the first page of its contents using <code>first</code>, and <em class="rfc2119" title="SHOULD">SHOULD</em> have a link to the last page of its contents using <code>last</code>.
-</p>
-
-<p>The URI of the Collection in the response should differentiate between whether the pages contain just the URIs, or the full descriptions of the Annotations.  It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that this be done with a query parameter.  The server <em class="rfc2119" title="MAY">MAY</em> redirect the client to this URI and deliver the response there, otherwise it <em class="rfc2119" title="MUST">MUST</em> include a <code>Content-Location</code> header with the URI as its value. The server <em class="rfc2119" title="SHOULD">SHOULD</em> include <code>Prefer</code> in the <code>Vary</code> response header to assist with caching.</p>
-
-<div>
-
-Request:
-<div class="example"><div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: Collection Request</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">GET </span><span class="pun">/</span><span class="pln">annotations</span><span class="pun">/</span><span class="pln"> HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">org
-</span><span class="typ">Accept</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Prefer</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">return</span><span class="pun">=</span><span class="pln">representation</span><span class="pun">;</span><span class="pln">include</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/ldp#PreferContainedURIs"</span></pre></div>
-
-Response:
-<div class="example"><div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: Collection Response</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">200</span><span class="pln"> OK
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Location</span><span class="pun">:</span><span class="pln"> http</span><span class="pun">:</span><span class="com">//example.org/annotations/?uris=1</span><span class="pln">
-</span><span class="typ">ETag</span><span class="pun">:</span><span class="pln"> </span><span class="str">"_87e52ce123123"</span><span class="pln">
-</span><span class="typ">Link</span><span class="pun">:</span><span class="pln"> </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"</span><span class="pln">
-      </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/TR/annotation-protocol/&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> POST</span><span class="pun">,</span><span class="pln">GET</span><span class="pun">,</span><span class="pln">OPTIONS</span><span class="pun">,</span><span class="pln">HEAD
-</span><span class="typ">Vary</span><span class="pun">:</span><span class="pln"> </span><span class="typ">Accept</span><span class="pun">,</span><span class="pln"> </span><span class="typ">Prefer</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">221</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"http://www.w3.org/ns/ldp.jsonld"</span><span class="pln">
-  </span><span class="pun">],</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/?uris=1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="str">"BasicContainer"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"AnnotationCollection"</span><span class="pun">],</span><span class="pln">
-  </span><span class="str">"total"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">42023</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"label"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"A Container for Web Annotations"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"first"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/?uris=1&amp;page=0"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"last"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/?uris=1&amp;page=42"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</div>
-
-<h4 id="page-response">Page Response</h4>
-<p>
-Individual pages are instances of <code>CollectionPage</code>.  The page contains the Annotations, either via their URIs or full descriptions, in the <code>items</code> property.</p>
-
-<p>Each page <em class="rfc2119" title="MUST">MUST</em> have a link to the container that it is part of, using the <code>partOf</code> property.  If it is not the first page, it <em class="rfc2119" title="MUST">MUST</em> have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it <em class="rfc2119" title="MUST">MUST</em> have a link to the next page in the sequence, using the <code>next</code> property. The response <em class="rfc2119" title="MAY">MAY</em> include properties of the Collection in the response, including the total number of items or first and last page links.
-</p>
-
-<p>
-The client <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> send the <code>Prefer</code> header when requesting the page, as it has already been taken into account when requesting the Container.
-</p>
-
-<p>This specification does not require any particular functionality when a client makes requests other than GET, HEAD or OPTIONS to a page.</p>
-
-<p>As the <code>CollectionPage</code> is not a Container, it does not have the requirement to include a <code>Link</code> header with a type. That the URLs can be constructed with query parameters added to the Container's URI is an implementation convenience, and does not imply the type of the resource.</p>
-
-<div>
-
-Request:
-<div class="example"><div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: Page Request</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">GET </span><span class="pun">/</span><span class="pln">annotations</span><span class="pun">/?</span><span class="pln">uris</span><span class="pun">=</span><span class="lit">1</span><span class="pun">&amp;</span><span class="pln">page</span><span class="pun">=</span><span class="lit">0</span><span class="pln"> HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">org
-</span><span class="typ">Accept</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span></pre></div>
-
-Response:
-<div class="example"><div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: Page Response</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">200</span><span class="pln"> OK
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> GET</span><span class="pun">,</span><span class="pln">OPTIONS</span><span class="pun">,</span><span class="pln">HEAD
-</span><span class="typ">Vary</span><span class="pun">:</span><span class="pln"> </span><span class="typ">Accept</span><span class="pun">,</span><span class="pln"> </span><span class="typ">Prefer</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">221</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/?uris=1&amp;page=0"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"AnnotationPage"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"partOf"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/?uris=1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"total"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">42023</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"next"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/?uris=1&amp;page=1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    </span><span class="str">"http://example.org/annotations/anno1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"http://example.org/annotations/anno2"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"http://example.org/annotations/anno3"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"http://example.org/annotations/anno4"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"http://example.org/annotations/anno5"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"http://example.org/annotations/anno6"</span><span class="pun">,</span><span class="pln">
-    </span><span class="pun">...</span><span class="pln">
-    </span><span class="str">"http://example.org/annotations/anno999"</span><span class="pun">,</span><span class="pln">
-  </span><span class="pun">]</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</div>
-</section>
-</section>
-
-<section id="discovery-of-annotation-containers" typeof="bibo:Chapter" resource="#discovery-of-annotation-containers" property="bibo:hasPart">
-  <h3 id="h-discovery-of-annotation-containers" resource="#h-discovery-of-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.2 </span>Discovery of Annotation Containers</span></h3>
-
-<p>As the URI for Annotation Containers <em class="rfc2119" title="MAY">MAY</em> be any URI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
-
-<p>Any resource <em class="rfc2119" title="MAY">MAY</em> link to an Annotation Container when Annotations on the resource <em class="rfc2119" title="SHOULD">SHOULD</em> be created within the referenced Container.  This link is carried in an HTTP <code>Link</code> header and the value of the <code>rel</code> parameter <em class="rfc2119" title="MUST">MUST</em> be <code>http://www.w3.org/ns/oa#annotationService</code>.</p>
-
-<p>For HTML representations of resources, the equivalent <code>link</code> tag in the header of the document <em class="rfc2119" title="MAY">MAY</em> also be used.</p>
-
-<div>
-<p>For an example image resource, a GET request and response with a link to the above Annotation Container might look like:</p>
-
-Request:
-<div class="example"><div class="example-title marker"><span>Example 10</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">GET </span><span class="pun">/</span><span class="pln">images</span><span class="pun">/</span><span class="pln">logo</span><span class="pun">.</span><span class="pln">jpg HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">com</span></pre></div>
-Response:
-<div class="example"><div class="example-title marker"><span>Example 11</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">200</span><span class="pln"> OK
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> image</span><span class="pun">/</span><span class="pln">jpeg
-</span><span class="typ">Link</span><span class="pun">:</span><span class="pln"> </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//example.org/annotations/&gt;; rel="http://www.w3.org/ns/oa#annotationService"</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> GET
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">76983</span><span class="pln">
-
-</span><span class="pun">[...]</span></pre></div>
-</div>
-
-</section>
-</section>
-<!-- End of Containers -->
-
-<section id="creation-updating-and-deletion-of-annotations" typeof="bibo:Chapter" resource="#creation-updating-and-deletion-of-annotations" property="bibo:hasPart">
-  <!--OddPage--><h2 id="h-creation-updating-and-deletion-of-annotations" resource="#h-creation-updating-and-deletion-of-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Creation, Updating and Deletion of Annotations</span></h2>
-
-<section id="create-a-new-annotation" typeof="bibo:Chapter" resource="#create-a-new-annotation" property="bibo:hasPart">
-<h3 id="h-create-a-new-annotation" resource="#h-create-a-new-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.1 </span>Create a New Annotation</span></h3>
-
-<p>New Annotations are created via a POST request of a JSON-LD serialization of the Annotation to an Annotation Container.  The Annotation's data is sent in the body of the request. All of the known information about the Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> be sent, and if there are already URIs associated with the resources, they <em class="rfc2119" title="MAY">MAY</em> be included. The serialization <em class="rfc2119" title="SHOULD">SHOULD</em> use the Web Annotation JSON-LD profile, and servers <em class="rfc2119" title="MAY">MAY</em> reject other contexts even if they would otherwise produce the same model. The server <em class="rfc2119" title="MAY">MAY</em> reject content that is not an Annotation according to the Web Annotation specification.</p>
-
-<p>Upon receipt of an Annotation, the server <em class="rfc2119" title="SHOULD">SHOULD</em> assign HTTP URIs to all resources and blank nodes in the Annotation, and <em class="rfc2119" title="MUST">MUST</em> assign a URI to the Annotation resource, even if it aleady has one provided in the entity body description.  The server <em class="rfc2119" title="MAY">MAY</em> also add additional information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, additional types and formats.</p>
-
-<p>If the Annotation contains a <code>canonical</code> link, then it <em class="rfc2119" title="MUST">MUST</em> be maintained without change.  If the Annotation has a URI in the <code>id</code> property, then it <em class="rfc2119" title="SHOULD">SHOULD</em> be copied to the <code>via</code> property, and the URI assigned by the server at which the Annotation is available <em class="rfc2119" title="MUST">MUST</em> be put in the <code>id</code> field to replace it.</p>
-
-<p>The server <em class="rfc2119" title="MUST">MUST</em> respond with a <code>201</code> Created response if the creation is successful, and an appropriate error code otherwise.  The response <em class="rfc2119" title="MUST">MUST</em> have a <code>Location</code> header with the Annotation's new URI.</p>
-
-<p>The body of the response <em class="rfc2119" title="MUST">MUST</em> be the Annotation as now managed by the server, including any additional URIs or data created in the process or without any information that was sent but not stored. Barring content negotiation, the response <em class="rfc2119" title="SHOULD">SHOULD</em> be serialized in JSON-LD following the Annotation Data Model specification.</p>
-<p>The response <em class="rfc2119" title="MUST">MUST</em> include a <code>Link</code> header with the target IRI of <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value of <code>type</code> to advertise that this is an RDF Source, according to the LDP specification.  It <em class="rfc2119" title="MAY">MAY</em> also include the URI <code>http://www.w3.org/ns/oa#Annotation</code> with the same <code>rel</code> parameter of <code>type</code> to also assert that it is an Annotation following the Web Annotation specifications.</p>
-
-<p>The response <em class="rfc2119" title="MUST">MUST</em> include a <code>Vary</code> header with the value that includes <code>Accept</code>, as the representation is negotiable based on the client's Accept header. If the container preferences described above are supported, this <em class="rfc2119" title="MUST">MUST</em> also include <code>Prefer</code> <!-- HTTP -->.
-
-
-</p><div>
-Request:
-<div class="example"><div class="example-title marker"><span>Example 12</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">POST </span><span class="pun">/</span><span class="pln">annotations</span><span class="pun">/</span><span class="pln"> HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">org
-</span><span class="typ">Accept</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">153</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I like this page!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.example.com/index.html"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-Response:
-<div class="example"><div class="example-title marker"><span>Example 13</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">201</span><span class="pln"> CREATED
-</span><span class="typ">Link</span><span class="pun">:</span><span class="pln"> </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"</span><span class="pln">
-      </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/TR/annotation-protocol/&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> PUT</span><span class="pun">,</span><span class="pln">GET</span><span class="pun">,</span><span class="pln">OPTIONS</span><span class="pun">,</span><span class="pln">HEAD</span><span class="pun">,</span><span class="pln">DELETE</span><span class="pun">,</span><span class="pln">PATCH
-</span><span class="typ">Vary</span><span class="pun">:</span><span class="pln"> </span><span class="typ">Accept</span><span class="pln">
-</span><span class="typ">Location</span><span class="pun">:</span><span class="pln"> http</span><span class="pun">:</span><span class="com">//example.org/annotations/anno1</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">243</span><span class="pln">
-</span><span class="typ">ETag</span><span class="pun">:</span><span class="pln"> </span><span class="str">"_87e52ce126126"</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/anno1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-01-31T12:03:45Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I like this page!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.example.com/index.html"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</div>
-</section>
-
-<section id="suggesting-a-uri-for-an-annotation" typeof="bibo:Chapter" resource="#suggesting-a-uri-for-an-annotation" property="bibo:hasPart">
-<h3 id="h-suggesting-a-uri-for-an-annotation" resource="#h-suggesting-a-uri-for-an-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.2 </span>Suggesting a URI for an Annotation</span></h3>
-<p>The URI path segment that is appended to the Container URI for a resource <em class="rfc2119" title="MAY">MAY</em> be suggested by the Annotation Client by using the <code>Slug</code> HTTP header on the request when the resource is created.  The server <em class="rfc2119" title="SHOULD">SHOULD</em> use this name, so long as it does not already identify an existing resource, but <em class="rfc2119" title="MAY">MAY</em> ignore it and use an automatically assigned name. </p>
-
-<div>
-Request:
-<div class="example"><div class="example-title marker"><span>Example 14</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">POST </span><span class="pun">/</span><span class="pln">annotations</span><span class="pun">/</span><span class="pln"> HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">org
-</span><span class="typ">Accept</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">153</span><span class="pln">
-</span><span class="typ">Slug</span><span class="pun">:</span><span class="pln"> </span><span class="str">"my_first_annotation"</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I like this page!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.example.com/index.html"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-Response:
-<div class="example"><div class="example-title marker"><span>Example 15</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">201</span><span class="pln"> CREATED
-</span><span class="typ">Link</span><span class="pun">:</span><span class="pln"> </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> PUT</span><span class="pun">,</span><span class="pln">GET</span><span class="pun">,</span><span class="pln">OPTIONS</span><span class="pun">,</span><span class="pln">HEAD</span><span class="pun">,</span><span class="pln">DELETE</span><span class="pun">,</span><span class="pln">PATCH
-</span><span class="typ">Location</span><span class="pun">:</span><span class="pln"> http</span><span class="pun">:</span><span class="com">//example.org/annotations/my_first_annotation</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">ETag</span><span class="pun">:</span><span class="pln"> </span><span class="str">"_87e52ce126126"</span><span class="pln">
-</span><span class="typ">Vary</span><span class="pun">:</span><span class="pln"> </span><span class="typ">Accept</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">257</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/my_first_annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-01-31T12:03:45Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I like this page!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.example.com/index.html"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</div>
-
-</section>
-
-
-<section id="update-an-existing-annotation" typeof="bibo:Chapter" resource="#update-an-existing-annotation" property="bibo:hasPart">
-<h3 id="h-update-an-existing-annotation" resource="#h-update-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.3 </span>Update an Existing Annotation</span></h3>
-
-<p>Annotations can be updated by using a PUT request to replace the entire state of the Annotation.  Annotation Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support this method. Servers <em class="rfc2119" title="MAY">MAY</em> also support using a PATCH request to update only the aspects of the Annotation that have changed, but that functionality is not specified in this document.
-</p>
-
-<p>Replacing the Annotation with a new state <em class="rfc2119" title="MUST">MUST</em> be done with the PUT method, where the body of the request is the intended new state of the Annotation.  The client <em class="rfc2119" title="SHOULD">SHOULD</em> use the <code>If-Match</code> header with a value of the ETag it received from the server before the editing process began, to avoid collisions of multiple users modifying the same Annotation at the same time.</p>
-
-<p>If successful, the server <em class="rfc2119" title="MUST">MUST</em> return a 200 OK status with the Annotation as the body according to the content-type requested.</p>
-
-<p>Servers <em class="rfc2119" title="MUST">MUST</em> advertise the availability of updating via PUT on requests to the Annotation's URI using the <code>Allow</code> response header.</p>
-
-<div>
-Request:
-<div class="example"><div class="example-title marker"><span>Example 16</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">PUT </span><span class="pun">/</span><span class="pln">annotations</span><span class="pun">/</span><span class="pln">anno1 HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">org
-</span><span class="typ">Accept</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">163</span><span class="pln">
-</span><span class="typ">If</span><span class="pun">-</span><span class="typ">Match</span><span class="pun">:</span><span class="pln"> </span><span class="str">"_87e52ce126126"</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/anno1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-02-01T10:13:40Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I REALLY like this page!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.example.com/index.html"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-Response:
-<div class="example"><div class="example-title marker"><span>Example 17</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">200</span><span class="pln"> OK
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Type</span><span class="pun">:</span><span class="pln"> application</span><span class="pun">/</span><span class="pln">ld</span><span class="pun">+</span><span class="pln">json</span><span class="pun">;</span><span class="pln"> profile</span><span class="pun">=</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pln">
-</span><span class="typ">ETag</span><span class="pun">:</span><span class="pln"> </span><span class="str">"_87e52ce234234"</span><span class="pln">
-</span><span class="typ">Link</span><span class="pun">:</span><span class="pln"> </span><span class="pun">&lt;</span><span class="pln">http</span><span class="pun">:</span><span class="com">//www.w3.org/ns/ldp#Resource&gt;; rel="type"</span><span class="pln">
-</span><span class="typ">Allow</span><span class="pun">:</span><span class="pln"> PUT</span><span class="pun">,</span><span class="pln">GET</span><span class="pun">,</span><span class="pln">OPTIONS</span><span class="pun">,</span><span class="pln">HEAD</span><span class="pun">,</span><span class="pln">DELETE</span><span class="pun">,</span><span class="pln">PATCH
-</span><span class="typ">Vary</span><span class="pun">:</span><span class="pln"> </span><span class="typ">Accept</span><span class="pln">
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">243</span><span class="pln">
-
-</span><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/annotations/anno1"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"created"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-02-01T10:13:40Z"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"modified"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"2015-02-02T20:43:19Z"</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I REALLY like this page!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.example.com/index.html"</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-</div>
-
-</section>
-
-
-<section id="delete-an-existing-annotation" typeof="bibo:Chapter" resource="#delete-an-existing-annotation" property="bibo:hasPart">
-<h3 id="h-delete-an-existing-annotation" resource="#h-delete-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.4 </span>Delete an Existing Annotation</span></h3>
-
-<p>Clients use the DELETE method to request that an Annotation be deleted.  Annotation Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support this method. Clients <em class="rfc2119" title="SHOULD">SHOULD</em> send the ETag of the Annotation in the <code>If-Match</code> header to ensure that it is operating against the most recent version of the Annotation.</p>
-
-<p>If the DELETE request is successfully processed, then the server <em class="rfc2119" title="MUST">MUST</em> return a 200 or 204 status response.  The URIs of deleted Annotations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be re-used for subsequent Annotations. <!-- LDP -->  The URI of the deleted Annotation <em class="rfc2119" title="MUST">MUST</em> be removed from the Annotation Container it was created in. <!-- LDP --> </p>
-
-<div>
-Request:
-<div class="example"><div class="example-title marker"><span>Example 18</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">DELETE </span><span class="pun">/</span><span class="pln">annotations</span><span class="pun">/</span><span class="pln">anno1 HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln">
-</span><span class="typ">Host</span><span class="pun">:</span><span class="pln"> example</span><span class="pun">.</span><span class="pln">org
-</span><span class="typ">If</span><span class="pun">-</span><span class="typ">Match</span><span class="pun">:</span><span class="pln"> </span><span class="str">"_87e52ce126126"</span></pre></div>
-Response:
-<div class="example"><div class="example-title marker"><span>Example 19</span></div><pre class="highlight prettyprint prettyprinted"><span class="pln">HTTP</span><span class="pun">/</span><span class="lit">1.1</span><span class="pln"> </span><span class="lit">204</span><span class="pln"> NO CONTENT
-</span><span class="typ">Content</span><span class="pun">-</span><span class="typ">Length</span><span class="pun">:</span><span class="pln"> </span><span class="lit">0</span></pre></div>
-</div>
-</section>
-</section>
-
-
-<section id="error-conditions" typeof="bibo:Chapter" resource="#error-conditions" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-error-conditions" resource="#h-error-conditions"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Error Conditions</span></h2>
-
-<p>There are inevitably situations where errors occur in the when retrieving or managing Annotations.  The use of the HTTP Status codes below provides a method for clients to understand the reason why a request has failed.  No requirements are made regarding the entity-body of the response from the Annotation Server, however all HTTP header requirements from section 4 <em class="rfc2119" title="MUST">MUST</em> be adhered to.</p>
-
-<dl>
-  <dt>400</dt><dd>The Annotation Client sent a request which the Annotation Server cannot process due to the request not following the appropriate specifications</dd>
-  <dt>401</dt><dd>The Annotation Client is not authorized to perform the requested operation, such as creating or deleting an Annotation, as it did not supply authentication credentials</dd>
-  <dt>403</dt><dd>The Annotation Client is not authorized to perform the requested operation, as the authentication credentials supplied did not meet the requirements of a particular access control policy for the Annotation or Annotation Container</dd>
-  <dt>404</dt><dd>The Annotation or Annotation Container requested does not exist</dd>
-  <dt>405</dt><dd>The requested HTTP method is not allowed for the resource, such as trying to POST to an Annotation Container page, or trying to PATCH an Annotation when that functionality is not supported</dd>
-  <dt>406</dt><dd>The requested format for the Annotation or Annotation Container's representation is not available, for example if a client requested RDF/XML and the server does not support that (optional) transformation.</dd>
-  <dt>409</dt><dd>The Annotation Client tried to set or change a value that the server does not allow Clients to modify, such as the containment list of an Annotation Container or server set modification timestamps</dd>
-  <dt>410</dt><dd>The Annotation is known to have existed in the past and was deleted</dd>
-  <dt>412</dt><dd>The Annotation Client supplied an If-Match header that did not match the ETag of the Annotation being modified</dd>
-  <dt>415</dt><dd>The Annotation Client sent an entity-body that is not able to be processed by the Server, such as non-Annotation or in a context that is unrecognized</dd>
-</dl>
-
-</section>
-
-<section id="containers-for-related-resources" typeof="bibo:Chapter" resource="#containers-for-related-resources" property="bibo:hasPart">
-  <!--OddPage--><h2 id="h-containers-for-related-resources" resource="#h-containers-for-related-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">8. </span>Containers for Related Resources</span></h2>
-
-<p>Annotations may have related resources that are required for their correct interpretation and rendering, such as content resources used in or as the Body, CSS stylesheets that determine the rendering of the annotation, SVG documents describing a non-rectangular region of a resource, and so forth.  If these resources do not already have URIs, then they need to be made available somewhere so that they can be refered to.</p>
-
-<p>Annotation Servers <em class="rfc2119" title="MAY">MAY</em> support the management of related resources independently from the Annotations. If a server supports the management of these resources, it <em class="rfc2119" title="SHOULD">SHOULD</em> do this with one or more separate Containers.  Resources that are not Annotations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be included in an Annotation Container, as Annotation Clients would not expect to find arbitrary content when dereferencing the URIs. <!-- Additional but insanity reducing constraint -->  Containers for related resources <em class="rfc2119" title="MAY">MAY</em> contain both RDF Sources and Non-RDF Sources.  No restrictions are placed on the type or configuration of the Container beyond those of the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>].</p>
-<p>Containers for related resources <em class="rfc2119" title="MUST">MUST</em> support the same HTTP methods as described above for the Annotation Container, and <em class="rfc2119" title="MUST">MUST</em> support identifying their type with a <code>Link</code> header. The <code>constrainedBy</code> link header on the response when dereferencing the Container <em class="rfc2119" title="SHOULD">SHOULD</em> refer to a server specific set of constraints listing the types of content that are acceptable. <!-- LDP --> </p>
-
-</section>
-
-
-<section class="appendix" id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
-<!--OddPage--><h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Acknowledgements</span></h2>
-
-<p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>.  The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model and protocol.
-</p>
-
-<p>The following people have been instrumental in providing thoughts, feedback, reviews, content, criticism and input in the creation of this specification:
-
-</p><div style="margin-left: 3em">
-Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven Capadisli, Paolo Ciccarese, Tim Cole, Ray Denenberg, TB Dinesh, Sergiu Gordea, Benjamin Goering, Amy Guy, Ivan Herman, Frederick Hirsch, Antoine Isaac, Jacob Jett, Takeshi Kanai, Gregg Kellogg, Andreas Kuckartz, Randall Leeds, Hugo Manguinhas, Ben De Meester, Luc Moreau, Addison Phillips, Davis Salisbury, Robert Sanderson, Felix Sasaki, Doug Schepers, Tzviya Siegman, Stian Soiland-Reyes, Manu Sporney, Nick Stenning, Jon Stroop, Lutz Suhrbier, Kyrce Swenson, Raphael Troncy, Simeon Warner, Erik Wilde, Dan Whaley, Benjamin Young
-</div>
-<p></p>
-</section>
-
-
-
-<section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
-</dd><dt id="bib-activitystreams-core">[activitystreams-core]</dt><dd>James Snell; Evan Prodromou. W3C. <a href="http://www.w3.org/TR/activitystreams-core/" property="dc:requires"><cite>Activity Streams 2.0</cite></a>. 15 December 2015. W3C Working Draft. URL: <a href="http://www.w3.org/TR/activitystreams-core/" property="dc:requires">http://www.w3.org/TR/activitystreams-core/</a>
-</dd><dt id="bib-annotation-model">[annotation-model]</dt><dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires"><cite>Web Annotation Data Model</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
-</dd><dt id="bib-annotation-vocab">[annotation-vocab]</dt><dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/" property="dc:requires"><cite>Web Annotation Vocabulary</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/</a>
-</dd><dt id="bib-cors">[cors]</dt><dd>Anne van Kesteren. W3C. <a href="http://www.w3.org/TR/cors/" property="dc:requires"><cite>Cross-Origin Resource Sharing</cite></a>. 16 January 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/cors/" property="dc:requires">http://www.w3.org/TR/cors/</a>
-</dd><dt id="bib-ldp">[ldp]</dt><dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a href="http://www.w3.org/TR/ldp/" property="dc:requires"><cite>Linked Data Platform 1.0</cite></a>. 26 February 2015. W3C Recommendation. URL: <a href="http://www.w3.org/TR/ldp/" property="dc:requires">http://www.w3.org/TR/ldp/</a>
-</dd><dt id="bib-ldp-paging">[ldp-paging]</dt><dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a href="http://www.w3.org/TR/ldp-paging/" property="dc:requires"><cite>Linked Data Platform Paging 1.0</cite></a>. 30 June 2015. W3C Note. URL: <a href="http://www.w3.org/TR/ldp-paging/" property="dc:requires">http://www.w3.org/TR/ldp-paging/</a>
-</dd><dt id="bib-rfc5988">[rfc5988]</dt><dd>M. Nottingham. IETF. <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires">https://tools.ietf.org/html/rfc5988</a>
-</dd><dt id="bib-rfc7230">[rfc7230]</dt><dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7230" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7230" property="dc:requires">https://tools.ietf.org/html/rfc7230</a>
-</dd><dt id="bib-rfc7231">[rfc7231]</dt><dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7231" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231" property="dc:requires">https://tools.ietf.org/html/rfc7231</a>
-</dd><dt id="bib-rfc7232">[rfc7232]</dt><dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7232" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7232" property="dc:requires">https://tools.ietf.org/html/rfc7232</a>
-</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script async="" defer="" src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>
+    </p>
+    <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+    </p>
+
+  </section>
+  <nav id="toc">
+    <h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
+    <ul class="toc" role="directory">
+      <li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#aims-of-the-protocol" class="tocxref"><span class="secno">1.1 </span>Aims of the Protocol</a></li>
+          <li class="tocline"><a href="#summary" class="tocxref"><span class="secno">1.2 </span>Summary</a></li>
+          <li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">1.3 </span>Conformance</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#web-annotation-protocol-principles" class="tocxref"><span class="secno">2. </span>Web Annotation Protocol Principles</a></li>
+      <li class="tocline"><a href="#terminology" class="tocxref"><span class="secno">3. </span>Terminology</a></li>
+      <li class="tocline"><a href="#annotation-retrieval" class="tocxref"><span class="secno">4. </span>Annotation Retrieval</a></li>
+      <li class="tocline"><a href="#annotation-containers" class="tocxref"><span class="secno">5. </span>Annotation Containers</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#container-retrieval" class="tocxref"><span class="secno">5.1 </span>Container Retrieval</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#client-preferences" class="tocxref"><span class="secno">5.1.1 </span>Client Preferences</a></li>
+              <li class="tocline"><a href="#responses-without-annotations" class="tocxref"><span class="secno">5.1.2 </span>Responses without Annotations</a></li>
+              <li class="tocline"><a href="#responses-with-annotations" class="tocxref"><span class="secno">5.1.3 </span>Responses with Annotations</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#discovery-of-annotation-containers" class="tocxref"><span class="secno">5.2 </span>Discovery of Annotation Containers</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#creation-updating-and-deletion-of-annotations" class="tocxref"><span class="secno">6. </span>Creation, Updating and Deletion of Annotations</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#create-a-new-annotation" class="tocxref"><span class="secno">6.1 </span>Create a New Annotation</a></li>
+          <li class="tocline"><a href="#suggesting-an-iri-for-an-annotation" class="tocxref"><span class="secno">6.2 </span>Suggesting an IRI for an Annotation</a></li>
+          <li class="tocline"><a href="#update-an-existing-annotation" class="tocxref"><span class="secno">6.3 </span>Update an Existing Annotation</a></li>
+          <li class="tocline"><a href="#delete-an-existing-annotation" class="tocxref"><span class="secno">6.4 </span>Delete an Existing Annotation</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#error-conditions" class="tocxref"><span class="secno">7. </span>Error Conditions</a></li>
+      <li class="tocline"><a href="#containers-for-related-resources" class="tocxref"><span class="secno">8. </span>Containers for Related Resources</a></li>
+      <li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">A. </span>Acknowledgements</a></li>
+      <li class="tocline"><a href="#references" class="tocxref"><span class="secno">B. </span>References</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">B.1 </span>Normative references</a></li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+
+
+  <section class="informative" id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
+    <p><em>This section is non-normative.</em></p>
+
+    <p>Interoperability between systems has two basic aspects: the syntax and semantics of the data that is moved between the systems, and the transport mechanism for that movement. The HTTP protocol and the Web architecture provides us with a great starting point for a standardized transport layer, and can be used to move content between systems easily and effectively. Building upon these foundations allows us to make use of existing technology and patterns to ensure consistency and ease of development.</p>
+
+    <p>The Web Annotation Protocol describes a transport mechanism for creating, managing, and retrieving Annotations. Annotations in this specification are assumed to follow the requirements of the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>] and Web Annotation Vocabulary [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>]. This specification builds upon REST principles and the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] recommendation, and familiarity with it is recommended.</p>
+
+
+    <section id="aims-of-the-protocol" typeof="bibo:Chapter" resource="#aims-of-the-protocol" property="bibo:hasPart">
+      <h3 id="h-aims-of-the-protocol" resource="#h-aims-of-the-protocol"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Aims of the Protocol</span></h3>
+
+      <p>
+        The primary aim of the Web Annotation Protocol is to provide a standard set of interactions that allow annotation clients and servers to interoperate seamlessly. By being able to discover annotation protocol end-points and how to interact with them, clients can be configured either automatically or by the user to store annotations in any compatible remote system, rather than being locked in to a single client and server pair.
+      </p>
+
+    </section>
+
+    <section id="summary" typeof="bibo:Chapter" resource="#summary" property="bibo:hasPart">
+      <h3 id="h-summary" resource="#h-summary"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Summary</span></h3>
+
+      <p>For those familiar with the Web Annotation model, LDP and REST, much of the Annotation Protocol will be very obvious. The following aspects are the most important new requirements.
+      </p>
+
+      <ul>
+        <li>The media type to use for Annotations is: <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code></li>
+        <li>Annotation Containers are constrained by the set of constraints described in this specification, and thus the <code>ldp:constrainedBy</code> URL is <code>http://www.w3.org/TR/annotation-protocol/</code></li>
+        <li>The link header can refer from any resource to an Annotation Container using a <code>rel</code> type of: <code>http://www.w3.org/ns/oa#annotationService</code></li>
+        <li>The response from a Container after creating an Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> include a representation of the Annotation, after any changes have been made to it, in the JSON-LD serialization.</li>
+        <li>Annotation Containers <em class="rfc2119" title="SHOULD">SHOULD</em> only contain Annotations, and not other resources.</li>
+        <li>LDP-Paging [<cite><a class="bibref" href="#bib-ldp-paging">ldp-paging</a></cite>] is not used, as in-page ordering is an important requirement. Instead, the Activity Streams Collection model is used [<cite><a class="bibref" href="#bib-activitystreams-core">activitystreams-core</a></cite>].</li>
+      </ul>
+
+    </section>
+
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart">
+      <h3 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
+      <p>
+        As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
+      </p>
+      <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+      </p>
+
+    </section>
+
+  </section>
+
+  <!-- End Introduction -->
+
+  <section id="web-annotation-protocol-principles" typeof="bibo:Chapter" resource="#web-annotation-protocol-principles" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-web-annotation-protocol-principles" resource="#h-web-annotation-protocol-principles"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Protocol Principles</span></h2>
+
+    <p>
+      The Web Annotation Protocol is defined using the following basic principles:
+
+    </p>
+    <ul>
+      <li>The protocol is developed within the framework laid out by the Web Architecture.</li>
+      <li>Interactions will follow the REST best practice guidelines when there is a resource being acted upon.</li>
+      <li>Interactions are designed to take place over HTTP.</li>
+      <li>Existing specifications and systems will be re-used whenever possible, constrained further when necessary, with invention of new specifications only as a last resort</li>
+      <li>Simplicity and ease of implementation are important design criteria, but ultimately subjective and less important than the above principles.</li>
+    </ul>
+    <p></p>
+
+
+  </section>
+
+  <section id="terminology" typeof="bibo:Chapter" resource="#terminology" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-terminology" resource="#h-terminology"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Terminology</span></h2>
+
+    <p>
+    </p>
+    <dl>
+      <dt>Web Server</dt>
+      <dd>A program that accepts connections in order to service HTTP requests by sending HTTP responses.</dd>
+      <dt>Annotation</dt>
+      <dd>A web resource that follows the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>]</dd>
+      <dt>Annotation Server</dt>
+      <dd>A Web Server that also makes available and allows the management of Annotations via the protocol described in this document</dd>
+      <dt>Annotation Client</dt>
+      <dd>A program that establishes connections to Annotation Servers for the purpose of retrieving and managing Annotations via the protocol described in this document</dd>
+      <dt>Annotation Container</dt>
+      <dd>An LDP Container [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] used to manage Annotations</dd>
+    </dl>
+    <p></p>
+  </section>
+
+  <section id="annotation-retrieval" typeof="bibo:Chapter" resource="#annotation-retrieval" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-annotation-retrieval" resource="#h-annotation-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Annotation Retrieval</span></h2>
+
+    <p>
+      The Annotation Server <em class="rfc2119" title="MUST">MUST</em> support the following HTTP methods on the Annotation's IRI:
+
+    </p>
+    <ul>
+      <li><code>GET</code> (retrieve the description of the Annotation), </li>
+      <li><code>HEAD</code> (retrieve the headers of the Annotation without an entity-body),</li>
+      <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a class="bibref" href="#bib-cors">cors</a></cite>]).</li>
+    </ul>
+
+    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use HTTPS rather than HTTP for all interactions, including retrieval of Annotations.</p>
+
+    <p>Servers <em class="rfc2119" title="MUST">MUST</em> support the JSON-LD representation using the Web Annotation profile. These responses <em class="rfc2119" title="MUST">MUST</em> have a <code>Content-Type</code> header with the <code>application/ld+json</code> media type, and it <em class="rfc2119" title="SHOULD">SHOULD</em> have the Web Annotation profile IRI of <code>http://www.w3.org/ns/anno.jsonld</code> in the <code>profile</code> parameter.</p>
+
+    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support a Turtle representation, and <em class="rfc2119" title="MAY">MAY</em> support other formats. If more than one representation of the Annotation is available, then the server <em class="rfc2119" title="SHOULD">SHOULD</em> support content negotiation. Content negotiation for different serializations is performed by including the desired media type in the HTTP <code>Accept</code> header of the request, however clients cannot assume that the server will honor their preferences [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>].</p>
+
+    <p>
+      Servers <em class="rfc2119" title="MAY">MAY</em> support different JSON-LD profiles. Content negotiation for different JSON-LD profiles is performed by adding a <code>profile</code> parameter to the JSON-LD media type in a space separated, quoted list as part of the <code>Accept</code> header.</p>
+
+    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use the 200 HTTP status code when no errors occured while processing the request to retrieve an Annotation, and <em class="rfc2119" title="MAY">MAY</em> use 3XX HTTP status codes to redirect to a new location.</p>
+
+    <p>The response from the Annotation Server <em class="rfc2119" title="MUST">MUST</em> have a <code>Link</code> header entry
+      <!-- LDP 4.2.1.4 -->where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>. The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> <em class="rfc2119" title="MAY">MAY</em> also be added with the same <code>rel</code> type.</p>
+
+    <p>The response <em class="rfc2119" title="MUST">MUST</em> have an <code>ETag</code> header
+      <!-- LDP 4.2.1.3 -->with an entity reference value that implements the notion of entity tags from HTTP [<cite><a class="bibref" href="#bib-rfc7232">rfc7232</a></cite>].</p>
+
+    <p>The response <em class="rfc2119" title="MUST">MUST</em> have an <code>Allow</code> header
+      <!-- LDP 4.2.8.2 from 4.2.2.2 -->that lists the HTTP methods available for the Annotation [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>].</p>
+
+    <p>The response <em class="rfc2119" title="MUST">MUST</em> have a <code>Vary</code> header with <code>Accept</code> in the value. [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>]
+      <!-- HTTP + LDP 4.3.2.1 -->
+    </p>
+
+    <div>
+      Request:
+      <div class="example">
+        <div class="example-title marker"><span>Example 1</span></div><pre class="highlight hljs http"><span class="hljs-request">GET <span class="hljs-string">/annotations/anno1</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span></pre></div>
+      Response:
+      <div class="example">
+        <div class="example-title marker"><span>Example 2</span></div><pre class="highlight hljs http"><span class="hljs-status">HTTP/1.1 <span class="hljs-number">200</span> OK</span>
+<span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;http://www.w3.org/ns/ldp#Resource&gt;; rel="type"</span>
+<span class="hljs-attribute">ETag</span>: <span class="hljs-string">"_87e52ce126126"</span>
+<span class="hljs-attribute">Allow</span>: <span class="hljs-string">PUT,GET,OPTIONS,HEAD,DELETE,PATCH</span>
+<span class="hljs-attribute">Vary</span>: <span class="hljs-string">Accept</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">243</span>
+
+<span class="json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/annotations/anno1"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">created</span>": <span class="hljs-value"><span class="hljs-string">"2015-01-31T12:03:45Z"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I like this page!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://www.example.com/index.html"</span>
+</span>}</span></pre></div>
+    </div>
+
+  </section>
+
+  <section id="annotation-containers" typeof="bibo:Chapter" resource="#annotation-containers" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-annotation-containers" resource="#h-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Annotation Containers</span></h2>
+
+    <p>
+      If the Annotation Server supports the management of Annotations, including one or more of creating, updating and deleting them, then the following section's requirements apply. The Annotation Protocol is a use of the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] specification, with some additional constraints derived from the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>].
+    </p>
+
+    <p>An Annotation Server <em class="rfc2119" title="MUST">MUST</em> provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] (a service for managing Annotations) and a Collection [<cite><a class="bibref" href="#bib-activitystreams-core">activitystreams-core</a></cite>] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.</p>
+    <p>
+
+    </p>
+    <p>
+      Annotation Containers <em class="rfc2119" title="SHOULD">SHOULD</em> implement the LDP Basic Container specification, but implementers <em class="rfc2119" title="MAY">MAY</em> instead implement it as one of the other types of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers <em class="rfc2119" title="MAY">MAY</em> have any IRI, but <em class="rfc2119" title="MUST">MUST</em> end in a <code>"/"</code> character. The Annotations <em class="rfc2119" title="MUST">MUST</em> be assigned IRIs with an additional path component below the Container's IRI.
+    </p>
+
+    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use HTTPS rather than HTTP for all interactions with Annotation Containers.</p>
+
+    <p>
+      The creation, management and structure of Annotation Containers are beyond the scope of this specification. Please see the Linked Data Platform specification [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] for additional information in this regard.
+    </p>
+
+    <section id="container-retrieval" typeof="bibo:Chapter" resource="#container-retrieval" property="bibo:hasPart">
+      <h3 id="h-container-retrieval" resource="#h-container-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Container Retrieval</span></h3>
+
+      <p>
+        The Annotation Server <em class="rfc2119" title="MUST">MUST</em> support the following HTTP methods on the Annotation Container's IRI:
+
+      </p>
+      <ul>
+        <li><code>GET</code> (retrieve the description of the Container and the list of its contents, described below), </li>
+        <li><code>HEAD</code> (retrieve the headers of the Container without an entity-body),</li>
+        <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a class="bibref" href="#bib-cors">cors</a></cite>]).</li>
+      </ul>
+      <!-- LDP -->
+
+      <p>
+        When an HTTP GET request is issued against the Annotation Container, the server <em class="rfc2119" title="MUST">MUST</em> return a description of the container. That description <em class="rfc2119" title="MUST">MUST</em> be available in JSON-LD, <em class="rfc2119" title="SHOULD">SHOULD</em> be available in Turtle, and <em class="rfc2119" title="MAY">MAY</em> be available in other formats. The JSON-LD serialization of the Container's description <em class="rfc2119" title="SHOULD">SHOULD</em> use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>], unless the request would determine otherwise.
+      </p>
+
+      <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences. If redirection is required, then the server <em class="rfc2119" title="SHOULD">SHOULD</em> use a 3XX HTTP status code instead.</p>
+
+      <p>
+        Clients that have a preference for JSON-LD <em class="rfc2119" title="SHOULD">SHOULD</em> explicitly request it using an <code>Accept</code> header on the request. If the <code>Accept</code> header is absent from the request, then Annotation Servers <em class="rfc2119" title="MUST">MUST</em> respond with the JSON-LD representation of the Annotation Container.
+      </p>
+
+      <p>
+        All supported methods for interacting with the Annotation Container <em class="rfc2119" title="MUST">MUST</em> be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's IRI
+        <!-- LDP -->. The <code>Allow</code> header <em class="rfc2119" title="MAY">MAY</em> also be included on any other responses.</p>
+
+      <p>Annotation Containers <em class="rfc2119" title="MUST">MUST</em> return a <code>Link</code> header [<cite><a class="bibref" href="#bib-rfc5988">rfc5988</a></cite>] on all responses with the following components:
+      </p>
+      <ul>
+        <li>It <em class="rfc2119" title="MUST">MUST</em> advertise its type by including a link where the <code>rel</code> parameter value is <code>type</code> and the target IRI is the appropriate Container Type, such as <code>http://www.w3.org/ns/ldp#BasicContainer</code> for Basic Containers.</li>
+        <li>It <em class="rfc2119" title="MUST">MUST</em> advertise that it imposes Annotation protocol specific constraints by including a link where the target IRI is <code>http://www.w3.org/TR/annotation-protocol/</code>, and the <code>rel</code> parameter value is the IRI <code>http://www.w3.org/ns/ldp#constrainedBy</code>.</li>
+      </ul>
+      <p></p>
+
+      <p>
+        All HTTP responses from Annotation Containers <em class="rfc2119" title="MUST">MUST</em> include an <code>ETag</code> header, that implements the notion of entity tags from HTTP [<cite><a class="bibref" href="#bib-rfc7230">rfc7230</a></cite>].</p>
+
+      <p>
+        Responses from Annotation Containers <em class="rfc2119" title="MUST">MUST</em> include a <code>Vary</code> header
+        <!-- HTTP + LDP -->. The value <em class="rfc2119" title="MUST">MUST</em> include <code>Accept</code>, and <em class="rfc2119" title="MAY">MAY</em> include any other headers used to determine the representation provided in the response.</p>
+
+      <p>Responses from Annotation Containers that support the use of the POST method to create Annotations <em class="rfc2119" title="SHOULD">SHOULD</em> include an <code>Accept-Post</code> header on responses to GET, HEAD and OPTIONS requests. The value is a comma separated list of media-types that are acceptable for the client to send via POST [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>].</p>
+
+      <div>
+        <div class="example">
+          <div class="example-title marker"><span>Example 3</span><span style="text-transform: none">: Example Annotation Container Headers</span></div><pre class="highlight hljs groovy"><span class="hljs-string">Link:</span> &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//www.w3.org/ns/ldp#BasicContainer&gt;; rel="type",</span>
+      &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//www.w3.org/TR/annotation-protocol/&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"</span>
+<span class="hljs-string">ETag:</span> <span class="hljs-string">"0f6b5cd8dc1f754a1738a53b1da34f6b"</span>
+<span class="hljs-string">Vary:</span> Accept
+<span class="hljs-string">Allow:</span> POST, GET, OPTIONS, HEAD</pre></div>
+      </div>
+
+      <section id="client-preferences" typeof="bibo:Chapter" resource="#client-preferences" property="bibo:hasPart">
+        <h4 id="h-client-preferences" resource="#h-client-preferences"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1.1 </span>Client Preferences</span></h4> There are three possibilities for the request that will govern the server's response:
+
+        <ol>
+          <li>If the client prefers to only receive the Container description and no annotations, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
+          <li>If the client prefers to receive the list of annotations only as IRIs, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
+          <li>If the client prefers to receive the complete annotation description, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
+        </ol>
+
+        If no preference is given by the client, the server <em class="rfc2119" title="SHOULD">SHOULD</em> return the full annotation descriptions. The server <em class="rfc2119" title="MAY">MAY</em> ignore the client's preference.
+
+      </section>
+
+      <section id="responses-without-annotations" typeof="bibo:Chapter" resource="#responses-without-annotations" property="bibo:hasPart">
+        <h4 id="h-responses-without-annotations" resource="#h-responses-without-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1.2 </span>Responses without Annotations</span></h4>
+
+        <p>The Client may request the description of the Annotation Container without any included Annotations.</p>
+
+        Collection <em class="rfc2119" title="SHOULD">SHOULD</em> include links to the first and last CollectionPages.
+
+        <div>
+
+          Request:
+          <div class="example">
+            <div class="example-title marker"><span>Example 4</span><span style="text-transform: none">: Container Request without Annotations</span></div><pre class="highlight hljs http"><span class="hljs-request">GET <span class="hljs-string">/annotations/</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Prefer</span>: <span class="hljs-string">return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</span></pre></div>
+
+          Response:
+          <div class="example">
+            <div class="example-title marker"><span>Example 5</span><span style="text-transform: none">: Container Response without Annotations</span></div><pre class="highlight hljs avrasm">HTTP/<span class="hljs-number">1.1</span> <span class="hljs-number">200</span> OK
+Content-Type: application/<span class="hljs-keyword">ld</span>+json<span class="hljs-comment">; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-label">ETag:</span> <span class="hljs-string">"_87e52ce123123"</span>
+<span class="hljs-label">Link:</span> &lt;http://www.w3<span class="hljs-preprocessor">.org</span>/ns/ldp<span class="hljs-preprocessor">#BasicContainer&gt;; rel="type"</span>
+      &lt;http://www.w3<span class="hljs-preprocessor">.org</span>/TR/annotation-protocol/&gt;<span class="hljs-comment">; rel="http://www.w3.org/ns/ldp#constrainedBy"</span>
+<span class="hljs-label">Allow:</span> POST,GET,OPTIONS,HEAD
+<span class="hljs-label">Vary:</span> Accept
+Content-Length: <span class="hljs-number">221</span>
+
+{
+  <span class="hljs-string">"@context"</span>: [
+    <span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span>,
+    <span class="hljs-string">"http://www.w3.org/ns/ldp.jsonld"</span>
+  ],
+  <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/"</span>,
+  <span class="hljs-string">"type"</span>: [<span class="hljs-string">"BasicContainer"</span>, <span class="hljs-string">"AnnotationCollection"</span>],
+  <span class="hljs-string">"total"</span>: <span class="hljs-number">42023</span>,
+  <span class="hljs-string">"label"</span>: <span class="hljs-string">"A Container for Web Annotations"</span>,
+  <span class="hljs-string">"first"</span>: <span class="hljs-string">"http://example.org/annotations/?page=0"</span>,
+  <span class="hljs-string">"last"</span>: <span class="hljs-string">"http://example.org/annotations/?page=42"</span>
+}</pre></div>
+        </div>
+      </section>
+
+      <section id="responses-with-annotations" typeof="bibo:Chapter" resource="#responses-with-annotations" property="bibo:hasPart">
+
+        <h4 id="h-responses-with-annotations" resource="#h-responses-with-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1.3 </span>Responses with Annotations</span></h4>
+
+        <p>If the client requests a response that would include the Annotations, either by IRI or embedded in the response, then the server <em class="rfc2119" title="MUST">MUST</em> use the paged collection model. Each page, described below, will contain an ordered list with a subset of the managed annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container. The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages. The feature or features by which the annotations are sorted are not explicit in the response.
+        </p>
+
+        <p>
+          The Collection <em class="rfc2119" title="SHOULD">SHOULD</em> include the <code>total</code> property with the total number of annotations in the container. It <em class="rfc2119" title="MUST">MUST</em> also have a link to the first page of its contents using <code>first</code>, and <em class="rfc2119" title="SHOULD">SHOULD</em> have a link to the last page of its contents using <code>last</code>.
+        </p>
+
+        <p>The IRI of the Collection in the response should differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations. It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that this be done with a query parameter. The server <em class="rfc2119" title="MAY">MAY</em> redirect the client to this IRI and deliver the response there, otherwise it <em class="rfc2119" title="MUST">MUST</em> include a <code>Content-Location</code> header with the IRI as its value. The server <em class="rfc2119" title="SHOULD">SHOULD</em> include <code>Prefer</code> in the <code>Vary</code> response header to assist with caching.</p>
+
+        <div>
+
+          Request:
+          <div class="example">
+            <div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: Collection Request</span></div><pre class="highlight hljs http"><span class="hljs-request">GET <span class="hljs-string">/annotations/</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Prefer</span>: <span class="hljs-string">return=representation;include="http://www.w3.org/ns/ldp#PreferContainedIRIs"</span></pre></div>
+
+          Response:
+          <div class="example">
+            <div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: Collection Response</span></div><pre class="highlight hljs avrasm">HTTP/<span class="hljs-number">1.1</span> <span class="hljs-number">200</span> OK
+Content-Type: application/<span class="hljs-keyword">ld</span>+json<span class="hljs-comment">; profile="http://www.w3.org/ns/anno.jsonld"</span>
+Content-Location: http://example<span class="hljs-preprocessor">.org</span>/annotations/?uris=<span class="hljs-number">1</span>
+<span class="hljs-label">ETag:</span> <span class="hljs-string">"_87e52ce123123"</span>
+<span class="hljs-label">Link:</span> &lt;http://www.w3<span class="hljs-preprocessor">.org</span>/ns/ldp<span class="hljs-preprocessor">#BasicContainer&gt;; rel="type"</span>
+      &lt;http://www.w3<span class="hljs-preprocessor">.org</span>/TR/annotation-protocol/&gt;<span class="hljs-comment">; rel="http://www.w3.org/ns/ldp#constrainedBy"</span>
+<span class="hljs-label">Allow:</span> POST,GET,OPTIONS,HEAD
+<span class="hljs-label">Vary:</span> Accept, Prefer
+Content-Length: <span class="hljs-number">221</span>
+
+{
+  <span class="hljs-string">"@context"</span>: [
+    <span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span>,
+    <span class="hljs-string">"http://www.w3.org/ns/ldp.jsonld"</span>
+  ],
+  <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/?uris=1"</span>,
+  <span class="hljs-string">"type"</span>: [<span class="hljs-string">"BasicContainer"</span>, <span class="hljs-string">"AnnotationCollection"</span>],
+  <span class="hljs-string">"total"</span>: <span class="hljs-number">42023</span>,
+  <span class="hljs-string">"label"</span>: <span class="hljs-string">"A Container for Web Annotations"</span>,
+  <span class="hljs-string">"first"</span>: <span class="hljs-string">"http://example.org/annotations/?uris=1&amp;page=0"</span>,
+  <span class="hljs-string">"last"</span>: <span class="hljs-string">"http://example.org/annotations/?uris=1&amp;page=42"</span>
+}</pre></div>
+        </div>
+
+        <h4 id="page-response">Page Response</h4>
+        <p>
+          Individual pages are instances of <code>CollectionPage</code>. The page contains the Annotations, either via their IRIs or full descriptions, in the <code>items</code> property.</p>
+
+        <p>Each page <em class="rfc2119" title="MUST">MUST</em> have a link to the container that it is part of, using the <code>partOf</code> property. If it is not the first page, it <em class="rfc2119" title="MUST">MUST</em> have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it <em class="rfc2119" title="MUST">MUST</em> have a link to the next page in the sequence, using the <code>next</code> property. The response <em class="rfc2119" title="MAY">MAY</em> include properties of the Collection in the response, including the total number of items or first and last page links.
+        </p>
+
+        <p>
+          The client <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> send the <code>Prefer</code> header when requesting the page, as it has already been taken into account when requesting the Container.
+        </p>
+
+        <p>This specification does not require any particular functionality when a client makes requests other than GET, HEAD or OPTIONS to a page.</p>
+
+        <p>As the <code>CollectionPage</code> is not a Container, it does not have the requirement to include a <code>Link</code> header with a type. That the URLs can be constructed with query parameters added to the Container's IRI is an implementation convenience, and does not imply the type of the resource.</p>
+
+        <div>
+
+          Request:
+          <div class="example">
+            <div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: Page Request</span></div><pre class="highlight hljs http"><span class="hljs-request">GET <span class="hljs-string">/annotations/?uris=1&amp;page=0</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span></pre></div>
+
+          Response:
+          <div class="example">
+            <div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: Page Response</span></div><pre class="highlight hljs http"><span class="hljs-status">HTTP/1.1 <span class="hljs-number">200</span> OK</span>
+<span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Allow</span>: <span class="hljs-string">GET,OPTIONS,HEAD</span>
+<span class="hljs-attribute">Vary</span>: <span class="hljs-string">Accept, Prefer</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">221</span>
+
+<span class="json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/annotations/?uris=1&amp;page=0"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"AnnotationPage"</span></span>,
+  "<span class="hljs-attribute">partOf</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/annotations/?uris=1"</span></span>,
+    "<span class="hljs-attribute">total</span>": <span class="hljs-value"><span class="hljs-number">42023</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">next</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/annotations/?uris=1&amp;page=1"</span></span>,
+  "<span class="hljs-attribute">items</span>": <span class="hljs-value">[
+    <span class="hljs-string">"http://example.org/annotations/anno1"</span>,
+    <span class="hljs-string">"http://example.org/annotations/anno2"</span>,
+    <span class="hljs-string">"http://example.org/annotations/anno3"</span>,
+    <span class="hljs-string">"http://example.org/annotations/anno4"</span>,
+    <span class="hljs-string">"http://example.org/annotations/anno5"</span>,
+    <span class="hljs-string">"http://example.org/annotations/anno6"</span>,
+    ...
+    <span class="hljs-string">"http://example.org/annotations/anno999"</span>,
+  ]
+</span>}</span></pre></div>
+        </div>
+      </section>
+    </section>
+
+    <section id="discovery-of-annotation-containers" typeof="bibo:Chapter" resource="#discovery-of-annotation-containers" property="bibo:hasPart">
+      <h3 id="h-discovery-of-annotation-containers" resource="#h-discovery-of-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.2 </span>Discovery of Annotation Containers</span></h3>
+
+      <p>As the IRI for Annotation Containers <em class="rfc2119" title="MAY">MAY</em> be any IRI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
+
+      <p>Any resource <em class="rfc2119" title="MAY">MAY</em> link to an Annotation Container when Annotations on the resource <em class="rfc2119" title="SHOULD">SHOULD</em> be created within the referenced Container. This link is carried in an HTTP <code>Link</code> header and the value of the <code>rel</code> parameter <em class="rfc2119" title="MUST">MUST</em> be <code>http://www.w3.org/ns/oa#annotationService</code>.</p>
+
+      <p>For HTML representations of resources, the equivalent <code>link</code> tag in the header of the document <em class="rfc2119" title="MAY">MAY</em> also be used.</p>
+
+      <div>
+        <p>For an example image resource, a GET request and response with a link to the above Annotation Container might look like:</p>
+
+        Request:
+        <div class="example">
+          <div class="example-title marker"><span>Example 10</span></div><pre class="highlight hljs http"><span class="hljs-request">GET <span class="hljs-string">/images/logo.jpg</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.com</span></pre></div>
+        Response:
+        <div class="example">
+          <div class="example-title marker"><span>Example 11</span></div><pre class="highlight hljs http"><span class="hljs-status">HTTP/1.1 <span class="hljs-number">200</span> OK</span>
+<span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">image/jpeg</span>
+<span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;http://example.org/annotations/&gt;; rel="http://www.w3.org/ns/oa#annotationService"</span>
+<span class="hljs-attribute">Allow</span>: <span class="hljs-string">GET</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">76983</span>
+
+<span class="json">[...]</span></pre></div>
+      </div>
+
+    </section>
+  </section>
+  <!-- End of Containers -->
+
+  <section id="creation-updating-and-deletion-of-annotations" typeof="bibo:Chapter" resource="#creation-updating-and-deletion-of-annotations" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-creation-updating-and-deletion-of-annotations" resource="#h-creation-updating-and-deletion-of-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Creation, Updating and Deletion of Annotations</span></h2>
+
+    <section id="create-a-new-annotation" typeof="bibo:Chapter" resource="#create-a-new-annotation" property="bibo:hasPart">
+      <h3 id="h-create-a-new-annotation" resource="#h-create-a-new-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.1 </span>Create a New Annotation</span></h3>
+
+      <p>New Annotations are created via a POST request of a JSON-LD serialization of the Annotation to an Annotation Container. The Annotation's data is sent in the body of the request. All of the known information about the Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> be sent, and if there are already IRIs associated with the resources, they <em class="rfc2119" title="MAY">MAY</em> be included. The serialization <em class="rfc2119" title="SHOULD">SHOULD</em> use the Web Annotation JSON-LD profile, and servers <em class="rfc2119" title="MAY">MAY</em> reject other contexts even if they would otherwise produce the same model. The server <em class="rfc2119" title="MAY">MAY</em> reject content that is not an Annotation according to the Web Annotation specification.</p>
+
+      <p>Upon receipt of an Annotation, the server <em class="rfc2119" title="SHOULD">SHOULD</em> assign HTTPS IRIs to all resources and blank nodes in the Annotation, and <em class="rfc2119" title="MUST">MUST</em> assign a IRI to the Annotation resource, even if it aleady has one provided in the entity body description. The server <em class="rfc2119" title="MAY">MAY</em> also add additional information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, additional types and formats.</p>
+
+      <p>If the Annotation contains a <code>canonical</code> link, then it <em class="rfc2119" title="MUST">MUST</em> be maintained without change. If the Annotation has a IRI in the <code>id</code> property, then it <em class="rfc2119" title="SHOULD">SHOULD</em> be copied to the <code>via</code> property, and the IRI assigned by the server at which the Annotation is available <em class="rfc2119" title="MUST">MUST</em> be put in the <code>id</code> field to replace it.</p>
+
+      <p>The server <em class="rfc2119" title="MUST">MUST</em> respond with a <code>201</code> Created response if the creation is successful, and an appropriate error code otherwise. The response <em class="rfc2119" title="MUST">MUST</em> have a <code>Location</code> header with the Annotation's new IRI.</p>
+
+      <p>The body of the response <em class="rfc2119" title="MUST">MUST</em> be the Annotation as now managed by the server, including any additional IRIs or data created in the process or without any information that was sent but not stored. Barring content negotiation, the response <em class="rfc2119" title="SHOULD">SHOULD</em> be serialized in JSON-LD following the Annotation Data Model specification.</p>
+      <p>The response <em class="rfc2119" title="MUST">MUST</em> include a <code>Link</code> header with the target IRI of <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value of <code>type</code> to advertise that this is an RDF Source, according to the LDP specification. It <em class="rfc2119" title="MAY">MAY</em> also include the IRI <code>http://www.w3.org/ns/oa#Annotation</code> with the same <code>rel</code> parameter of <code>type</code> to also assert that it is an Annotation following the Web Annotation specifications.</p>
+
+      <p>The response <em class="rfc2119" title="MUST">MUST</em> include a <code>Vary</code> header with the value that includes <code>Accept</code>, as the representation is negotiable based on the client's Accept header. If the container preferences described above are supported, this <em class="rfc2119" title="MUST">MUST</em> also include <code>Prefer</code>
+        <!-- HTTP -->.
+
+
+      </p>
+      <div>
+        Request:
+        <div class="example">
+          <div class="example-title marker"><span>Example 12</span></div><pre class="highlight hljs http"><span class="hljs-request">POST <span class="hljs-string">/annotations/</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">153</span>
+
+<span class="json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I like this page!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://www.example.com/index.html"</span>
+</span>}</span></pre></div>
+        Response:
+        <div class="example">
+          <div class="example-title marker"><span>Example 13</span></div><pre class="highlight hljs avrasm">HTTP/<span class="hljs-number">1.1</span> <span class="hljs-number">201</span> CREATED
+<span class="hljs-label">Link:</span> &lt;http://www.w3<span class="hljs-preprocessor">.org</span>/ns/ldp<span class="hljs-preprocessor">#BasicContainer&gt;; rel="type"</span>
+      &lt;http://www.w3<span class="hljs-preprocessor">.org</span>/TR/annotation-protocol/&gt;<span class="hljs-comment">; rel="http://www.w3.org/ns/ldp#constrainedBy"</span>
+<span class="hljs-label">Allow:</span> PUT,GET,OPTIONS,HEAD,DELETE,PATCH
+<span class="hljs-label">Vary:</span> Accept
+<span class="hljs-label">Location:</span> http://example<span class="hljs-preprocessor">.org</span>/annotations/anno1
+Content-Type: application/<span class="hljs-keyword">ld</span>+json<span class="hljs-comment">; profile="http://www.w3.org/ns/anno.jsonld"</span>
+Content-Length: <span class="hljs-number">243</span>
+<span class="hljs-label">ETag:</span> <span class="hljs-string">"_87e52ce126126"</span>
+
+{
+  <span class="hljs-string">"@context"</span>: <span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span>,
+  <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/anno1"</span>,
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Annotation"</span>,
+  <span class="hljs-string">"created"</span>: <span class="hljs-string">"2015-01-31T12:03:45Z"</span>,
+  <span class="hljs-string">"body"</span>: {
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"TextualBody"</span>,
+    <span class="hljs-string">"value"</span>: <span class="hljs-string">"I like this page!"</span>
+  },
+  <span class="hljs-string">"target"</span>: <span class="hljs-string">"http://www.example.com/index.html"</span>
+}</pre></div>
+      </div>
+    </section>
+
+    <section id="suggesting-an-iri-for-an-annotation" typeof="bibo:Chapter" resource="#suggesting-an-iri-for-an-annotation" property="bibo:hasPart">
+      <h3 id="h-suggesting-an-iri-for-an-annotation" resource="#h-suggesting-an-iri-for-an-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.2 </span>Suggesting an IRI for an Annotation</span></h3>
+      <p>The IRI path segment that is appended to the Container IRI for a resource <em class="rfc2119" title="MAY">MAY</em> be suggested by the Annotation Client by using the <code>Slug</code> HTTP header on the request when the resource is created. The server <em class="rfc2119" title="SHOULD">SHOULD</em> use this name, so long as it does not already identify an existing resource, but <em class="rfc2119" title="MAY">MAY</em> ignore it and use an automatically assigned name. </p>
+
+      <div>
+        Request:
+        <div class="example">
+          <div class="example-title marker"><span>Example 14</span></div><pre class="highlight hljs http"><span class="hljs-request">POST <span class="hljs-string">/annotations/</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">153</span>
+<span class="hljs-attribute">Slug</span>: <span class="hljs-string">"my_first_annotation"</span>
+
+<span class="json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I like this page!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://www.example.com/index.html"</span>
+</span>}</span></pre></div>
+        Response:
+        <div class="example">
+          <div class="example-title marker"><span>Example 15</span></div><pre class="highlight hljs http"><span class="hljs-status">HTTP/1.1 <span class="hljs-number">201</span> CREATED</span>
+<span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"</span>
+<span class="hljs-attribute">Allow</span>: <span class="hljs-string">PUT,GET,OPTIONS,HEAD,DELETE,PATCH</span>
+<span class="hljs-attribute">Location</span>: <span class="hljs-string">http://example.org/annotations/my_first_annotation</span>
+<span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">ETag</span>: <span class="hljs-string">"_87e52ce126126"</span>
+<span class="hljs-attribute">Vary</span>: <span class="hljs-string">Accept</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">257</span>
+
+<span class="json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/annotations/my_first_annotation"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">created</span>": <span class="hljs-value"><span class="hljs-string">"2015-01-31T12:03:45Z"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I like this page!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://www.example.com/index.html"</span>
+</span>}</span></pre></div>
+      </div>
+
+    </section>
+
+
+    <section id="update-an-existing-annotation" typeof="bibo:Chapter" resource="#update-an-existing-annotation" property="bibo:hasPart">
+      <h3 id="h-update-an-existing-annotation" resource="#h-update-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.3 </span>Update an Existing Annotation</span></h3>
+
+      <p>Annotations can be updated by using a PUT request to replace the entire state of the Annotation. Annotation Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support this method. Servers <em class="rfc2119" title="MAY">MAY</em> also support using a PATCH request to update only the aspects of the Annotation that have changed, but that functionality is not specified in this document.
+      </p>
+
+      <p>Replacing the Annotation with a new state <em class="rfc2119" title="MUST">MUST</em> be done with the PUT method, where the body of the request is the intended new state of the Annotation. The client <em class="rfc2119" title="SHOULD">SHOULD</em> use the <code>If-Match</code> header with a value of the ETag it received from the server before the editing process began, to avoid collisions of multiple users modifying the same Annotation at the same time.</p>
+
+      <p>If successful, the server <em class="rfc2119" title="MUST">MUST</em> return a 200 OK status with the Annotation as the body according to the content-type requested.</p>
+
+      <p>Servers <em class="rfc2119" title="MUST">MUST</em> advertise the availability of updating via PUT on requests to the Annotation's IRI using the <code>Allow</code> response header.</p>
+
+      <div>
+        Request:
+        <div class="example">
+          <div class="example-title marker"><span>Example 16</span></div><pre class="highlight hljs http"><span class="hljs-request">PUT <span class="hljs-string">/annotations/anno1</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">163</span>
+<span class="hljs-attribute">If-Match</span>: <span class="hljs-string">"_87e52ce126126"</span>
+
+<span class="json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/annotations/anno1"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">created</span>": <span class="hljs-value"><span class="hljs-string">"2015-02-01T10:13:40Z"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I REALLY like this page!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://www.example.com/index.html"</span>
+</span>}</span></pre></div>
+
+        Response:
+        <div class="example">
+          <div class="example-title marker"><span>Example 17</span></div><pre class="highlight hljs http"><span class="hljs-status">HTTP/1.1 <span class="hljs-number">200</span> OK</span>
+<span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">ETag</span>: <span class="hljs-string">"_87e52ce234234"</span>
+<span class="hljs-attribute">Link</span>: <span class="hljs-string">&lt;http://www.w3.org/ns/ldp#Resource&gt;; rel="type"</span>
+<span class="hljs-attribute">Allow</span>: <span class="hljs-string">PUT,GET,OPTIONS,HEAD,DELETE,PATCH</span>
+<span class="hljs-attribute">Vary</span>: <span class="hljs-string">Accept</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">243</span>
+
+<span class="json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/annotations/anno1"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">created</span>": <span class="hljs-value"><span class="hljs-string">"2015-02-01T10:13:40Z"</span></span>,
+  "<span class="hljs-attribute">modified</span>": <span class="hljs-value"><span class="hljs-string">"2015-02-02T20:43:19Z"</span>
+  <span class="hljs-string">"body"</span>: {
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I REALLY like this page!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value"><span class="hljs-string">"http://www.example.com/index.html"</span>
+</span>}</span></pre></div>
+      </div>
+
+    </section>
+
+
+    <section id="delete-an-existing-annotation" typeof="bibo:Chapter" resource="#delete-an-existing-annotation" property="bibo:hasPart">
+      <h3 id="h-delete-an-existing-annotation" resource="#h-delete-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.4 </span>Delete an Existing Annotation</span></h3>
+
+      <p>Clients use the DELETE method to request that an Annotation be deleted. Annotation Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support this method. Clients <em class="rfc2119" title="SHOULD">SHOULD</em> send the ETag of the Annotation in the <code>If-Match</code> header to ensure that it is operating against the most recent version of the Annotation.</p>
+
+      <p>If the DELETE request is successfully processed, then the server <em class="rfc2119" title="MUST">MUST</em> return a 204 status response. The IRIs of deleted Annotations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be re-used for subsequent Annotations.
+        <!-- LDP -->The IRI of the deleted Annotation <em class="rfc2119" title="MUST">MUST</em> be removed from the Annotation Container it was created in.
+        <!-- LDP -->
+      </p>
+
+      <div>
+        Request:
+        <div class="example">
+          <div class="example-title marker"><span>Example 18</span></div><pre class="highlight hljs http"><span class="hljs-request">DELETE <span class="hljs-string">/annotations/anno1</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">If-Match</span>: <span class="hljs-string">"_87e52ce126126"</span></pre></div>
+        Response:
+        <div class="example">
+          <div class="example-title marker"><span>Example 19</span></div><pre class="highlight hljs http"><span class="hljs-status">HTTP/1.1 <span class="hljs-number">204</span> NO CONTENT</span>
+<span class="hljs-attribute">Content-Length</span>: <span class="hljs-string">0</span></pre></div>
+      </div>
+    </section>
+  </section>
+
+
+  <section id="error-conditions" typeof="bibo:Chapter" resource="#error-conditions" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-error-conditions" resource="#h-error-conditions"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Error Conditions</span></h2>
+
+    <p>There are inevitably situations where errors occur in the when retrieving or managing Annotations. The use of the HTTP Status codes below provides a method for clients to understand the reason why a request has failed. No requirements are made regarding the entity-body of the response from the Annotation Server, however all HTTP header requirements from section 4 <em class="rfc2119" title="MUST">MUST</em> be adhered to.</p>
+
+    <dl>
+      <dt>400</dt>
+      <dd>The Annotation Client sent a request which the Annotation Server cannot process due to the request not following the appropriate specifications</dd>
+      <dt>401</dt>
+      <dd>The Annotation Client is not authorized to perform the requested operation, such as creating or deleting an Annotation, as it did not supply authentication credentials</dd>
+      <dt>403</dt>
+      <dd>The Annotation Client is not authorized to perform the requested operation, as the authentication credentials supplied did not meet the requirements of a particular access control policy for the Annotation or Annotation Container</dd>
+      <dt>404</dt>
+      <dd>The Annotation or Annotation Container requested does not exist</dd>
+      <dt>405</dt>
+      <dd>The requested HTTP method is not allowed for the resource, such as trying to POST to an Annotation Container page, or trying to PATCH an Annotation when that functionality is not supported</dd>
+      <dt>406</dt>
+      <dd>The requested format for the Annotation or Annotation Container's representation is not available, for example if a client requested RDF/XML and the server does not support that (optional) transformation.</dd>
+      <dt>409</dt>
+      <dd>The Annotation Client tried to set or change a value that the server does not allow Clients to modify, such as the containment list of an Annotation Container or server set modification timestamps</dd>
+      <dt>410</dt>
+      <dd>The Annotation is known to have existed in the past and was deleted</dd>
+      <dt>412</dt>
+      <dd>The Annotation Client supplied an If-Match header that did not match the ETag of the Annotation being modified</dd>
+      <dt>415</dt>
+      <dd>The Annotation Client sent an entity-body that is not able to be processed by the Server, such as non-Annotation or in a context that is unrecognized</dd>
+    </dl>
+
+  </section>
+
+  <section id="containers-for-related-resources" typeof="bibo:Chapter" resource="#containers-for-related-resources" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-containers-for-related-resources" resource="#h-containers-for-related-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">8. </span>Containers for Related Resources</span></h2>
+
+    <p>Annotations may have related resources that are required for their correct interpretation and rendering, such as content resources used in or as the Body, CSS stylesheets that determine the rendering of the annotation, SVG documents describing a non-rectangular region of a resource, and so forth. If these resources do not already have IRIs, then they need to be made available somewhere so that they can be refered to.</p>
+
+    <p>Annotation Servers <em class="rfc2119" title="MAY">MAY</em> support the management of related resources independently from the Annotations. If a server supports the management of these resources, it <em class="rfc2119" title="SHOULD">SHOULD</em> do this with one or more separate Containers. Resources that are not Annotations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be included in an Annotation Container, as Annotation Clients would not expect to find arbitrary content when dereferencing the IRIs.
+      <!-- Additional but insanity reducing constraint -->Containers for related resources <em class="rfc2119" title="MAY">MAY</em> contain both RDF Sources and Non-RDF Sources. No restrictions are placed on the type or configuration of the Container beyond those of the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>].</p>
+    <p>Containers for related resources <em class="rfc2119" title="MUST">MUST</em> support the same HTTP methods as described above for the Annotation Container, and <em class="rfc2119" title="MUST">MUST</em> support identifying their type with a <code>Link</code> header. The <code>constrainedBy</code> link header on the response when dereferencing the Container <em class="rfc2119" title="SHOULD">SHOULD</em> refer to a server specific set of constraints listing the types of content that are acceptable.
+      <!-- LDP -->
+    </p>
+
+  </section>
+
+
+  <section class="appendix" id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Acknowledgements</span></h2>
+
+    <p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>. The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model and protocol.
+    </p>
+
+    <p>The following people have been instrumental in providing thoughts, feedback, reviews, content, criticism and input in the creation of this specification:
+
+    </p>
+    <div style="margin-left: 3em">
+      Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven Capadisli, Paolo Ciccarese, Tim Cole, Ray Denenberg, TB Dinesh, Sergiu Gordea, Benjamin Goering, Amy Guy, Ivan Herman, Frederick Hirsch, Antoine Isaac, Jacob Jett, Takeshi Kanai, Gregg Kellogg, Andreas Kuckartz, Randall Leeds, Hugo Manguinhas, Ben De Meester, Luc Moreau, Addison Phillips, Davis Salisbury, Robert Sanderson, Felix Sasaki, Doug Schepers, Tzviya Siegman, Stian Soiland-Reyes, Manu Sporney, Nick Stenning, Jon Stroop, Lutz Suhrbier, Kyrce Swenson, Raphael Troncy, Simeon Warner, Erik Wilde, Dan Whaley, Benjamin Young
+    </div>
+    <p></p>
+  </section>
+
+
+
+  <section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>References</span></h2>
+
+    <section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart">
+      <h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.1 </span>Normative references</span></h3>
+      <dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt>
+        <dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+        </dd><dt id="bib-activitystreams-core">[activitystreams-core]</dt>
+        <dd>James Snell; Evan Prodromou. W3C. <a href="http://www.w3.org/TR/activitystreams-core/" property="dc:requires"><cite>Activity Streams 2.0</cite></a>. 15 December 2015. W3C Working Draft. URL: <a href="http://www.w3.org/TR/activitystreams-core/" property="dc:requires">http://www.w3.org/TR/activitystreams-core/</a>
+        </dd><dt id="bib-annotation-model">[annotation-model]</dt>
+        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires"><cite>Web Annotation Data Model</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
+        </dd><dt id="bib-annotation-vocab">[annotation-vocab]</dt>
+        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/" property="dc:requires"><cite>Web Annotation Vocabulary</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/</a>
+        </dd><dt id="bib-cors">[cors]</dt>
+        <dd>Anne van Kesteren. W3C. <a href="http://www.w3.org/TR/cors/" property="dc:requires"><cite>Cross-Origin Resource Sharing</cite></a>. 16 January 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/cors/" property="dc:requires">http://www.w3.org/TR/cors/</a>
+        </dd><dt id="bib-ldp">[ldp]</dt>
+        <dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a href="http://www.w3.org/TR/ldp/" property="dc:requires"><cite>Linked Data Platform 1.0</cite></a>. 26 February 2015. W3C Recommendation. URL: <a href="http://www.w3.org/TR/ldp/" property="dc:requires">http://www.w3.org/TR/ldp/</a>
+        </dd><dt id="bib-ldp-paging">[ldp-paging]</dt>
+        <dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a href="http://www.w3.org/TR/ldp-paging/" property="dc:requires"><cite>Linked Data Platform Paging 1.0</cite></a>. 30 June 2015. W3C Note. URL: <a href="http://www.w3.org/TR/ldp-paging/" property="dc:requires">http://www.w3.org/TR/ldp-paging/</a>
+        </dd><dt id="bib-rfc5988">[rfc5988]</dt>
+        <dd>M. Nottingham. IETF. <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires">https://tools.ietf.org/html/rfc5988</a>
+        </dd><dt id="bib-rfc7230">[rfc7230]</dt>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7230" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7230" property="dc:requires">https://tools.ietf.org/html/rfc7230</a>
+        </dd><dt id="bib-rfc7231">[rfc7231]</dt>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7231" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231" property="dc:requires">https://tools.ietf.org/html/rfc7231</a>
+        </dd><dt id="bib-rfc7232">[rfc7232]</dt>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7232" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7232" property="dc:requires">https://tools.ietf.org/html/rfc7232</a>
+        </dd>
+      </dl>
+    </section>
+  </section>
+  <p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p>
+  <script async="" defer="" src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+</body>
+</html>

--- a/vocab/wd/examples/correct/anno10.ttl
+++ b/vocab/wd/examples/correct/anno10.ttl
@@ -12,6 +12,13 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno11> a oa:Annotation ;
-    oa:hasBody <http://example.org/description1> ;
-    oa:hasTarget <http://example.com/resource1> ;
-    oa:motivatedBy oa:describing .
+    oa:motivatedBy oa:tagging ;
+    oa:hasBody [ a oa:TextualBody ; rdf:value "important" ] ;
+    oa:hasTarget [
+        a oa:List ;
+        as:items (
+          <http://example.com/book/page1>
+          <http://example.net/book/page2>
+          <http://example.com/book/page3>
+          <http://example.org/book/page4>
+        ) ] .

--- a/vocab/wd/examples/correct/anno11.ttl
+++ b/vocab/wd/examples/correct/anno11.ttl
@@ -12,14 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno12> a oa:Annotation ;
-    oa:hasBody <http://example.org/note1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
-        oa:hasSelector [
-          a oa:RangeSelector ;
-          oa:hasStartSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[2]" ] ;
-          oa:hasEndSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .
+    oa:hasBody <http://example.org/description1> ;
+    oa:hasTarget <http://example.com/resource1> ;
+    oa:motivatedBy oa:describing .

--- a/vocab/wd/examples/correct/anno12.ttl
+++ b/vocab/wd/examples/correct/anno12.ttl
@@ -11,8 +11,15 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/cell1> a oa:ResourceSelection ;
-    oa:hasSource <http://example.org/image1> ;
-    oa:hasSelector [
-      a oa:XPathSelector ;
-      rdf:value "//table[1]/tr[1]/td[4]" ] .
+<http://example.org/anno13> a oa:Annotation ;
+    oa:hasBody <http://example.org/note1> ;
+    oa:hasTarget [
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasSelector [
+          a oa:RangeSelector ;
+          oa:hasStartSelector [
+            a oa:XPathSelector ;
+            rdf:value "//table[1]/tr[1]/td[2]" ] ;
+          oa:hasEndSelector [
+            a oa:XPathSelector ;
+            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .

--- a/vocab/wd/examples/correct/anno13.ttl
+++ b/vocab/wd/examples/correct/anno13.ttl
@@ -11,9 +11,8 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno13> a oa:Annotation ;
-    oa:hasBody <http://example.org/comment1> ;
-    oa:hasTarget <http://example.org/region1> .
-
-<http://example.org/region1> a oa:SpecificResource ;
-    oa:hasSource <http://example.org/image1> .
+<http://example.org/cell1> a oa:ResourceSelection ;
+    oa:hasSource <http://example.org/image1> ;
+    oa:hasSelector [
+      a oa:XPathSelector ;
+      rdf:value "//table[1]/tr[1]/td[4]" ] .

--- a/vocab/wd/examples/correct/anno14.ttl
+++ b/vocab/wd/examples/correct/anno14.ttl
@@ -12,9 +12,8 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno14> a oa:Annotation ;
-    oa:hasBody <http://example.org/road1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/map1> ;
-        oa:hasSelector [
-            a oa:SvgSelector ;
-            rdf:value "<svg:svg> ... </svg:svg>" ] ] .
+    oa:hasBody <http://example.org/comment1> ;
+    oa:hasTarget <http://example.org/region1> .
+
+<http://example.org/region1> a oa:SpecificResource ;
+    oa:hasSource <http://example.org/image1> .

--- a/vocab/wd/examples/correct/anno15.ttl
+++ b/vocab/wd/examples/correct/anno15.ttl
@@ -12,10 +12,9 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno15> a oa:Annotation ;
-    oa:hasBody <http://example.org/review1> ;
+    oa:hasBody <http://example.org/road1> ;
     oa:hasTarget [
-        oa:hasSource <http://example.org/ebook1> ;
+        oa:hasSource <http://example.org/map1> ;
         oa:hasSelector [
-            a oa:TextPositionSelector ;
-            oa:start 412 ;
-            oa:end 795 ] ] .
+            a oa:SvgSelector ;
+            rdf:value "<svg:svg> ... </svg:svg>" ] ] .

--- a/vocab/wd/examples/correct/anno16.ttl
+++ b/vocab/wd/examples/correct/anno16.ttl
@@ -12,11 +12,10 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno16> a oa:Annotation ;
-    oa:hasBody <http://example.org/comment1> ;
+    oa:hasBody <http://example.org/review1> ;
     oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
+        oa:hasSource <http://example.org/ebook1> ;
         oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .
+            a oa:TextPositionSelector ;
+            oa:start 412 ;
+            oa:end 795 ] ] .

--- a/vocab/wd/examples/correct/anno17.ttl
+++ b/vocab/wd/examples/correct/anno17.ttl
@@ -12,9 +12,11 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno17> a oa:Annotation ;
-    oa:hasTarget <http://example.org/photo1> ;
-    oa:hasBody [
-        a oa:TextualBody;
-        rdf:value "<p>Comment text</p>" ;
-        dc:language "en" ;
-        dc:format "text/html" ] .
+    oa:hasBody <http://example.org/comment1> ;
+    oa:hasTarget [
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "anotation" ;
+            oa:prefix "this is an " ;
+            oa:suffix " that has some" ] ] .

--- a/vocab/wd/examples/correct/anno18.ttl
+++ b/vocab/wd/examples/correct/anno18.ttl
@@ -12,10 +12,9 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno18> a oa:Annotation ;
-    oa:hasBody <http://example.org/note1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:cachedSource <http://example.org/copy1> ;
-            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .
+    oa:hasTarget <http://example.org/photo1> ;
+    oa:hasBody [
+        a oa:TextualBody;
+        rdf:value "<p>Comment text</p>" ;
+        dc:language "en" ;
+        dc:format "text/html" ] .

--- a/vocab/wd/examples/correct/anno19.ttl
+++ b/vocab/wd/examples/correct/anno19.ttl
@@ -15,6 +15,7 @@
     oa:hasBody <http://example.org/note1> ;
     oa:hasTarget [
         oa:hasSource <http://example.org/page1> ;
-        oa:hasSelector [
-          a oa:XPathSelector ;
-          rdf:value "/html/body/p[2]/table/tr[2]/td[3]/span" ] ] .
+        oa:hasState [
+            a oa:TimeState ;
+            oa:cachedSource <http://example.org/copy1> ;
+            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .

--- a/vocab/wd/examples/correct/anno20.ttl
+++ b/vocab/wd/examples/correct/anno20.ttl
@@ -11,5 +11,10 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/diagram.jpg> a dctypes:Image ;
-    oa:annotationService <http://example.org/services/annotations/> .
+<http://example.org/anno20> a oa:Annotation ;
+    oa:hasBody <http://example.org/note1> ;
+    oa:hasTarget [
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasSelector [
+          a oa:XPathSelector ;
+          rdf:value "/html/body/p[2]/table/tr[2]/td[3]/span" ] ] .

--- a/vocab/wd/examples/correct/anno21.ttl
+++ b/vocab/wd/examples/correct/anno21.ttl
@@ -11,6 +11,5 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno20> a oa:Annotation ;
-    oa:bodyValue "Comment text" ;
-    oa:hasTarget <http://example.org/target1> .
+<http://example.org/diagram.jpg> a dctypes:Image ;
+    oa:annotationService <http://example.org/services/annotations/> .

--- a/vocab/wd/examples/correct/anno22.ttl
+++ b/vocab/wd/examples/correct/anno22.ttl
@@ -12,10 +12,5 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno21> a oa:Annotation ;
-    oa:hasBody <http://example.org/note1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:cachedSource <http://example.org/copy1> ;
-            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .
+    oa:bodyValue "Comment text" ;
+    oa:hasTarget <http://example.org/target1> .

--- a/vocab/wd/examples/correct/anno23.ttl
+++ b/vocab/wd/examples/correct/anno23.ttl
@@ -13,5 +13,9 @@
 
 <http://example.org/anno22> a oa:Annotation ;
     oa:hasBody <http://example.org/note1> ;
-    oa:hasTarget <http://example.org/page1> ;
-    oa:canonical <urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df> .
+    oa:hasTarget [
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasState [
+            a oa:TimeState ;
+            oa:cachedSource <http://example.org/copy1> ;
+            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .

--- a/vocab/wd/examples/correct/anno24.ttl
+++ b/vocab/wd/examples/correct/anno24.ttl
@@ -13,9 +13,5 @@
 
 <http://example.org/anno23> a oa:Annotation ;
     oa:hasBody <http://example.org/note1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/diskimg1> ;
-        oa:hasSelector [
-            a oa:DataPositionSelector ;
-            oa:start 4096 ;
-            oa:end 4104 ] ] .
+    oa:hasTarget <http://example.org/page1> ;
+    oa:canonical <urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df> .

--- a/vocab/wd/examples/correct/anno25.ttl
+++ b/vocab/wd/examples/correct/anno25.ttl
@@ -12,11 +12,10 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno24> a oa:Annotation ;
-    oa:hasBody <http://example.org/comment1> ;
+    oa:hasBody <http://example.org/note1> ;
     oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
+        oa:hasSource <http://example.org/diskimg1> ;
         oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .
+            a oa:DataPositionSelector ;
+            oa:start 4096 ;
+            oa:end 4104 ] ] .

--- a/vocab/wd/examples/correct/anno26.ttl
+++ b/vocab/wd/examples/correct/anno26.ttl
@@ -12,5 +12,11 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno25> a oa:Annotation ;
-    oa:hasBody <http://example.org/post1> ;
-    oa:hasTarget <http://example.com/page1> .
+    oa:hasBody <http://example.org/comment1> ;
+    oa:hasTarget [
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "anotation" ;
+            oa:prefix "this is an " ;
+            oa:suffix " that has some" ] ] .

--- a/vocab/wd/examples/correct/anno27.ttl
+++ b/vocab/wd/examples/correct/anno27.ttl
@@ -12,14 +12,5 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno26> a oa:Annotation ;
-    oa:hasBody <http://example.org/note1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
-        oa:hasSelector [
-          a oa:RangeSelector ;
-          oa:hasStartSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[2]" ] ;
-          oa:hasEndSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .
+    oa:hasBody <http://example.org/post1> ;
+    oa:hasTarget <http://example.com/page1> .

--- a/vocab/wd/examples/correct/anno28.ttl
+++ b/vocab/wd/examples/correct/anno28.ttl
@@ -12,9 +12,14 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno27> a oa:Annotation ;
-    oa:motivatedBy oa:bookmarking ;
-    oa:hasBody [
-        a oa:TextualBody ;
-        rdf:value "readme" ;
-        oa:hasPurpose oa:tagging ] ;
-    oa:hasTarget <http://example.org/page1> .
+    oa:hasBody <http://example.org/note1> ;
+    oa:hasTarget [
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasSelector [
+          a oa:RangeSelector ;
+          oa:hasStartSelector [
+            a oa:XPathSelector ;
+            rdf:value "//table[1]/tr[1]/td[2]" ] ;
+          oa:hasEndSelector [
+            a oa:XPathSelector ;
+            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .

--- a/vocab/wd/examples/correct/anno29.ttl
+++ b/vocab/wd/examples/correct/anno29.ttl
@@ -13,7 +13,8 @@
 
 <http://example.org/anno28> a oa:Annotation ;
     oa:motivatedBy oa:bookmarking ;
-    oa:hasBody <http://example.org/comment1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/logo1.jpg> ;
-        oa:hasScope <http://example.org/index.html> ] .
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "readme" ;
+        oa:hasPurpose oa:tagging ] ;
+    oa:hasTarget <http://example.org/page1> .

--- a/vocab/wd/examples/correct/anno30.ttl
+++ b/vocab/wd/examples/correct/anno30.ttl
@@ -12,9 +12,8 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno29> a oa:Annotation ;
-    oa:hasBody [
-      oa:hasSource <http://example.org/page1> ;
-      oa:hasSelector <http://example.org/paraselector1> ] ;
+    oa:motivatedBy oa:bookmarking ;
+    oa:hasBody <http://example.org/comment1> ;
     oa:hasTarget [
-      oa:hasSource <http://example.com/dataset1> ;
-      oa:hasSelector <http://example.org/dataselector1> ] .
+        oa:hasSource <http://example.org/logo1.jpg> ;
+        oa:hasScope <http://example.org/index.html> ] .

--- a/vocab/wd/examples/correct/anno31.ttl
+++ b/vocab/wd/examples/correct/anno31.ttl
@@ -12,8 +12,9 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno30> a oa:Annotation ;
-    oa:hasBody <http://example.org/comment1> ;
-    oa:hasTarget <http://example.org/region1> .
-
-<http://example.org/region1> a oa:SpecificResource ;
-    oa:hasSource <http://example.org/image1> .
+    oa:hasBody [
+      oa:hasSource <http://example.org/page1> ;
+      oa:hasSelector <http://example.org/paraselector1> ] ;
+    oa:hasTarget [
+      oa:hasSource <http://example.com/dataset1> ;
+      oa:hasSelector <http://example.org/dataselector1> ] .

--- a/vocab/wd/examples/correct/anno32.ttl
+++ b/vocab/wd/examples/correct/anno32.ttl
@@ -12,14 +12,8 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno31> a oa:Annotation ;
-    oa:hasBody <http://example.org/note1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
-        oa:hasSelector [
-          a oa:RangeSelector ;
-          oa:hasStartSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[2]" ] ;
-          oa:hasEndSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .
+    oa:hasBody <http://example.org/comment1> ;
+    oa:hasTarget <http://example.org/region1> .
+
+<http://example.org/region1> a oa:SpecificResource ;
+    oa:hasSource <http://example.org/image1> .

--- a/vocab/wd/examples/correct/anno33.ttl
+++ b/vocab/wd/examples/correct/anno33.ttl
@@ -14,5 +14,12 @@
 <http://example.org/anno32> a oa:Annotation ;
     oa:hasBody <http://example.org/note1> ;
     oa:hasTarget [
-        oa:hasState <http://example.org/state1> ;
-        oa:hasSource <http://example.org/page1> ] .
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasSelector [
+          a oa:RangeSelector ;
+          oa:hasStartSelector [
+            a oa:XPathSelector ;
+            rdf:value "//table[1]/tr[1]/td[2]" ] ;
+          oa:hasEndSelector [
+            a oa:XPathSelector ;
+            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .

--- a/vocab/wd/examples/correct/anno34.ttl
+++ b/vocab/wd/examples/correct/anno34.ttl
@@ -12,5 +12,7 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno33> a oa:Annotation ;
-    oa:hasBody <http://example.org/post1> ;
-    oa:hasTarget <http://example.com/page1> .
+    oa:hasBody <http://example.org/note1> ;
+    oa:hasTarget [
+        oa:hasState <http://example.org/state1> ;
+        oa:hasSource <http://example.org/page1> ] .

--- a/vocab/wd/examples/correct/anno35.ttl
+++ b/vocab/wd/examples/correct/anno35.ttl
@@ -12,6 +12,5 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno34> a oa:Annotation ;
-    oa:hasBody <http://example.org/description1> ;
-    oa:hasTarget <http://example.com/resource1> ;
-    oa:motivatedBy oa:describing .
+    oa:hasBody <http://example.org/post1> ;
+    oa:hasTarget <http://example.com/page1> .

--- a/vocab/wd/examples/correct/anno36.ttl
+++ b/vocab/wd/examples/correct/anno36.ttl
@@ -12,11 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno35> a oa:Annotation ;
-    oa:hasBody <http://example.org/comment1> ;
-    oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
-        oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .
+    oa:hasBody <http://example.org/description1> ;
+    oa:hasTarget <http://example.com/resource1> ;
+    oa:motivatedBy oa:describing .

--- a/vocab/wd/examples/correct/anno37.ttl
+++ b/vocab/wd/examples/correct/anno37.ttl
@@ -14,13 +14,9 @@
 <http://example.org/anno36> a oa:Annotation ;
     oa:hasBody <http://example.org/comment1> ;
     oa:hasTarget [
-        a oa:SpecificResource ;
         oa:hasSource <http://example.org/page1> ;
         oa:hasSelector [
-          a oa:FragmentSelector ;
-          rdf:value "para5" ;
-          oa:refinedBy [
             a oa:TextQuoteSelector ;
-            oa:exact "Selected Text" ;
-            oa:prefix "text before the " ;
-            oa:suffix "and text after it" ] ] ] .
+            oa:exact "anotation" ;
+            oa:prefix "this is an " ;
+            oa:suffix " that has some" ] ] .

--- a/vocab/wd/examples/correct/anno38.ttl
+++ b/vocab/wd/examples/correct/anno38.ttl
@@ -14,8 +14,13 @@
 <http://example.org/anno37> a oa:Annotation ;
     oa:hasBody <http://example.org/comment1> ;
     oa:hasTarget [
-      a oa:SpecificResource ;
-      oa:hasSource <http://example.org/page1> ;
-      oa:renderedVia [
-        a as:Application ;
-        schema:softwareVersion "2.5" ] ] .
+        a oa:SpecificResource ;
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasSelector [
+          a oa:FragmentSelector ;
+          rdf:value "para5" ;
+          oa:refinedBy [
+            a oa:TextQuoteSelector ;
+            oa:exact "Selected Text" ;
+            oa:prefix "text before the " ;
+            oa:suffix "and text after it" ] ] ] .

--- a/vocab/wd/examples/correct/anno39.ttl
+++ b/vocab/wd/examples/correct/anno39.ttl
@@ -12,9 +12,10 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno38> a oa:Annotation ;
-    oa:hasBody <http://example.org/note1> ;
+    oa:hasBody <http://example.org/comment1> ;
     oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .
+      a oa:SpecificResource ;
+      oa:hasSource <http://example.org/page1> ;
+      oa:renderedVia [
+        a as:Application ;
+        schema:softwareVersion "2.5" ] ] .

--- a/vocab/wd/examples/correct/anno40.ttl
+++ b/vocab/wd/examples/correct/anno40.ttl
@@ -17,5 +17,4 @@
         oa:hasSource <http://example.org/page1> ;
         oa:hasState [
             a oa:TimeState ;
-            oa:sourceDateStart "2015-07-20T13:30:00Z" ;
-            oa:sourceDateEnd   "2015-07-21T19:45:00Z" ] ] .
+            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .

--- a/vocab/wd/examples/correct/anno42.ttl
+++ b/vocab/wd/examples/correct/anno42.ttl
@@ -12,10 +12,10 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno41> a oa:Annotation ;
-    oa:hasBody <http://example.org/review1> ;
+    oa:hasBody <http://example.org/note1> ;
     oa:hasTarget [
-        oa:hasSource <http://example.org/ebook1> ;
-        oa:hasSelector [
-            a oa:TextPositionSelector ;
-            oa:start 412 ;
-            oa:end 795 ] ] .
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasState [
+            a oa:TimeState ;
+            oa:sourceDateStart "2015-07-20T13:30:00Z" ;
+            oa:sourceDateEnd   "2015-07-21T19:45:00Z" ] ] .

--- a/vocab/wd/examples/correct/anno43.ttl
+++ b/vocab/wd/examples/correct/anno43.ttl
@@ -12,10 +12,10 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno42> a oa:Annotation ;
-    oa:hasBody <http://example.org/comment1> ;
-    oa:styledBy <http://example.org/style1> ;
+    oa:hasBody <http://example.org/review1> ;
     oa:hasTarget [
-        oa:hasSource <http://example.org/document1> ;
-        oa:styleClass "red" ] .
-
-<http://example.org/style1> a oa:CssStyle .
+        oa:hasSource <http://example.org/ebook1> ;
+        oa:hasSelector [
+            a oa:TextPositionSelector ;
+            oa:start 412 ;
+            oa:end 795 ] ] .

--- a/vocab/wd/examples/correct/anno44.ttl
+++ b/vocab/wd/examples/correct/anno44.ttl
@@ -12,10 +12,10 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno43> a oa:Annotation ;
-    oa:hasBody <http://example.org/body1> ;
-    oa:styledBy [
-        a oa:CssStyle ;
-        rdf:value ".red { color: red }" ] ;
+    oa:hasBody <http://example.org/comment1> ;
+    oa:styledBy <http://example.org/style1> ;
     oa:hasTarget [
-        oa:hasSource <http://example.org/target1> ;
+        oa:hasSource <http://example.org/document1> ;
         oa:styleClass "red" ] .
+
+<http://example.org/style1> a oa:CssStyle .

--- a/vocab/wd/examples/correct/anno45.ttl
+++ b/vocab/wd/examples/correct/anno45.ttl
@@ -12,11 +12,10 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno44> a oa:Annotation ;
-    oa:hasBody <http://example.org/comment1> ;
+    oa:hasBody <http://example.org/body1> ;
+    oa:styledBy [
+        a oa:CssStyle ;
+        rdf:value ".red { color: red }" ] ;
     oa:hasTarget [
-        oa:hasSource <http://example.org/page1> ;
-        oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .
+        oa:hasSource <http://example.org/target1> ;
+        oa:styleClass "red" ] .

--- a/vocab/wd/examples/correct/anno46.ttl
+++ b/vocab/wd/examples/correct/anno46.ttl
@@ -12,6 +12,11 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno45> a oa:Annotation ;
-    oa:hasBody <http://example.org/note1> ;
-    oa:hasTarget <http://example.org/page1> ;
-    oa:via <http://other.example.com/anno1b> .
+    oa:hasBody <http://example.org/comment1> ;
+    oa:hasTarget [
+        oa:hasSource <http://example.org/page1> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "anotation" ;
+            oa:prefix "this is an " ;
+            oa:suffix " that has some" ] ] .

--- a/vocab/wd/examples/correct/anno47.ttl
+++ b/vocab/wd/examples/correct/anno47.ttl
@@ -12,5 +12,9 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno46> a oa:Annotation ;
-    oa:hasTarget <http://example.com/page1> ;
-    oa:motivatedBy oa:bookmarking .
+    oa:hasBody [
+        rdfs:value "This is a comment" ;
+        dc:language "en" ;
+        dc:format "text/plain" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget <http://example.org/page1> .

--- a/vocab/wd/examples/correct/anno48.ttl
+++ b/vocab/wd/examples/correct/anno48.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno47> a oa:Annotation ;
-    oa:hasBody <http://example.org/type1> ;
-    oa:hasTarget <http://example.com/resource1> ;
-    oa:motivatedBy oa:classifying .
+    oa:hasBody <http://example.org/note1> ;
+    oa:hasTarget <http://example.org/page1> ;
+    oa:via <http://other.example.com/anno1b> .

--- a/vocab/wd/examples/correct/anno50.ttl
+++ b/vocab/wd/examples/correct/anno50.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno49> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A description of the image" ] ;
-    oa:hasTarget <http://example.com/image1> ;
-    oa:motivatedBy oa:describing .
+    oa:hasBody <http://example.org/type1> ;
+    oa:hasTarget <http://example.com/resource1> ;
+    oa:motivatedBy oa:classifying .

--- a/vocab/wd/examples/correct/anno51.ttl
+++ b/vocab/wd/examples/correct/anno51.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno50> a oa:Annotation ;
-    oa:hasBody [ rdf:value "Editorial suggestion" ] ;
-    oa:hasTarget <http://example.com/text1> ;
-    oa:motivatedBy oa:editing .
+    oa:hasBody [ rdf:value "A comment about the page" ] ;
+    oa:hasTarget <http://example.com/page1> ;
+    oa:motivatedBy oa:commenting .

--- a/vocab/wd/examples/correct/anno52.ttl
+++ b/vocab/wd/examples/correct/anno52.ttl
@@ -12,5 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno51> a oa:Annotation ;
-    oa:hasTarget <http://example.com/region1> ;
-    oa:motivatedBy oa:highlighting .
+    oa:hasBody [ rdf:value "A description of the image" ] ;
+    oa:hasTarget <http://example.com/image1> ;
+    oa:motivatedBy oa:describing .

--- a/vocab/wd/examples/correct/anno53.ttl
+++ b/vocab/wd/examples/correct/anno53.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno52> a oa:Annotation ;
-    oa:hasBody <http://example.com/identities/object1> ;
-    oa:hasTarget <http://example.com/image-of-object1> ;
-    oa:motivatedBy oa:identifying .
+    oa:hasBody [ rdf:value "Editorial suggestion" ] ;
+    oa:hasTarget <http://example.com/text1> ;
+    oa:motivatedBy oa:editing .

--- a/vocab/wd/examples/correct/anno54.ttl
+++ b/vocab/wd/examples/correct/anno54.ttl
@@ -12,6 +12,5 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno53> a oa:Annotation ;
-    oa:hasBody <http://example.org/from1> ;
-    oa:hasTarget <http://example.com/to1> ;
-    oa:motivatedBy oa:linking .
+    oa:hasTarget <http://example.com/region1> ;
+    oa:motivatedBy oa:highlighting .

--- a/vocab/wd/examples/correct/anno55.ttl
+++ b/vocab/wd/examples/correct/anno55.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno54> a oa:Annotation ;
-    oa:hasBody <http://example.org/tags/approved1> ;
-    oa:hasTarget <http://example.com/anno1> ;
-    oa:motivatedBy oa:moderating .
+    oa:hasBody <http://example.com/identities/object1> ;
+    oa:hasTarget <http://example.com/image-of-object1> ;
+    oa:motivatedBy oa:identifying .

--- a/vocab/wd/examples/correct/anno56.ttl
+++ b/vocab/wd/examples/correct/anno56.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno55> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A question about the resource" ] ;
-    oa:hasTarget <http://example.com/resource1> ;
-    oa:motivatedBy oa:questioning .
+    oa:hasBody <http://example.org/from1> ;
+    oa:hasTarget <http://example.com/to1> ;
+    oa:motivatedBy oa:linking .

--- a/vocab/wd/examples/correct/anno57.ttl
+++ b/vocab/wd/examples/correct/anno57.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno56> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A reply to a question" ] ;
+    oa:hasBody <http://example.org/tags/approved1> ;
     oa:hasTarget <http://example.com/anno1> ;
-    oa:motivatedBy oa:replying .
+    oa:motivatedBy oa:moderating .

--- a/vocab/wd/examples/correct/anno58.ttl
+++ b/vocab/wd/examples/correct/anno58.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno57> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A review of the resource" ] ;
+    oa:hasBody [ rdf:value "A question about the resource" ] ;
     oa:hasTarget <http://example.com/resource1> ;
-    oa:motivatedBy oa:reviewing .
+    oa:motivatedBy oa:questioning .

--- a/vocab/wd/examples/correct/anno59.ttl
+++ b/vocab/wd/examples/correct/anno59.ttl
@@ -12,6 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno58> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget <http://example.com/thing1> ;
-    oa:motivatedBy oa:tagging .
+    oa:hasBody [ rdf:value "A reply to a question" ] ;
+    oa:hasTarget <http://example.com/anno1> ;
+    oa:motivatedBy oa:replying .

--- a/vocab/wd/examples/correct/anno6.ttl
+++ b/vocab/wd/examples/correct/anno6.ttl
@@ -12,11 +12,9 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno7> a oa:Annotation ;
-    oa:hasTarget <http://example.org/image1> ;
     oa:hasBody [
-        oa:hasSource <http://example.org/video1> ;
-        oa:hasPurpose oa:describing ;
-        oa:hasSelector [
-            a oa:FragmentSelector ;
-            dcterms:conformsTo <http://www.w3.org/TR/media-frags/> ;
-            rdf:value "t=30,60" ] ] .
+        rdfs:value "This is a comment" ;
+        dc:language "en" ;
+        dc:format "text/plain" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget <http://example.org/page1> .

--- a/vocab/wd/examples/correct/anno60.ttl
+++ b/vocab/wd/examples/correct/anno60.ttl
@@ -12,10 +12,6 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno59> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    as:generator <http://example.org/client1> .
-
-<http://example.org/client1> a as:Application ;
-    foaf:homepage <HomePage1> ;
-    foaf:name "Code v2.1" .
+    oa:hasBody [ rdf:value "A review of the resource" ] ;
+    oa:hasTarget <http://example.com/resource1> ;
+    oa:motivatedBy oa:reviewing .

--- a/vocab/wd/examples/correct/anno61.ttl
+++ b/vocab/wd/examples/correct/anno61.ttl
@@ -11,8 +11,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1 a as:OrderedCollection ;
-  rdfs:label "Example Collection" ;
-  as:totalItems 42023 ;
-  as:first <http://example.org/collection1/page1> ;
-  as:last <http://example.org/collection1/page42> .
+<http://example.org/anno60> a oa:Annotation ;
+    oa:hasBody [ rdf:value "tag" ] ;
+    oa:hasTarget <http://example.com/thing1> ;
+    oa:motivatedBy oa:tagging .

--- a/vocab/wd/examples/correct/anno62.ttl
+++ b/vocab/wd/examples/correct/anno62.ttl
@@ -11,11 +11,8 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1/page1 a as:OrderedCollectionPage ;
-  as:partOf <http://example.org/collection1> ;
-  as:next <http://example.org/collection1/page2> ;
-  as:startIndex 0 ;
-  as:items (
-    <http://example.org/anno1>
-    <http://example.org/anno2>
-    <http://example.org/anno3> ) .
+<http://example.org/anno61> a oa:Annotation ;
+    oa:hasBody [ 
+        rdf:value "Some text" ;
+        oa:textDirection oa:auto ] ;
+    oa:hasTarget <http://example.com/thing1>  .

--- a/vocab/wd/examples/correct/anno63.ttl
+++ b/vocab/wd/examples/correct/anno63.ttl
@@ -11,10 +11,8 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno60> a oa:Annotation ;
-    oa:motivatedBy oa:commenting ;
-    oa:hasBody <http://example.com/note1> ;
-    oa:hasTarget <http://example.com/dataset1> .
-
-<http://example.com/dataset1> a dctypes:Dataset ;
-  dc:format "text/csv" .
+<http://example.org/anno62> a oa:Annotation ;
+    oa:hasBody [ 
+        rdf:value "Left to Right text" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget <http://example.com/thing1>  .

--- a/vocab/wd/examples/correct/anno64.ttl
+++ b/vocab/wd/examples/correct/anno64.ttl
@@ -11,9 +11,9 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno61> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget <http://example.com/video1> ;
-    oa:motivatedBy oa:tagging .
+<http://example.org/anno63> a oa:Annotation ;
+    oa:hasBody <http://example.org/ar/comment1> ;
+    oa:hasTarget <http://example.com/thing1>  .
 
-<http://example.org/video1> a dctypes:MovingImage .
+<http://example.org/ar/comment1> a dctypes:Text ; 
+    oa:textDirection oa:rtl .

--- a/vocab/wd/examples/correct/anno65.ttl
+++ b/vocab/wd/examples/correct/anno65.ttl
@@ -11,9 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno62> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget <http://example.com/image1> ;
-    oa:motivatedBy oa:tagging .
+<http://example.org/anno64> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    as:generator <http://example.org/client1> .
 
-<http://example.org/image1> a dctypes:StillImage .
+<http://example.org/client1> a as:Application ;
+    foaf:homepage <HomePage1> ;
+    foaf:name "Code v2.1" .

--- a/vocab/wd/examples/correct/anno66.ttl
+++ b/vocab/wd/examples/correct/anno66.ttl
@@ -11,9 +11,8 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno63> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget <http://example.com/audio1> ;
-    oa:motivatedBy oa:tagging .
-
-<http://example.org/audio1> a dctypes:Sound .
+<http://example.org/collection1 a as:OrderedCollection ;
+  rdfs:label "Example Collection" ;
+  as:totalItems 42023 ;
+  as:first <http://example.org/collection1/page1> ;
+  as:last <http://example.org/collection1/page42> .

--- a/vocab/wd/examples/correct/anno67.ttl
+++ b/vocab/wd/examples/correct/anno67.ttl
@@ -11,9 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno64> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget <http://example.com/document1> ;
-    oa:motivatedBy oa:tagging .
-
-<http://example.org/document1> a dctypes:Text .
+<http://example.org/collection1/page1 a as:OrderedCollectionPage ;
+  as:partOf <http://example.org/collection1> ;
+  as:next <http://example.org/collection1/page2> ;
+  as:startIndex 0 ;
+  as:items (
+    <http://example.org/anno1>
+    <http://example.org/anno2>
+    <http://example.org/anno3> ) .

--- a/vocab/wd/examples/correct/anno68.ttl
+++ b/vocab/wd/examples/correct/anno68.ttl
@@ -13,9 +13,8 @@
 
 <http://example.org/anno65> a oa:Annotation ;
     oa:motivatedBy oa:commenting ;
-    oa:hasBody <http://example.net/comment1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    dcterms:creator <http://example.org/org> .
+    oa:hasBody <http://example.com/note1> ;
+    oa:hasTarget <http://example.com/dataset1> .
 
-<http://example.org/org> a foaf:Organization ;
-    foaf:name "Example Organization" .
+<http://example.com/dataset1> a dctypes:Dataset ;
+  dc:format "text/csv" .

--- a/vocab/wd/examples/correct/anno69.ttl
+++ b/vocab/wd/examples/correct/anno69.ttl
@@ -12,10 +12,8 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno66> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    dcterms:creator <http://example.org/user1> .
+    oa:hasBody [ rdf:value "tag" ] ;
+    oa:hasTarget <http://example.com/video1> ;
+    oa:motivatedBy oa:tagging .
 
-<http://example.org/user1> a foaf:Person ;
-    foaf:nick "pseudo" ;
-    foaf:name "My Pseudonym" .
+<http://example.org/video1> a dctypes:MovingImage .

--- a/vocab/wd/examples/correct/anno7.ttl
+++ b/vocab/wd/examples/correct/anno7.ttl
@@ -12,9 +12,11 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno8> a oa:Annotation ;
-    oa:hasBody <http://example.org/description1> ;
-    oa:hasTarget  [
-        oa:hasSource <http://example.org/target1> ;
-        oa:hasState [
-            a oa:HttpRequestState ;
-            rdf:value "Accept: application/pdf" ] ] .
+    oa:hasTarget <http://example.org/image1> ;
+    oa:hasBody [
+        oa:hasSource <http://example.org/video1> ;
+        oa:hasPurpose oa:describing ;
+        oa:hasSelector [
+            a oa:FragmentSelector ;
+            dcterms:conformsTo <http://www.w3.org/TR/media-frags/> ;
+            rdf:value "t=30,60" ] ] .

--- a/vocab/wd/examples/correct/anno70.ttl
+++ b/vocab/wd/examples/correct/anno70.ttl
@@ -12,9 +12,8 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno67> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    schema:audience <http://example.net/roles/musician> .
+    oa:hasBody [ rdf:value "tag" ] ;
+    oa:hasTarget <http://example.com/image1> ;
+    oa:motivatedBy oa:tagging .
 
-<http://example.net/roles/musician> a schema:Audience ;
-    schema:audienceType "musician" .
+<http://example.org/image1> a dctypes:StillImage .

--- a/vocab/wd/examples/correct/anno71.ttl
+++ b/vocab/wd/examples/correct/anno71.ttl
@@ -11,8 +11,9 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1 a as:OrderedCollection ;
-  rdfs:label "Example Collection" ;
-  as:totalItems 42023 ;
-  as:first <http://example.org/collection1/page1> ;
-  as:last <http://example.org/collection1/page42> .
+<http://example.org/anno68> a oa:Annotation ;
+    oa:hasBody [ rdf:value "tag" ] ;
+    oa:hasTarget <http://example.com/audio1> ;
+    oa:motivatedBy oa:tagging .
+
+<http://example.org/audio1> a dctypes:Sound .

--- a/vocab/wd/examples/correct/anno72.ttl
+++ b/vocab/wd/examples/correct/anno72.ttl
@@ -11,11 +11,9 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno68> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    as:generator <http://example.org/client1> .
+<http://example.org/anno69> a oa:Annotation ;
+    oa:hasBody [ rdf:value "tag" ] ;
+    oa:hasTarget <http://example.com/document1> ;
+    oa:motivatedBy oa:tagging .
 
-<http://example.org/client1> a as:Application ;
-    foaf:homepage <HomePage1> ;
-    foaf:name "Code v2.1" .
+<http://example.org/document1> a dctypes:Text .

--- a/vocab/wd/examples/correct/anno73.ttl
+++ b/vocab/wd/examples/correct/anno73.ttl
@@ -11,11 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1/page1 a as:OrderedCollectionPage ;
-  as:partOf <http://example.org/collection1> ;
-  as:next <http://example.org/collection1/page2> ;
-  as:startIndex 0 ;
-  as:items (
-    <http://example.org/anno1>
-    <http://example.org/anno2>
-    <http://example.org/anno3> ) .
+<http://example.org/anno70> a oa:Annotation ;
+    oa:motivatedBy oa:commenting ;
+    oa:hasBody <http://example.net/comment1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    dcterms:creator <http://example.org/org> .
+
+<http://example.org/org> a foaf:Organization ;
+    foaf:name "Example Organization" .

--- a/vocab/wd/examples/correct/anno74.ttl
+++ b/vocab/wd/examples/correct/anno74.ttl
@@ -11,8 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1 a as:OrderedCollection ;
-  rdfs:label "Example Collection" ;
-  as:totalItems 42023 ;
-  as:first <http://example.org/collection1/page1> ;
-  as:last <http://example.org/collection1/page42> .
+<http://example.org/anno71> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    dcterms:creator <http://example.org/user1> .
+
+<http://example.org/user1> a foaf:Person ;
+    foaf:nick "pseudo" ;
+    foaf:name "My Pseudonym" .

--- a/vocab/wd/examples/correct/anno75.ttl
+++ b/vocab/wd/examples/correct/anno75.ttl
@@ -11,11 +11,10 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1/page1 a as:OrderedCollectionPage ;
-  as:partOf <http://example.org/collection1> ;
-  as:next <http://example.org/collection1/page2> ;
-  as:startIndex 0 ;
-  as:items (
-    <http://example.org/anno1>
-    <http://example.org/anno2>
-    <http://example.org/anno3> ) .
+<http://example.org/anno72> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    schema:audience <http://example.net/roles/musician> .
+
+<http://example.net/roles/musician> a schema:Audience ;
+    schema:audienceType "musician" .

--- a/vocab/wd/examples/correct/anno76.ttl
+++ b/vocab/wd/examples/correct/anno76.ttl
@@ -11,11 +11,8 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1/page1 a as:OrderedCollectionPage ;
-  as:partOf <http://example.org/collection1> ;
-  as:next <http://example.org/collection1/page2> ;
-  as:startIndex 0 ;
-  as:items (
-    <http://example.org/anno1>
-    <http://example.org/anno2>
-    <http://example.org/anno3> ) .
+<http://example.org/collection1 a as:OrderedCollection ;
+  rdfs:label "Example Collection" ;
+  as:totalItems 42023 ;
+  as:first <http://example.org/collection1/page1> ;
+  as:last <http://example.org/collection1/page42> .

--- a/vocab/wd/examples/correct/anno77.ttl
+++ b/vocab/wd/examples/correct/anno77.ttl
@@ -11,12 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1/page2 a as:OrderedCollectionPage ;
-  as:partOf <http://example.org/collection1> ;
-  as:prev <http://example.org/collection1/page1> ;
-  as:next <http://example.org/collection1/page3> ;
-  as:startIndex 3 ;
-  as:items (
-    <http://example.org/anno4>
-    <http://example.org/anno5>
-    <http://example.org/anno6> ) .
+<http://example.org/anno73> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    as:generator <http://example.org/client1> .
+
+<http://example.org/client1> a as:Application ;
+    foaf:homepage <HomePage1> ;
+    foaf:name "Code v2.1" .

--- a/vocab/wd/examples/correct/anno78.ttl
+++ b/vocab/wd/examples/correct/anno78.ttl
@@ -11,12 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/collection1/page2 a as:OrderedCollectionPage ;
+<http://example.org/collection1/page1 a as:OrderedCollectionPage ;
   as:partOf <http://example.org/collection1> ;
-  as:prev <http://example.org/collection1/page1> ;
-  as:next <http://example.org/collection1/page3> ;
-  as:startIndex 3 ;
+  as:next <http://example.org/collection1/page2> ;
+  as:startIndex 0 ;
   as:items (
-    <http://example.org/anno4>
-    <http://example.org/anno5>
-    <http://example.org/anno6> ) .
+    <http://example.org/anno1>
+    <http://example.org/anno2>
+    <http://example.org/anno3> ) .

--- a/vocab/wd/examples/correct/anno8.ttl
+++ b/vocab/wd/examples/correct/anno8.ttl
@@ -12,13 +12,9 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno9> a oa:Annotation ;
-    oa:motivatedBy oa:classifying ;
-    oa:hasBody <http://example.org/vocab/art/portrait> ;
-    oa:hasTarget [
-        a oa:Independents ;
-        as:items (
-          <http://example.com/image1>
-          <http://example.net/image2>
-          <http://example.com/image4>
-          <http://example.org/image9>
-        ) ] .
+    oa:hasBody <http://example.org/description1> ;
+    oa:hasTarget  [
+        oa:hasSource <http://example.org/target1> ;
+        oa:hasState [
+            a oa:HttpRequestState ;
+            rdf:value "Accept: application/pdf" ] ] .

--- a/vocab/wd/examples/correct/anno80.ttl
+++ b/vocab/wd/examples/correct/anno80.ttl
@@ -11,10 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno69> a oa:Annotation ;
-    oa:hasTarget <http://example.org/photo1> ;
-    oa:hasBody [
-        a oa:TextualBody;
-        rdf:value "<p>Comment text</p>" ;
-        dc:language "en" ;
-        dc:format "text/html" ] .
+<http://example.org/collection1/page1 a as:OrderedCollectionPage ;
+  as:partOf <http://example.org/collection1> ;
+  as:next <http://example.org/collection1/page2> ;
+  as:startIndex 0 ;
+  as:items (
+    <http://example.org/anno1>
+    <http://example.org/anno2>
+    <http://example.org/anno3> ) .

--- a/vocab/wd/examples/correct/anno81.ttl
+++ b/vocab/wd/examples/correct/anno81.ttl
@@ -11,10 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno70> a oa:Annotation ;
-    oa:hasTarget <http://example.org/photo1> ;
-    oa:hasBody [
-        a oa:TextualBody;
-        rdf:value "<p>Comment text</p>" ;
-        dc:language "en" ;
-        dc:format "text/html" ] .
+<http://example.org/collection1/page1 a as:OrderedCollectionPage ;
+  as:partOf <http://example.org/collection1> ;
+  as:next <http://example.org/collection1/page2> ;
+  as:startIndex 0 ;
+  as:items (
+    <http://example.org/anno1>
+    <http://example.org/anno2>
+    <http://example.org/anno3> ) .

--- a/vocab/wd/examples/correct/anno82.ttl
+++ b/vocab/wd/examples/correct/anno82.ttl
@@ -11,7 +11,12 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno71> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    dcterms:created "2015-10-13T13:00:00Z" .
+<http://example.org/collection1/page2 a as:OrderedCollectionPage ;
+  as:partOf <http://example.org/collection1> ;
+  as:prev <http://example.org/collection1/page1> ;
+  as:next <http://example.org/collection1/page3> ;
+  as:startIndex 3 ;
+  as:items (
+    <http://example.org/anno4>
+    <http://example.org/anno5>
+    <http://example.org/anno6> ) .

--- a/vocab/wd/examples/correct/anno83.ttl
+++ b/vocab/wd/examples/correct/anno83.ttl
@@ -11,12 +11,12 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno72> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    dcterms:creator <http://example.org/user1> ;
-    as:generator <http://example.org/client1> .
-
-<http://example.org/user1> a foaf:Person ;
-    foaf:nick "pseudo" ;
-    foaf:name "My Pseudonym" .
+<http://example.org/collection1/page2 a as:OrderedCollectionPage ;
+  as:partOf <http://example.org/collection1> ;
+  as:prev <http://example.org/collection1/page1> ;
+  as:next <http://example.org/collection1/page3> ;
+  as:startIndex 3 ;
+  as:items (
+    <http://example.org/anno4>
+    <http://example.org/anno5>
+    <http://example.org/anno6> ) .

--- a/vocab/wd/examples/correct/anno84.ttl
+++ b/vocab/wd/examples/correct/anno84.ttl
@@ -11,12 +11,8 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno73> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    dcterms:issued "2015-10-14T15:13:28Z" ;
-    as:generated <http://example.org/client1> .
-
-<http://example.org/client2> a as:Application ;
-    foaf:homepage <HomePage2> ;
-    foaf:name "Code v1" .
+<http://example.org/collection1 a as:OrderedCollection ;
+  rdfs:label "Example Collection" ;
+  as:totalItems 42023 ;
+  as:first <http://example.org/collection1/page1> ;
+  as:last <http://example.org/collection1/page42> .

--- a/vocab/wd/examples/correct/anno85.ttl
+++ b/vocab/wd/examples/correct/anno85.ttl
@@ -12,10 +12,9 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno74> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    as:generator <http://example.org/client1> .
-
-<http://example.org/client1> a as:Application ;
-    foaf:homepage <HomePage1> ;
-    foaf:name "Code v2.1" .
+    oa:hasTarget <http://example.org/photo1> ;
+    oa:hasBody [
+        a oa:TextualBody;
+        rdf:value "<p>Comment text</p>" ;
+        dc:language "en" ;
+        dc:format "text/html" ] .

--- a/vocab/wd/examples/correct/anno86.ttl
+++ b/vocab/wd/examples/correct/anno86.ttl
@@ -12,10 +12,9 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno75> a oa:Annotation ;
-    oa:hasBody <http://example.net/review1> ;
-    oa:hasTarget <http://example.com/restaurant1> ;
-    dcterms:creator <http://example.org/user1> .
-
-<http://example.org/user1> a foaf:Person ;
-    foaf:nick "pseudo" ;
-    foaf:name "My Pseudonym" .
+    oa:hasTarget <http://example.org/photo1> ;
+    oa:hasBody [
+        a oa:TextualBody;
+        rdf:value "<p>Comment text</p>" ;
+        dc:language "en" ;
+        dc:format "text/html" ] .

--- a/vocab/wd/examples/correct/anno87.ttl
+++ b/vocab/wd/examples/correct/anno87.ttl
@@ -14,8 +14,4 @@
 <http://example.org/anno76> a oa:Annotation ;
     oa:hasBody <http://example.net/review1> ;
     oa:hasTarget <http://example.com/restaurant1> ;
-    dcterms:creator <http://example.org/user1> .
-
-<http://example.org/user1> a foaf:Person ;
-    foaf:nick "pseudo" ;
-    foaf:name "My Pseudonym" .
+    dcterms:created "2015-10-13T13:00:00Z" .

--- a/vocab/wd/examples/correct/anno88.ttl
+++ b/vocab/wd/examples/correct/anno88.ttl
@@ -14,7 +14,9 @@
 <http://example.org/anno77> a oa:Annotation ;
     oa:hasBody <http://example.net/review1> ;
     oa:hasTarget <http://example.com/restaurant1> ;
-    schema:audience <http://example.net/roles/musician> .
+    dcterms:creator <http://example.org/user1> ;
+    as:generator <http://example.org/client1> .
 
-<http://example.net/roles/musician> a schema:Audience ;
-    schema:audienceType "musician" .
+<http://example.org/user1> a foaf:Person ;
+    foaf:nick "pseudo" ;
+    foaf:name "My Pseudonym" .

--- a/vocab/wd/examples/correct/anno89.ttl
+++ b/vocab/wd/examples/correct/anno89.ttl
@@ -11,6 +11,12 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno48> a oa:Annotation ;
-    oa:hasTarget <http://example.com/page1> ;
-    oa:motivatedBy oa:bookmarking .
+<http://example.org/anno78> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    dcterms:issued "2015-10-14T15:13:28Z" ;
+    as:generated <http://example.org/client1> .
+
+<http://example.org/client2> a as:Application ;
+    foaf:homepage <HomePage2> ;
+    foaf:name "Code v1" .

--- a/vocab/wd/examples/correct/anno9.ttl
+++ b/vocab/wd/examples/correct/anno9.ttl
@@ -12,13 +12,13 @@
 @prefix schema: <http://schema.org/> .
 
 <http://example.org/anno10> a oa:Annotation ;
-    oa:motivatedBy oa:tagging ;
-    oa:hasBody [ a oa:TextualBody ; rdf:value "important" ] ;
+    oa:motivatedBy oa:classifying ;
+    oa:hasBody <http://example.org/vocab/art/portrait> ;
     oa:hasTarget [
-        a oa:List ;
+        a oa:Independents ;
         as:items (
-          <http://example.com/book/page1>
-          <http://example.net/book/page2>
-          <http://example.com/book/page3>
-          <http://example.org/book/page4>
+          <http://example.com/image1>
+          <http://example.net/image2>
+          <http://example.com/image4>
+          <http://example.org/image9>
         ) ] .

--- a/vocab/wd/examples/correct/anno90.ttl
+++ b/vocab/wd/examples/correct/anno90.ttl
@@ -11,6 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno48> a oa:Annotation ;
-    oa:hasTarget <http://example.com/page1> ;
-    oa:motivatedBy oa:bookmarking .
+<http://example.org/anno79> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    as:generator <http://example.org/client1> .
+
+<http://example.org/client1> a as:Application ;
+    foaf:homepage <HomePage1> ;
+    foaf:name "Code v2.1" .

--- a/vocab/wd/examples/correct/anno91.ttl
+++ b/vocab/wd/examples/correct/anno91.ttl
@@ -11,6 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno48> a oa:Annotation ;
-    oa:hasTarget <http://example.com/page1> ;
-    oa:motivatedBy oa:bookmarking .
+<http://example.org/anno80> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    dcterms:creator <http://example.org/user1> .
+
+<http://example.org/user1> a foaf:Person ;
+    foaf:nick "pseudo" ;
+    foaf:name "My Pseudonym" .

--- a/vocab/wd/examples/correct/anno92.ttl
+++ b/vocab/wd/examples/correct/anno92.ttl
@@ -11,6 +11,11 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno48> a oa:Annotation ;
-    oa:hasTarget <http://example.com/page1> ;
-    oa:motivatedBy oa:bookmarking .
+<http://example.org/anno81> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    dcterms:creator <http://example.org/user1> .
+
+<http://example.org/user1> a foaf:Person ;
+    foaf:nick "pseudo" ;
+    foaf:name "My Pseudonym" .

--- a/vocab/wd/examples/correct/anno93.ttl
+++ b/vocab/wd/examples/correct/anno93.ttl
@@ -11,6 +11,9 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno48> a oa:Annotation ;
-    oa:hasTarget <http://example.com/page1> ;
-    oa:motivatedBy oa:bookmarking .
+<http://example.org/anno82> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/video1> .
+
+<http://example.com/video1> a dctypes:MovingImage ;
+    schema:accessibilityFeature "captions" .

--- a/vocab/wd/examples/correct/anno94.ttl
+++ b/vocab/wd/examples/correct/anno94.ttl
@@ -11,6 +11,10 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 
-<http://example.org/anno48> a oa:Annotation ;
-    oa:hasTarget <http://example.com/page1> ;
-    oa:motivatedBy oa:bookmarking .
+<http://example.org/anno83> a oa:Annotation ;
+    oa:hasBody <http://example.net/review1> ;
+    oa:hasTarget <http://example.com/restaurant1> ;
+    schema:audience <http://example.net/roles/musician> .
+
+<http://example.net/roles/musician> a schema:Audience ;
+    schema:audienceType "musician" .

--- a/vocab/wd/extract_egs.py
+++ b/vocab/wd/extract_egs.py
@@ -38,6 +38,9 @@ for eg in egs:
 	egdata = egdata.strip()
 	if not egdata:
 		continue
+	if egdata.startswith("GET "):
+		continue
+
 	g = Graph()
 	data = pfxstr + "\n\n" + egdata
 	try:

--- a/vocab/wd/index-linktemplate.html
+++ b/vocab/wd/index-linktemplate.html
@@ -188,10 +188,6 @@
 </div>
 
 <p class="issue">
-The use of the W3CDTF format, instead of the more restrictive but more common xsd:datetime format, is considered to be at-risk.
-</p>
-
-<p class="issue">
 The use of the ActivityStreams terms are considered to be at-risk pending [[!activitystreams-vocabulary]] reaching Candidate Recommendation.
 </p>
 
@@ -424,6 +420,28 @@ Annotation | Choice | Composite | CssSelector | CssStyle | DataPositionSelector 
     </pre>
   </div>
 </section>
+
+<section class="term">
+  <h4>Direction</h4>
+  <p>A class to encapsulate the different text directions that a textual resource might take.  It is not used directly in the Annotation Model, only its three instances.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Direction</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:Direction">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody [
+        rdfs:value "This is a comment" ;
+        dc:language "en" ;
+        dc:format "text/plain" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget &lt;http://example.org/page1&gt; .
+    </pre>
+  </div>
+</section>
+
 
 <section class="term">
   <h4>FragmentSelector</h4>
@@ -923,7 +941,7 @@ annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#end</li>
-      <li><strong>Range:</strong> xsd:integer</li>
+      <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
     </ul>
   </div>
   <div>
@@ -1338,7 +1356,7 @@ annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#start</li>
-      <li><strong>Range:</strong> xsd:integer</li>
+      <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
     </ul>
   </div>
   <div>
@@ -1423,6 +1441,29 @@ annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody
             oa:exact "anotation" ;
             oa:prefix "this is an " ;
             oa:suffix " that has some" ] ] .
+</pre>
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>textDirection</h4>
+  <p>The direction of the text of the subject resource. There MUST only be one text direction associated with any given resource.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#textDirection</li>
+      <li><strong>Range:</strong> oa:Direction</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:suffix">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody [
+        rdfs:value "This is a comment" ;
+        dc:language "en" ;
+        dc:format "text/plain" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget &lt;http://example.org/page1&gt; .
 </pre>
     </pre>
   </div>
@@ -1682,6 +1723,103 @@ annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody
     </pre>
   </div>
 </section>
+
+  <h4>auto</h4>
+  <p>The direction of text that should be automatically determined from the content.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#auto</li>
+      <li><strong>Instance Of:</strong> oa:Direction</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:tagging">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody [ 
+        rdf:value "Some text" ;
+        oa:textDirection oa:auto ] ;
+    oa:hasTarget &lt;http://example.com/thing1&gt;  .
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>ltr</h4>
+  <p>The direction of text that is read from left to right.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#ltr</li>
+      <li><strong>Instance Of:</strong> oa:Direction</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:tagging">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody [ 
+        rdf:value "Left to Right text" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget &lt;http://example.com/thing1&gt;  .
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>rtl</h4>
+  <p>The direction of text that is read from right to left.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#rtl</li>
+      <li><strong>Instance Of:</strong> oa:Direction</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:tagging">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody &lt;http://example.org/ar/comment1&gt; ;
+    oa:hasTarget &lt;http://example.com/thing1&gt;  .
+
+&lt;http://example.org/ar/comment1&gt; a dctypes:Text ; 
+    oa:textDirection oa:rtl .   
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>PreferContainedDescriptions</h4>
+  <p>An IRI to signal the client prefers to receive full descriptions of the Annotations from a container, not just their IRIs.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#PreferContainedDescriptions</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:PreferContainedDescriptions">  
+GET /annotations/ HTTP/1.1
+Host: example.org
+Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
+Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferContainedDescriptions"
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>PreferContainedIRIs</h4>
+  <p>An IRI to signal that the client prefers to receive only the IRIs of the Annotations from a container, not their full descriptions.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#PreferContainedIRIs</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:PreferContainedIRIs">  
+GET /annotations/ HTTP/1.1
+Host: example.org
+Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
+Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferContainedIRIs"
+    </pre>
+  </div>
+</section>
+
 </section>
 </section>
 
@@ -1945,7 +2083,7 @@ as:Application | as:OrderedCollection | as:OrderedCollectionPage | dctypes:Datas
   <h3>Properties</h3>
 
 <div class="termtoc">
-as:first | as:generator | as:items | as:last | as:next | as:partOf | as:prev | as:startIndex | as:totalItems | dc:format | dc:language | dcterms:conformsTo | dcterms:created | dcterms:creator | dcterms:issued | dcterms:modified | dcterms:rights | foaf:homepage | foaf:mbox | foaf:mbox_sha1sum | foaf:name | foaf:nick | rdf:type | rdf:value | rdfs:label | schema:audience
+as:first | as:generator | as:items | as:last | as:next | as:partOf | as:prev | as:startIndex | as:totalItems | dc:format | dc:language | dcterms:conformsTo | dcterms:created | dcterms:creator | dcterms:issued | dcterms:modified | dcterms:rights | foaf:homepage | foaf:mbox | foaf:mbox_sha1sum | foaf:name | foaf:nick | rdf:type | rdf:value | rdfs:label | schema:accessibilityFeature | schema:audience
 </div>
 
 
@@ -2117,7 +2255,7 @@ as:first | as:generator | as:items | as:last | as:next | as:partOf | as:prev | a
     <ul>
       <li><strong>URI:</strong> _as_:startIndex</li>
       <li><strong>Domain:</strong> as:OrderedCollectionPage</li>
-      <li><strong>Range:</strong> xsd:integer</li>
+      <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
     </ul>
   </div>
   <div>
@@ -2142,7 +2280,7 @@ as:first | as:generator | as:items | as:last | as:next | as:partOf | as:prev | a
     <ul>
       <li><strong>URI:</strong> _as_:totalItems</li>
       <li><strong>Domain:</strong> as:OrderedCollection</li>
-      <li><strong>Range:</strong> xsd:integer</li>
+      <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
     </ul>
   </div>
   <div>
@@ -2225,7 +2363,7 @@ as:first | as:generator | as:items | as:last | as:next | as:partOf | as:prev | a
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> _dcterms_:created</li>
-      <li><strong>Range:</strong> |dcterms:W3CDTF</li>
+      <li><strong>Range:</strong> xsd:dateTime</li>
       <li><strong>Equivalent Properties:</strong> as:published</li>
     </ul>
   </div>
@@ -2269,7 +2407,7 @@ as:first | as:generator | as:items | as:last | as:next | as:partOf | as:prev | a
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> _dcterms_:issued</li>
-      <li><strong>Range:</strong> |dcterms:W3CDTF</li>
+      <li><strong>Range:</strong> xsd:dateTime</li>
     </ul>
   </div>
   <div>
@@ -2293,7 +2431,7 @@ as:first | as:generator | as:items | as:last | as:next | as:partOf | as:prev | a
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> _dcterms_:modified</li>
-      <li><strong>Range:</strong> |dcterms:W3CDTF</li>
+      <li><strong>Range:</strong> xsd:dateTime</li>
     </ul>
   </div>
   <div>
@@ -2454,6 +2592,26 @@ as:first | as:generator | as:items | as:last | as:next | as:partOf | as:prev | a
   </div>
   <div>
     <pre class="example highlight" title="rdfs:label">
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>schema:accessibilityFeature</h4>
+  <p></p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> _schema_:accessibilityFeature</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="schema:Audience">
+&lt;http://example.org/anno%%anno%%&gt; a oa:Annotation ;
+    oa:hasBody &lt;http://example.net/review1&gt; ;
+    oa:hasTarget &lt;http://example.com/video1&gt; .
+
+&lt;http://example.com/video1&gt; a dctypes:MovingImage ;
+    schema:accessibilityFeature "captions" .
     </pre>
   </div>
 </section>

--- a/vocab/wd/index-linktemplate.html
+++ b/vocab/wd/index-linktemplate.html
@@ -266,7 +266,7 @@ The namespace used for the Web Annotation Ontology is:
 <h3>Classes</h3>
 
 <div class="termtoc">
-Annotation | Choice | Composite | CssSelector | CssStyle | DataPositionSelector | FragmentSelector | HttpRequestState | Independents | List | Motivation | RangeSelector | ResourceSelection | Selector | SpecificResource | State | Style | SvgSelector | TextPositionSelector | TextQuoteSelector | TextualBody | TimeState | XPathSelector
+Annotation | Choice | Composite | CssSelector | CssStyle | DataPositionSelector | Direction | FragmentSelector | HttpRequestState | Independents | List | Motivation | RangeSelector | ResourceSelection | Selector | SpecificResource | State | Style | SvgSelector | TextPositionSelector | TextQuoteSelector | TextualBody | TimeState | XPathSelector
 </div>
 
 <section class="term">
@@ -851,7 +851,7 @@ Annotation | Choice | Composite | CssSelector | CssStyle | DataPositionSelector 
 
 
 <div class="termtoc">
-annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody | hasPurpose | hasScope | hasSelector | hasSource | hasState | hasTarget | motivatedBy | prefix | refinedBy | sourceDate | sourceDateEnd | sourceDateStart | start | styleClass | styledBy | suffix | via
+annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody | hasPurpose | hasScope | hasSelector | hasSource | hasState | hasTarget | motivatedBy | prefix | refinedBy | sourceDate | sourceDateEnd | sourceDateStart | start | styleClass | styledBy | suffix | textDirection | via
 </div>
 
 <section class="term">
@@ -1724,11 +1724,11 @@ annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody
   </div>
 </section>
 
-  <h4>auto</h4>
+  <h4>autoDirection</h4>
   <p>The direction of text that should be automatically determined from the content.</p>
   <div class="tech">
     <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#auto</li>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#autoDirection</li>
       <li><strong>Instance Of:</strong> oa:Direction</li>
     </ul>
   </div>
@@ -1748,7 +1748,7 @@ annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody
   <p>The direction of text that is read from left to right.</p>
   <div class="tech">
     <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#ltr</li>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#ltrDirection</li>
       <li><strong>Instance Of:</strong> oa:Direction</li>
     </ul>
   </div>
@@ -1768,7 +1768,7 @@ annotationService | bodyValue | cachedSource | canonical | end | exact | hasBody
   <p>The direction of text that is read from right to left.</p>
   <div class="tech">
     <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#rtl</li>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#rtlDirection</li>
       <li><strong>Instance Of:</strong> oa:Direction</li>
     </ul>
   </div>

--- a/vocab/wd/index-respec.html
+++ b/vocab/wd/index-respec.html
@@ -188,10 +188,6 @@
 </div>
 
 <p class="issue">
-The use of the W3CDTF format, instead of the more restrictive but more common xsd:datetime format, is considered to be at-risk.
-</p>
-
-<p class="issue">
 The use of the ActivityStreams terms are considered to be at-risk pending [[!activitystreams-vocabulary]] reaching Candidate Recommendation.
 </p>
 
@@ -270,7 +266,7 @@ The namespace used for the Web Annotation Ontology is:
 <h3>Classes</h3>
 
 <div class="termtoc">
-<a href="#annotation">Annotation</a> | <a href="#choice">Choice</a> | <a href="#composite">Composite</a> | <a href="#cssselector">CssSelector</a> | <a href="#cssstyle">CssStyle</a> | <a href="#datapositionselector">DataPositionSelector</a> | <a href="#fragmentselector">FragmentSelector</a> | <a href="#httprequeststate">HttpRequestState</a> | <a href="#independents">Independents</a> | <a href="#list">List</a> | <a href="#motivation">Motivation</a> | <a href="#rangeselector">RangeSelector</a> | <a href="#resourceselection">ResourceSelection</a> | <a href="#selector">Selector</a> | <a href="#specificresource">SpecificResource</a> | <a href="#state">State</a> | <a href="#style">Style</a> | <a href="#svgselector">SvgSelector</a> | <a href="#textpositionselector">TextPositionSelector</a> | <a href="#textquoteselector">TextQuoteSelector</a> | <a href="#textualbody">TextualBody</a> | <a href="#timestate">TimeState</a> | <a href="#xpathselector">XPathSelector</a>
+<a href="#annotation">Annotation</a> | <a href="#choice">Choice</a> | <a href="#composite">Composite</a> | <a href="#cssselector">CssSelector</a> | <a href="#cssstyle">CssStyle</a> | <a href="#datapositionselector">DataPositionSelector</a> | <a href="#direction">Direction</a> | <a href="#fragmentselector">FragmentSelector</a> | <a href="#httprequeststate">HttpRequestState</a> | <a href="#independents">Independents</a> | <a href="#list">List</a> | <a href="#motivation">Motivation</a> | <a href="#rangeselector">RangeSelector</a> | <a href="#resourceselection">ResourceSelection</a> | <a href="#selector">Selector</a> | <a href="#specificresource">SpecificResource</a> | <a href="#state">State</a> | <a href="#style">Style</a> | <a href="#svgselector">SvgSelector</a> | <a href="#textpositionselector">TextPositionSelector</a> | <a href="#textquoteselector">TextQuoteSelector</a> | <a href="#textualbody">TextualBody</a> | <a href="#timestate">TimeState</a> | <a href="#xpathselector">XPathSelector</a>
 </div>
 
 <section class="term">
@@ -426,6 +422,28 @@ The namespace used for the Web Annotation Ontology is:
 </section>
 
 <section class="term">
+  <h4>Direction</h4>
+  <p>A class to encapsulate the different text directions that a textual resource might take.  It is not used directly in the Annotation Model, only its three instances.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Direction</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:Direction">
+&lt;http://example.org/anno7&gt; a oa:Annotation ;
+    oa:hasBody [
+        rdfs:value "This is a comment" ;
+        dc:language "en" ;
+        dc:format "text/plain" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget &lt;http://example.org/page1&gt; .
+    </pre>
+  </div>
+</section>
+
+
+<section class="term">
   <h4>FragmentSelector</h4>
   <p>The FragmentSelector class is used to record the segment of a representation using the URI fragment specification defined by the representation's media type.</p>
   <div class="tech">
@@ -438,7 +456,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:FragmentSelector">
-&lt;http://example.org/anno7&gt; a oa:Annotation ;
+&lt;http://example.org/anno8&gt; a oa:Annotation ;
     oa:hasTarget &lt;http://example.org/image1&gt; ;
     oa:hasBody [
         oa:hasSource &lt;http://example.org/video1&gt; ;
@@ -463,7 +481,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:HttpRequestState">
-&lt;http://example.org/anno8&gt; a oa:Annotation ;
+&lt;http://example.org/anno9&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/description1&gt; ;
     oa:hasTarget  [
         oa:hasSource &lt;http://example.org/target1&gt; ;
@@ -492,7 +510,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div id="example_independents">
     <pre class="example highlight" title="oa:Independents">
-&lt;http://example.org/anno9&gt; a oa:Annotation ;
+&lt;http://example.org/anno10&gt; a oa:Annotation ;
     oa:motivatedBy oa:classifying ;
     oa:hasBody &lt;http://example.org/vocab/art/portrait&gt; ;
     oa:hasTarget [
@@ -525,7 +543,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div id="example_list">
     <pre class="example highlight" title="oa:List">
-&lt;http://example.org/anno10&gt; a oa:Annotation ;
+&lt;http://example.org/anno11&gt; a oa:Annotation ;
     oa:motivatedBy oa:tagging ;
     oa:hasBody [ a oa:TextualBody ; rdf:value "important" ] ;
     oa:hasTarget [
@@ -552,7 +570,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:Motivation">
-&lt;http://example.org/anno11&gt; a oa:Annotation ;
+&lt;http://example.org/anno12&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/description1&gt; ;
     oa:hasTarget &lt;http://example.com/resource1&gt; ;
     oa:motivatedBy oa:describing .
@@ -572,7 +590,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:RangeSelector">
-&lt;http://example.org/anno12&gt; a oa:Annotation ;
+&lt;http://example.org/anno13&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -638,7 +656,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:SpecificResource">
-&lt;http://example.org/anno13&gt; a oa:Annotation ;
+&lt;http://example.org/anno14&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget &lt;http://example.org/region1&gt; .
 
@@ -691,7 +709,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:SvgSelector">
-&lt;http://example.org/anno14&gt; a oa:Annotation ;
+&lt;http://example.org/anno15&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/road1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/map1&gt; ;
@@ -714,7 +732,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:TextPositionSelector">
-&lt;http://example.org/anno15&gt; a oa:Annotation ;
+&lt;http://example.org/anno16&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/review1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/ebook1&gt; ;
@@ -739,7 +757,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:TextQuoteSelector">
-&lt;http://example.org/anno16&gt; a oa:Annotation ;
+&lt;http://example.org/anno17&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -766,7 +784,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:TextualBody">
-&lt;http://example.org/anno17&gt; a oa:Annotation ;
+&lt;http://example.org/anno18&gt; a oa:Annotation ;
     oa:hasTarget &lt;http://example.org/photo1&gt; ;
     oa:hasBody [
         a oa:TextualBody;
@@ -790,7 +808,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:TimeState">
-&lt;http://example.org/anno18&gt; a oa:Annotation ;
+&lt;http://example.org/anno19&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -814,7 +832,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:TimeState">
-&lt;http://example.org/anno19&gt; a oa:Annotation ;
+&lt;http://example.org/anno20&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -833,7 +851,7 @@ The namespace used for the Web Annotation Ontology is:
 
 
 <div class="termtoc">
-<a href="#annotationservice">annotationService</a> | <a href="#bodyvalue">bodyValue</a> | <a href="#cachedsource">cachedSource</a> | <a href="#canonical">canonical</a> | <a href="#end">end</a> | <a href="#exact">exact</a> | <a href="#hasbody">hasBody</a> | <a href="#haspurpose">hasPurpose</a> | <a href="#hasscope">hasScope</a> | <a href="#hasselector">hasSelector</a> | <a href="#hassource">hasSource</a> | <a href="#hasstate">hasState</a> | <a href="#hastarget">hasTarget</a> | <a href="#motivatedby">motivatedBy</a> | <a href="#prefix">prefix</a> | <a href="#refinedby">refinedBy</a> | <a href="#sourcedate">sourceDate</a> | <a href="#sourcedateend">sourceDateEnd</a> | <a href="#sourcedatestart">sourceDateStart</a> | <a href="#start">start</a> | <a href="#styleclass">styleClass</a> | <a href="#styledby">styledBy</a> | <a href="#suffix">suffix</a> | <a href="#via">via</a>
+<a href="#annotationservice">annotationService</a> | <a href="#bodyvalue">bodyValue</a> | <a href="#cachedsource">cachedSource</a> | <a href="#canonical">canonical</a> | <a href="#end">end</a> | <a href="#exact">exact</a> | <a href="#hasbody">hasBody</a> | <a href="#haspurpose">hasPurpose</a> | <a href="#hasscope">hasScope</a> | <a href="#hasselector">hasSelector</a> | <a href="#hassource">hasSource</a> | <a href="#hasstate">hasState</a> | <a href="#hastarget">hasTarget</a> | <a href="#motivatedby">motivatedBy</a> | <a href="#prefix">prefix</a> | <a href="#refinedby">refinedBy</a> | <a href="#sourcedate">sourceDate</a> | <a href="#sourcedateend">sourceDateEnd</a> | <a href="#sourcedatestart">sourceDateStart</a> | <a href="#start">start</a> | <a href="#styleclass">styleClass</a> | <a href="#styledby">styledBy</a> | <a href="#suffix">suffix</a> | <a href="#textdirection">textDirection</a> | <a href="#via">via</a>
 </div>
 
 <section class="term">
@@ -869,7 +887,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:bodyValue">
-&lt;http://example.org/anno20&gt; a oa:Annotation ;
+&lt;http://example.org/anno21&gt; a oa:Annotation ;
     oa:bodyValue "Comment text" ;
     oa:hasTarget &lt;http://example.org/target1&gt; .
     </pre>
@@ -887,7 +905,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="">
-&lt;http://example.org/anno21&gt; a oa:Annotation ;
+&lt;http://example.org/anno22&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -909,7 +927,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="">
-&lt;http://example.org/anno22&gt; a oa:Annotation ;
+&lt;http://example.org/anno23&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget &lt;http://example.org/page1&gt; ;
     oa:canonical &lt;urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df&gt; .
@@ -923,12 +941,12 @@ The namespace used for the Web Annotation Ontology is:
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#end</li>
-      <li><strong>Range:</strong> xsd:integer</li>
+      <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
     </ul>
   </div>
   <div>
     <pre class="example highlight" title="oa:end">
-&lt;http://example.org/anno23&gt; a oa:Annotation ;
+&lt;http://example.org/anno24&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/diskimg1&gt; ;
@@ -951,7 +969,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:exact">
-&lt;http://example.org/anno24&gt; a oa:Annotation ;
+&lt;http://example.org/anno25&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -976,7 +994,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasBody">
-&lt;http://example.org/anno25&gt; a oa:Annotation ;
+&lt;http://example.org/anno26&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/post1&gt; ;
     oa:hasTarget &lt;http://example.com/page1&gt; .
     </pre>
@@ -995,7 +1013,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasEndSelector">
-&lt;http://example.org/anno26&gt; a oa:Annotation ;
+&lt;http://example.org/anno27&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -1022,7 +1040,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasPurpose">
-&lt;http://example.org/anno27&gt; a oa:Annotation ;
+&lt;http://example.org/anno28&gt; a oa:Annotation ;
     oa:motivatedBy oa:bookmarking ;
     oa:hasBody [
         a oa:TextualBody ;
@@ -1045,7 +1063,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasPurpose">
-&lt;http://example.org/anno28&gt; a oa:Annotation ;
+&lt;http://example.org/anno29&gt; a oa:Annotation ;
     oa:motivatedBy oa:bookmarking ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget [
@@ -1067,7 +1085,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasSelector">
-&lt;http://example.org/anno29&gt; a oa:Annotation ;
+&lt;http://example.org/anno30&gt; a oa:Annotation ;
     oa:hasBody [
       oa:hasSource &lt;http://example.org/page1&gt; ;
       oa:hasSelector &lt;http://example.org/paraselector1&gt; ] ;
@@ -1089,7 +1107,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasSource">
-&lt;http://example.org/anno30&gt; a oa:Annotation ;
+&lt;http://example.org/anno31&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget &lt;http://example.org/region1&gt; .
 
@@ -1111,7 +1129,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasStartSelector">
-&lt;http://example.org/anno31&gt; a oa:Annotation ;
+&lt;http://example.org/anno32&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -1139,7 +1157,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasState">
-&lt;http://example.org/anno32&gt; a oa:Annotation ;
+&lt;http://example.org/anno33&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasState &lt;http://example.org/state1&gt; ;
@@ -1159,7 +1177,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:hasTarget">
-&lt;http://example.org/anno33&gt; a oa:Annotation ;
+&lt;http://example.org/anno34&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/post1&gt; ;
     oa:hasTarget &lt;http://example.com/page1&gt; .
     </pre>
@@ -1178,7 +1196,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:motivatedBy">
-&lt;http://example.org/anno34&gt; a oa:Annotation ;
+&lt;http://example.org/anno35&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/description1&gt; ;
     oa:hasTarget &lt;http://example.com/resource1&gt; ;
     oa:motivatedBy oa:describing .
@@ -1197,7 +1215,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:prefix">
-&lt;http://example.org/anno35&gt; a oa:Annotation ;
+&lt;http://example.org/anno36&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -1220,7 +1238,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:refinedBy">
-&lt;http://example.org/anno36&gt; a oa:Annotation ;
+&lt;http://example.org/anno37&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget [
         a oa:SpecificResource ;
@@ -1249,7 +1267,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:prefix">
-&lt;http://example.org/anno37&gt; a oa:Annotation ;
+&lt;http://example.org/anno38&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget [
       a oa:SpecificResource ;
@@ -1273,7 +1291,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:sourceDate">
-&lt;http://example.org/anno38&gt; a oa:Annotation ;
+&lt;http://example.org/anno39&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -1296,7 +1314,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:sourceDate">
-&lt;http://example.org/anno39&gt; a oa:Annotation ;
+&lt;http://example.org/anno40&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -1320,7 +1338,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:sourceDate">
-&lt;http://example.org/anno40&gt; a oa:Annotation ;
+&lt;http://example.org/anno41&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -1338,12 +1356,12 @@ The namespace used for the Web Annotation Ontology is:
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> http://www.w3.org/ns/oa#start</li>
-      <li><strong>Range:</strong> xsd:integer</li>
+      <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
     </ul>
   </div>
   <div>
     <pre class="example highlight" title="oa:start">
-&lt;http://example.org/anno41&gt; a oa:Annotation ;
+&lt;http://example.org/anno42&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/review1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/ebook1&gt; ;
@@ -1367,7 +1385,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:styleClass">
-&lt;http://example.org/anno42&gt; a oa:Annotation ;
+&lt;http://example.org/anno43&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:styledBy &lt;http://example.org/style1&gt; ;
     oa:hasTarget [
@@ -1391,7 +1409,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:styledBy">
-&lt;http://example.org/anno43&gt; a oa:Annotation ;
+&lt;http://example.org/anno44&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/body1&gt; ;
     oa:styledBy [
         a oa:CssStyle ;
@@ -1414,7 +1432,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:suffix">
-&lt;http://example.org/anno44&gt; a oa:Annotation ;
+&lt;http://example.org/anno45&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/comment1&gt; ;
     oa:hasTarget [
         oa:hasSource &lt;http://example.org/page1&gt; ;
@@ -1423,6 +1441,29 @@ The namespace used for the Web Annotation Ontology is:
             oa:exact "anotation" ;
             oa:prefix "this is an " ;
             oa:suffix " that has some" ] ] .
+</pre>
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>textDirection</h4>
+  <p>The direction of the text of the subject resource. There MUST only be one text direction associated with any given resource.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#textDirection</li>
+      <li><strong>Range:</strong> <a href="#direction">oa:Direction</a></li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:suffix">
+&lt;http://example.org/anno46&gt; a oa:Annotation ;
+    oa:hasBody [
+        rdfs:value "This is a comment" ;
+        dc:language "en" ;
+        dc:format "text/plain" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget &lt;http://example.org/page1&gt; .
 </pre>
     </pre>
   </div>
@@ -1438,7 +1479,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="">
-&lt;http://example.org/anno45&gt; a oa:Annotation ;
+&lt;http://example.org/anno47&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/note1&gt; ;
     oa:hasTarget &lt;http://example.org/page1&gt; ;
     oa:via &lt;http://other.example.com/anno1b&gt; .
@@ -1461,7 +1502,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:bookmarking">
-&lt;http://example.org/anno46&gt; a oa:Annotation ;
+&lt;http://example.org/anno48&gt; a oa:Annotation ;
     oa:hasTarget &lt;http://example.com/page1&gt; ;
     oa:motivatedBy oa:bookmarking .
     </pre>
@@ -1478,7 +1519,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:classifying">
-&lt;http://example.org/anno47&gt; a oa:Annotation ;
+&lt;http://example.org/anno49&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/type1&gt; ;
     oa:hasTarget &lt;http://example.com/resource1&gt; ;
     oa:motivatedBy oa:classifying .
@@ -1496,7 +1537,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:commenting">
-&lt;http://example.org/anno48&gt; a oa:Annotation ;
+&lt;http://example.org/anno50&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "A comment about the page" ] ;
     oa:hasTarget &lt;http://example.com/page1&gt; ;
     oa:motivatedBy oa:commenting .
@@ -1514,7 +1555,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:describing">
-&lt;http://example.org/anno49&gt; a oa:Annotation ;
+&lt;http://example.org/anno51&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "A description of the image" ] ;
     oa:hasTarget &lt;http://example.com/image1&gt; ;
     oa:motivatedBy oa:describing .
@@ -1532,7 +1573,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:editing">
-&lt;http://example.org/anno50&gt; a oa:Annotation ;
+&lt;http://example.org/anno52&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "Editorial suggestion" ] ;
     oa:hasTarget &lt;http://example.com/text1&gt; ;
     oa:motivatedBy oa:editing .
@@ -1550,7 +1591,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:highlighting">
-&lt;http://example.org/anno51&gt; a oa:Annotation ;
+&lt;http://example.org/anno53&gt; a oa:Annotation ;
     oa:hasTarget &lt;http://example.com/region1&gt; ;
     oa:motivatedBy oa:highlighting .
     </pre>
@@ -1567,7 +1608,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:identifying">
-&lt;http://example.org/anno52&gt; a oa:Annotation ;
+&lt;http://example.org/anno54&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.com/identities/object1&gt; ;
     oa:hasTarget &lt;http://example.com/image-of-object1&gt; ;
     oa:motivatedBy oa:identifying .
@@ -1585,7 +1626,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:linking">
-&lt;http://example.org/anno53&gt; a oa:Annotation ;
+&lt;http://example.org/anno55&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/from1&gt; ;
     oa:hasTarget &lt;http://example.com/to1&gt; ;
     oa:motivatedBy oa:linking .
@@ -1603,7 +1644,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:moderating">
-&lt;http://example.org/anno54&gt; a oa:Annotation ;
+&lt;http://example.org/anno56&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.org/tags/approved1&gt; ;
     oa:hasTarget &lt;http://example.com/anno1&gt; ;
     oa:motivatedBy oa:moderating .
@@ -1621,7 +1662,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:questioning">
-&lt;http://example.org/anno55&gt; a oa:Annotation ;
+&lt;http://example.org/anno57&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "A question about the resource" ] ;
     oa:hasTarget &lt;http://example.com/resource1&gt; ;
     oa:motivatedBy oa:questioning .
@@ -1639,7 +1680,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:replying">
-&lt;http://example.org/anno56&gt; a oa:Annotation ;
+&lt;http://example.org/anno58&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "A reply to a question" ] ;
     oa:hasTarget &lt;http://example.com/anno1&gt; ;
     oa:motivatedBy oa:replying .
@@ -1657,7 +1698,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:reviewing">
-&lt;http://example.org/anno57&gt; a oa:Annotation ;
+&lt;http://example.org/anno59&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "A review of the resource" ] ;
     oa:hasTarget &lt;http://example.com/resource1&gt; ;
     oa:motivatedBy oa:reviewing .
@@ -1675,13 +1716,110 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="oa:tagging">
-&lt;http://example.org/anno58&gt; a oa:Annotation ;
+&lt;http://example.org/anno60&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "tag" ] ;
     oa:hasTarget &lt;http://example.com/thing1&gt; ;
     oa:motivatedBy oa:tagging .
     </pre>
   </div>
 </section>
+
+  <h4>autoDirection</h4>
+  <p>The direction of text that should be automatically determined from the content.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#autoDirection</li>
+      <li><strong>Instance Of:</strong> <a href="#direction">oa:Direction</a></li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:tagging">
+&lt;http://example.org/anno61&gt; a oa:Annotation ;
+    oa:hasBody [ 
+        rdf:value "Some text" ;
+        oa:textDirection oa:auto ] ;
+    oa:hasTarget &lt;http://example.com/thing1&gt;  .
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>ltr</h4>
+  <p>The direction of text that is read from left to right.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#ltrDirection</li>
+      <li><strong>Instance Of:</strong> <a href="#direction">oa:Direction</a></li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:tagging">
+&lt;http://example.org/anno62&gt; a oa:Annotation ;
+    oa:hasBody [ 
+        rdf:value "Left to Right text" ;
+        oa:textDirection oa:ltr ] ;
+    oa:hasTarget &lt;http://example.com/thing1&gt;  .
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>rtl</h4>
+  <p>The direction of text that is read from right to left.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#rtlDirection</li>
+      <li><strong>Instance Of:</strong> <a href="#direction">oa:Direction</a></li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:tagging">
+&lt;http://example.org/anno63&gt; a oa:Annotation ;
+    oa:hasBody &lt;http://example.org/ar/comment1&gt; ;
+    oa:hasTarget &lt;http://example.com/thing1&gt;  .
+
+&lt;http://example.org/ar/comment1&gt; a dctypes:Text ; 
+    oa:textDirection oa:rtl .   
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>PreferContainedDescriptions</h4>
+  <p>An IRI to signal the client prefers to receive full descriptions of the Annotations from a container, not just their IRIs.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#PreferContainedDescriptions</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:PreferContainedDescriptions">  
+GET /annotations/ HTTP/1.1
+Host: example.org
+Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
+Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferContainedDescriptions"
+    </pre>
+  </div>
+</section>
+
+<section class="term">
+  <h4>PreferContainedIRIs</h4>
+  <p>An IRI to signal that the client prefers to receive only the IRIs of the Annotations from a container, not their full descriptions.</p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> http://www.w3.org/ns/oa#PreferContainedIRIs</li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="oa:PreferContainedIRIs">  
+GET /annotations/ HTTP/1.1
+Host: example.org
+Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
+Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferContainedIRIs"
+    </pre>
+  </div>
+</section>
+
 </section>
 </section>
 
@@ -1707,7 +1845,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="as:Application">
-&lt;http://example.org/anno59&gt; a oa:Annotation ;
+&lt;http://example.org/anno64&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     as:generator &lt;http://example.org/client1&gt; .
@@ -1777,7 +1915,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="dctypes:Dataset">
-&lt;http://example.org/anno60&gt; a oa:Annotation ;
+&lt;http://example.org/anno65&gt; a oa:Annotation ;
     oa:motivatedBy oa:commenting ;
     oa:hasBody &lt;http://example.com/note1&gt; ;
     oa:hasTarget &lt;http://example.com/dataset1&gt; .
@@ -1799,7 +1937,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="dctypes:MovingImage">
-&lt;http://example.org/anno61&gt; a oa:Annotation ;
+&lt;http://example.org/anno66&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "tag" ] ;
     oa:hasTarget &lt;http://example.com/video1&gt; ;
     oa:motivatedBy oa:tagging .
@@ -1820,7 +1958,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="dctypes:StillImage">
-&lt;http://example.org/anno62&gt; a oa:Annotation ;
+&lt;http://example.org/anno67&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "tag" ] ;
     oa:hasTarget &lt;http://example.com/image1&gt; ;
     oa:motivatedBy oa:tagging .
@@ -1841,7 +1979,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="dctypes:Sound">
-&lt;http://example.org/anno63&gt; a oa:Annotation ;
+&lt;http://example.org/anno68&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "tag" ] ;
     oa:hasTarget &lt;http://example.com/audio1&gt; ;
     oa:motivatedBy oa:tagging .
@@ -1861,7 +1999,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="dctypes:Text">
-&lt;http://example.org/anno64&gt; a oa:Annotation ;
+&lt;http://example.org/anno69&gt; a oa:Annotation ;
     oa:hasBody [ rdf:value "tag" ] ;
     oa:hasTarget &lt;http://example.com/document1&gt; ;
     oa:motivatedBy oa:tagging .
@@ -1882,7 +2020,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="foaf:Organization">
-&lt;http://example.org/anno65&gt; a oa:Annotation ;
+&lt;http://example.org/anno70&gt; a oa:Annotation ;
     oa:motivatedBy oa:commenting ;
     oa:hasBody &lt;http://example.net/comment1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
@@ -1905,7 +2043,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="foaf:Person">
-&lt;http://example.org/anno66&gt; a oa:Annotation ;
+&lt;http://example.org/anno71&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     dcterms:creator &lt;http://example.org/user1&gt; .
@@ -1928,7 +2066,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="schema:Audience">
-&lt;http://example.org/anno67&gt; a oa:Annotation ;
+&lt;http://example.org/anno72&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     schema:audience &lt;http://example.net/roles/musician&gt; .
@@ -1945,7 +2083,7 @@ The namespace used for the Web Annotation Ontology is:
   <h3>Properties</h3>
 
 <div class="termtoc">
-<a href="#as-first">as:first</a> | <a href="#as-generator">as:generator</a> | <a href="#as-items">as:items</a> | <a href="#as-last">as:last</a> | <a href="#as-next">as:next</a> | <a href="#as-partof">as:partOf</a> | <a href="#as-prev">as:prev</a> | <a href="#as-startindex">as:startIndex</a> | <a href="#as-totalitems">as:totalItems</a> | <a href="#dc-format">dc:format</a> | <a href="#dc-language">dc:language</a> | <a href="#dcterms-conformsto">dcterms:conformsTo</a> | <a href="#dcterms-created">dcterms:created</a> | <a href="#dcterms-creator">dcterms:creator</a> | <a href="#dcterms-issued">dcterms:issued</a> | <a href="#dcterms-modified">dcterms:modified</a> | <a href="#dcterms-rights">dcterms:rights</a> | <a href="#foaf-homepage">foaf:homepage</a> | <a href="#foaf-mbox">foaf:mbox</a> | <a href="#foaf-mbox_sha1sum">foaf:mbox_sha1sum</a> | <a href="#foaf-name">foaf:name</a> | <a href="#foaf-nick">foaf:nick</a> | <a href="#rdf-type">rdf:type</a> | <a href="#rdf-value">rdf:value</a> | <a href="#rdfs-label">rdfs:label</a> | <a href="#schema-audience">schema:audience</a>
+<a href="#as-first">as:first</a> | <a href="#as-generator">as:generator</a> | <a href="#as-items">as:items</a> | <a href="#as-last">as:last</a> | <a href="#as-next">as:next</a> | <a href="#as-partof">as:partOf</a> | <a href="#as-prev">as:prev</a> | <a href="#as-startindex">as:startIndex</a> | <a href="#as-totalitems">as:totalItems</a> | <a href="#dc-format">dc:format</a> | <a href="#dc-language">dc:language</a> | <a href="#dcterms-conformsto">dcterms:conformsTo</a> | <a href="#dcterms-created">dcterms:created</a> | <a href="#dcterms-creator">dcterms:creator</a> | <a href="#dcterms-issued">dcterms:issued</a> | <a href="#dcterms-modified">dcterms:modified</a> | <a href="#dcterms-rights">dcterms:rights</a> | <a href="#foaf-homepage">foaf:homepage</a> | <a href="#foaf-mbox">foaf:mbox</a> | <a href="#foaf-mbox_sha1sum">foaf:mbox_sha1sum</a> | <a href="#foaf-name">foaf:name</a> | <a href="#foaf-nick">foaf:nick</a> | <a href="#rdf-type">rdf:type</a> | <a href="#rdf-value">rdf:value</a> | <a href="#rdfs-label">rdfs:label</a> | <a href="#schema-accessibilityfeature">schema:accessibilityFeature</a> | <a href="#schema-audience">schema:audience</a>
 </div>
 
 
@@ -1980,7 +2118,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="as:generator">
-&lt;http://example.org/anno68&gt; a oa:Annotation ;
+&lt;http://example.org/anno73&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     as:generator &lt;http://example.org/client1&gt; .
@@ -2117,7 +2255,7 @@ The namespace used for the Web Annotation Ontology is:
     <ul>
       <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#startIndex">http://www.w3.org/ns/activitystreams#startIndex</a></li>
       <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-      <li><strong>Range:</strong> xsd:integer</li>
+      <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
     </ul>
   </div>
   <div>
@@ -2142,7 +2280,7 @@ The namespace used for the Web Annotation Ontology is:
     <ul>
       <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#totalItems">http://www.w3.org/ns/activitystreams#totalItems</a></li>
       <li><strong>Domain:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-      <li><strong>Range:</strong> xsd:integer</li>
+      <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
     </ul>
   </div>
   <div>
@@ -2167,7 +2305,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="dc:format">
-&lt;http://example.org/anno69&gt; a oa:Annotation ;
+&lt;http://example.org/anno74&gt; a oa:Annotation ;
     oa:hasTarget &lt;http://example.org/photo1&gt; ;
     oa:hasBody [
         a oa:TextualBody;
@@ -2189,7 +2327,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="dc:language">
-&lt;http://example.org/anno70&gt; a oa:Annotation ;
+&lt;http://example.org/anno75&gt; a oa:Annotation ;
     oa:hasTarget &lt;http://example.org/photo1&gt; ;
     oa:hasBody [
         a oa:TextualBody;
@@ -2225,13 +2363,13 @@ The namespace used for the Web Annotation Ontology is:
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/created">http://purl.org/dc/terms/created</a></li>
-      <li><strong>Range:</strong> <a href="http://purl.org/dc/terms/W3CDTF">dcterms:W3CDTF</a></li>
+      <li><strong>Range:</strong> xsd:dateTime</li>
       <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#published">as:published</a></li>
     </ul>
   </div>
   <div>
     <pre class="example highlight" title="dcterms:created">
-&lt;http://example.org/anno71&gt; a oa:Annotation ;
+&lt;http://example.org/anno76&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     dcterms:created "2015-10-13T13:00:00Z" .
@@ -2250,7 +2388,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="dcterms:creator">
-&lt;http://example.org/anno72&gt; a oa:Annotation ;
+&lt;http://example.org/anno77&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     dcterms:creator &lt;http://example.org/user1&gt; ;
@@ -2269,12 +2407,12 @@ The namespace used for the Web Annotation Ontology is:
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/issued">http://purl.org/dc/terms/issued</a></li>
-      <li><strong>Range:</strong> <a href="http://purl.org/dc/terms/W3CDTF">dcterms:W3CDTF</a></li>
+      <li><strong>Range:</strong> xsd:dateTime</li>
     </ul>
   </div>
   <div>
     <pre class="example highlight" title="dcterms:issued">
-&lt;http://example.org/anno73&gt; a oa:Annotation ;
+&lt;http://example.org/anno78&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     dcterms:issued "2015-10-14T15:13:28Z" ;
@@ -2293,7 +2431,7 @@ The namespace used for the Web Annotation Ontology is:
   <div class="tech">
     <ul>
       <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/modified">http://purl.org/dc/terms/modified</a></li>
-      <li><strong>Range:</strong> <a href="http://purl.org/dc/terms/W3CDTF">dcterms:W3CDTF</a></li>
+      <li><strong>Range:</strong> xsd:dateTime</li>
     </ul>
   </div>
   <div>
@@ -2331,7 +2469,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="foaf:homepage">
-&lt;http://example.org/anno74&gt; a oa:Annotation ;
+&lt;http://example.org/anno79&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     as:generator &lt;http://example.org/client1&gt; .
@@ -2381,7 +2519,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="foaf:name">
-&lt;http://example.org/anno75&gt; a oa:Annotation ;
+&lt;http://example.org/anno80&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     dcterms:creator &lt;http://example.org/user1&gt; .
@@ -2403,7 +2541,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="foaf:nick">
-&lt;http://example.org/anno76&gt; a oa:Annotation ;
+&lt;http://example.org/anno81&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     dcterms:creator &lt;http://example.org/user1&gt; .
@@ -2459,6 +2597,26 @@ The namespace used for the Web Annotation Ontology is:
 </section>
 
 <section class="term">
+  <h4>schema:accessibilityFeature</h4>
+  <p></p>
+  <div class="tech">
+    <ul>
+      <li><strong>URI:</strong> <a href="http://schema.org/accessibilityFeature">http://schema.org/accessibilityFeature</a></li>
+    </ul>
+  </div>
+  <div>
+    <pre class="example highlight" title="schema:Audience">
+&lt;http://example.org/anno82&gt; a oa:Annotation ;
+    oa:hasBody &lt;http://example.net/review1&gt; ;
+    oa:hasTarget &lt;http://example.com/video1&gt; .
+
+&lt;http://example.com/video1&gt; a dctypes:MovingImage ;
+    schema:accessibilityFeature "captions" .
+    </pre>
+  </div>
+</section>
+
+<section class="term">
   <h4>schema:audience</h4>
   <p></p>
   <div class="tech">
@@ -2468,7 +2626,7 @@ The namespace used for the Web Annotation Ontology is:
   </div>
   <div>
     <pre class="example highlight" title="schema:Audience">
-&lt;http://example.org/anno77&gt; a oa:Annotation ;
+&lt;http://example.org/anno83&gt; a oa:Annotation ;
     oa:hasBody &lt;http://example.net/review1&gt; ;
     oa:hasTarget &lt;http://example.com/restaurant1&gt; ;
     schema:audience &lt;http://example.net/roles/musician&gt; .
@@ -2492,7 +2650,7 @@ The namespace used for the Web Annotation Ontology is:
   <pre class="highlight example" title="Extension Example 1">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno78",
+  "id": "http://example.org/anno84",
   "type": "Annotation",
   "skos:prefLabel": "Picture Annotation",
   "body": {
@@ -2516,7 +2674,7 @@ The namespace used for the Web Annotation Ontology is:
   <pre class="highlight example" title="Extension Example 2">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno79",
+  "id": "http://example.org/anno85",
   "type": "Annotation",
   "skos:prefLabel": "Picture Annotation",
   "body": {
@@ -2542,7 +2700,7 @@ The namespace used for the Web Annotation Ontology is:
   <pre class="highlight example" title="Extension Example 3">
 {
   "@context": "http://www.w3.org/ns/anno.jsonld",
-  "id": "http://example.org/anno80",
+  "id": "http://example.org/anno86",
   "type": "Annotation",
   "skos:prefLabel": "3d Annotation",
   "body": {
@@ -2640,6 +2798,10 @@ The RECOMMENDED serialization format is [[!JSON-LD]]. The JSON-LD context presen
     "reviewing":     "oa:reviewing",
     "tagging":       "oa:tagging",
 
+    "auto":          "oa:autoDirection",
+    "ltr":           "oa:ltrDirection",
+    "rtl":           "oa:rtlDirection",
+
     "body":          {"@type": "@id", "@id": "oa:hasBody"},
     "target":        {"@type": "@id", "@id": "oa:hasTarget"},
     "source":        {"@type": "@id", "@id": "oa:hasSource"},
@@ -2668,7 +2830,9 @@ The RECOMMENDED serialization format is [[!JSON-LD]]. The JSON-LD context presen
     "audience":      {"@type": "@id", "@id": "schema:audience"},
     "motivation":    {"@type": "@vocab", "@id": "oa:motivatedBy"},
     "purpose":       {"@type": "@vocab", "@id": "oa:hasPurpose"},
+    "textDirection": {"@type": "@vocab", "@id": "oa:textDirection"},
 
+    "accessibility": "schema:accessibilityFeature",
     "bodyValue":     "oa:bodyValue",
     "format":        "dc:format",
     "language":      "dc:language",
@@ -2691,12 +2855,11 @@ The RECOMMENDED serialization format is [[!JSON-LD]]. The JSON-LD context presen
     "sourceDateEnd": {"@id": "oa:sourceDateEnd", "@type": "xsd:dateTime"},
 
     "start":         {"@id": "oa:start", "@type": "xsd:nonNegativeInteger"},
-    "end":           "oa:end", "@type": "xsd:nonNegativeInteger"},
+    "end":           {"@id": "oa:end", "@type": "xsd:nonNegativeInteger"},
     "total":         {"@id": "as:totalItems", "@type": "xsd:nonNegativeInteger"},
     "startIndex":    {"@id": "as:startIndex", "@type": "xsd:nonNegativeInteger"}
   }
 }
-
 </pre>
 </section>
 

--- a/vocab/wd/index.html
+++ b/vocab/wd/index.html
@@ -1,411 +1,617 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr" typeof="bibo:Document w3p:WD" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
-<head><meta property="dc:language" content="en" lang="">
-    <title>Web Annotation Vocabulary</title>
-    <meta charset="utf-8">
-    <style>
+<head>
+  <meta lang="" property="dc:language" content="en">
+  <style>
+    /*
 
-.model {
- empty-cells: show;
- border-collapse: collapse;
- margin-bottom: .5ex;
- border: 1px solid black;
- width: 100%;
-}
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
-.model th {
- padding: 3px;
- border: 1px solid #404040;
- text-align: center;
- font-weight: bold;
- font-family: sans-serif;
-}
-
-.model td {
- padding: 5px;
- border: 1px solid #404040;
- text-align: left;
- font-family: sans-serif;
-}
-
-.termtoc {
-  border: 1px dashed black;
-  background: #f0f0f0;
-  margin-left: 10px;
-  margin-bottom: 10px;
-  font-family: sans-serif;
-  padding: 5px;
-}
-
-.term {
-  border: 1px solid black;
-  margin-left: 10px;
-  padding: 5px;
-  margin-bottom: 5px;
-}
-
-.term h4 {
-  font-family: sans-serif;
-  color: #6060C0;
-  padding-left: 10px;
-  padding-bottom: 5px;
-  border-bottom: 1px solid black;
-}
-
-.tech {
-  border-top: 1px dashed black;
-  border-bottom: 1px dashed black;
-  background: #f0f0f0;
-  margin: 5px;
-}
-
-.example-padding {
-  padding-top: 5px;
-  padding-bottom: 5px;
-}
-
-.tech ul {
-  padding-left: 10px;
-}
-
-.tech ul li {
-  list-style: none;
-  padding-bottom: 2px;
-  padding-left: 0px;
-  margin-left: 0px;
-}
-
-.tech ul li {
-  font-family: sans-serif;
-  font-weight: normal;
-
-}
-
-.diagram_img {
-  text-align: center;
-}
-
-      </style>
-      
-      
-    <style>/*****************************************************************
+*/
+    
+    .hljs {
+      display: block;
+      overflow-x: auto;
+      padding: 0.5em;
+      color: #333;
+      background: #f8f8f8;
+      -webkit-text-size-adjust: none;
+    }
+    
+    .hljs-comment,
+    .diff .hljs-header {
+      color: #998;
+      font-style: italic;
+    }
+    
+    .hljs-keyword,
+    .css .rule .hljs-keyword,
+    .hljs-winutils,
+    .nginx .hljs-title,
+    .hljs-subst,
+    .hljs-request,
+    .hljs-status {
+      color: #333;
+      font-weight: bold;
+    }
+    
+    .hljs-number,
+    .hljs-hexcolor,
+    .ruby .hljs-constant {
+      color: #008080;
+    }
+    
+    .hljs-string,
+    .hljs-tag .hljs-value,
+    .hljs-doctag,
+    .tex .hljs-formula {
+      color: #d14;
+    }
+    
+    .hljs-title,
+    .hljs-id,
+    .scss .hljs-preprocessor {
+      color: #900;
+      font-weight: bold;
+    }
+    
+    .hljs-list .hljs-keyword,
+    .hljs-subst {
+      font-weight: normal;
+    }
+    
+    .hljs-class .hljs-title,
+    .hljs-type,
+    .vhdl .hljs-literal,
+    .tex .hljs-command {
+      color: #458;
+      font-weight: bold;
+    }
+    
+    .hljs-tag,
+    .hljs-tag .hljs-title,
+    .hljs-rule .hljs-property,
+    .django .hljs-tag .hljs-keyword {
+      color: #000080;
+      font-weight: normal;
+    }
+    
+    .hljs-attribute,
+    .hljs-variable,
+    .lisp .hljs-body,
+    .hljs-name {
+      color: #008080;
+    }
+    
+    .hljs-regexp {
+      color: #009926;
+    }
+    
+    .hljs-symbol,
+    .ruby .hljs-symbol .hljs-string,
+    .lisp .hljs-keyword,
+    .clojure .hljs-keyword,
+    .scheme .hljs-keyword,
+    .tex .hljs-special,
+    .hljs-prompt {
+      color: #990073;
+    }
+    
+    .hljs-built_in {
+      color: #0086b3;
+    }
+    
+    .hljs-preprocessor,
+    .hljs-pragma,
+    .hljs-pi,
+    .hljs-doctype,
+    .hljs-shebang,
+    .hljs-cdata {
+      color: #999;
+      font-weight: bold;
+    }
+    
+    .hljs-deletion {
+      background: #fdd;
+    }
+    
+    .hljs-addition {
+      background: #dfd;
+    }
+    
+    .diff .hljs-change {
+      background: #0086b3;
+    }
+    
+    .hljs-chunk {
+      color: #aaa;
+    }
+  </style>
+  <style id="respec-mainstyle">
+    /*****************************************************************
  * ReSpec 3 CSS
  * Robin Berjon - http://berjon.com/
  *****************************************************************/
-
-/* Override code highlighter background */
-.hljs {
-    background: transparent !important;
-}
-
-/* --- INLINES --- */
-em.rfc2119 {
-    text-transform:     lowercase;
-    font-variant:       small-caps;
-    font-style:         normal;
-    color:              #900;
-}
-
-h1 acronym, h2 acronym, h3 acronym, h4 acronym, h5 acronym, h6 acronym, a acronym,
-h1 abbr, h2 abbr, h3 abbr, h4 abbr, h5 abbr, h6 abbr, a abbr {
-    border: none;
-}
-
-dfn {
-    font-weight:    bold;
-}
-
-a.internalDFN {
-    color:  inherit;
-    border-bottom:  1px solid #99c;
-    text-decoration:    none;
-}
-
-a.externalDFN {
-    color:  inherit;
-    border-bottom:  1px dotted #ccc;
-    text-decoration:    none;
-}
-
-a.bibref {
-    text-decoration:    none;
-}
-
-cite .bibref {
-    font-style: normal;
-}
-
-code {
-    color:  #C83500;
-}
-
-/* --- TOC --- */
-.toc a, .tof a {
-    text-decoration:    none;
-}
-
-a .secno, a .figno {
-    color:  #000;
-}
-
-ul.tof, ol.tof {
-    list-style: none outside none;
-}
-
-.caption {
-    margin-top: 0.5em;
-    font-style:   italic;
-}
-
-/* --- TABLE --- */
-table.simple {
-    border-spacing: 0;
-    border-collapse:    collapse;
-    border-bottom:  3px solid #005a9c;
-}
-
-.simple th {
-    background: #005a9c;
-    color:  #fff;
-    padding:    3px 5px;
-    text-align: left;
-}
-
-.simple th[scope="row"] {
-    background: inherit;
-    color:  inherit;
-    border-top: 1px solid #ddd;
-}
-
-.simple td {
-    padding:    3px 10px;
-    border-top: 1px solid #ddd;
-}
-
-.simple tr:nth-child(even) {
-    background: #f0f6ff;
-}
-
-/* --- DL --- */
-.section dd > p:first-child {
-    margin-top: 0;
-}
-
-.section dd > p:last-child {
-    margin-bottom: 0;
-}
-
-.section dd {
-    margin-bottom:  1em;
-}
-
-.section dl.attrs dd, .section dl.eldef dd {
-    margin-bottom:  0;
-}
-
-.respec-hidden {
-    display: none;
-}
-
-@media print {
-    .removeOnSave {
+    /* Override code highlighter background */
+    
+    .hljs {
+      background: transparent !important;
+    }
+    /* --- INLINES --- */
+    
+    em.rfc2119 {
+      text-transform: lowercase;
+      font-variant: small-caps;
+      font-style: normal;
+      color: #900;
+    }
+    
+    h1 acronym,
+    h2 acronym,
+    h3 acronym,
+    h4 acronym,
+    h5 acronym,
+    h6 acronym,
+    a acronym,
+    h1 abbr,
+    h2 abbr,
+    h3 abbr,
+    h4 abbr,
+    h5 abbr,
+    h6 abbr,
+    a abbr {
+      border: none;
+    }
+    
+    dfn {
+      font-weight: bold;
+    }
+    
+    a.internalDFN {
+      color: inherit;
+      border-bottom: 1px solid #99c;
+      text-decoration: none;
+    }
+    
+    a.externalDFN {
+      color: inherit;
+      border-bottom: 1px dotted #ccc;
+      text-decoration: none;
+    }
+    
+    a.bibref {
+      text-decoration: none;
+    }
+    
+    cite .bibref {
+      font-style: normal;
+    }
+    
+    code {
+      color: #C83500;
+    }
+    /* --- TOC --- */
+    
+    .toc a,
+    .tof a {
+      text-decoration: none;
+    }
+    
+    a .secno,
+    a .figno {
+      color: #000;
+    }
+    
+    ul.tof,
+    ol.tof {
+      list-style: none outside none;
+    }
+    
+    .caption {
+      margin-top: 0.5em;
+      font-style: italic;
+    }
+    /* --- TABLE --- */
+    
+    table.simple {
+      border-spacing: 0;
+      border-collapse: collapse;
+      border-bottom: 3px solid #005a9c;
+    }
+    
+    .simple th {
+      background: #005a9c;
+      color: #fff;
+      padding: 3px 5px;
+      text-align: left;
+    }
+    
+    .simple th[scope="row"] {
+      background: inherit;
+      color: inherit;
+      border-top: 1px solid #ddd;
+    }
+    
+    .simple td {
+      padding: 3px 10px;
+      border-top: 1px solid #ddd;
+    }
+    
+    .simple tr:nth-child(even) {
+      background: #f0f6ff;
+    }
+    /* --- DL --- */
+    
+    .section dd > p:first-child {
+      margin-top: 0;
+    }
+    
+    .section dd > p:last-child {
+      margin-bottom: 0;
+    }
+    
+    .section dd {
+      margin-bottom: 1em;
+    }
+    
+    .section dl.attrs dd,
+    .section dl.eldef dd {
+      margin-bottom: 0;
+    }
+    
+    .respec-hidden {
+      display: none;
+    }
+    
+    @media print {
+      .removeOnSave {
         display: none;
+      }
     }
-}
-</style><meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"><style>/* --- EXAMPLES --- */
-div.example-title {
-    min-width: 7.5em;
-    color: #b9ab2d;
-}
-div.example-title span {
-    text-transform: uppercase;
-}
-aside.example, div.example, div.illegal-example {
-    padding: 0.5em;
-    margin: 1em 0;
-    position: relative;
-    clear: both;
-}
-div.illegal-example { color: red }
-div.illegal-example p { color: black }
-aside.example, div.example {
-    padding: .5em;
-    border-left-width: .5em;
-    border-left-style: solid;
-    border-color: #e0cb52;
-    background: #fcfaee;
-}
-
-aside.example div.example {
-    border-left-width: .1em;
-    border-color: #999;
-    background: #fff;
-}
-aside.example div.example div.example-title {
-    color: #999;
-}
-</style><style>/* --- ISSUES/NOTES --- */
-div.issue-title, div.note-title , div.ednote-title, div.warning-title {
-    padding-right:  1em;
-    min-width: 7.5em;
-    color: #b9ab2d;
-}
-div.issue-title { color: #e05252; }
-div.note-title, div.ednote-title { color: #2b2; }
-div.warning-title { color: #f22; }
-div.issue-title span, div.note-title span, div.ednote-title span, div.warning-title span {
-    text-transform: uppercase;
-}
-div.note, div.issue, div.ednote, div.warning {
-    margin-top: 1em;
-    margin-bottom: 1em;
-}
-.note > p:first-child, .ednote > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
-.issue, .note, .ednote, .warning {
-    padding: .5em;
-    border-left-width: .5em;
-    border-left-style: solid;
-}
-div.issue, div.note , div.ednote,  div.warning {
-    padding: 1em 1.2em 0.5em;
-    margin: 1em 0;
-    position: relative;
-    clear: both;
-}
-span.note, span.ednote, span.issue, span.warning { padding: .1em .5em .15em; }
-
-.issue {
-    border-color: #e05252;
-    background: #fbe9e9;
-}
-.note, .ednote {
-    border-color: #52e052;
-    background: #e9fbe9;
-}
-
-.warning {
-    border-color: #f11;
-    border-width: .2em;
-    border-style: solid;
-    background: #fbe9e9;
-}
-
-.warning-title:before{
-    content: "⚠"; /*U+26A0 WARNING SIGN*/
-    font-size: 3em;
-    float: left;
-    height: 100%;
-    padding-right: .3em;
-    vertical-align: top;
-    margin-top: -0.5em;
-}
-
-li.task-list-item {
-    list-style: none;
-}
-
-input.task-list-item-checkbox {
-    margin: 0 0.35em 0.25em -1.6em;
-    vertical-align: middle;
-}
-</style><style>/* HIGHLIGHTS */
-code.prettyprint {
-    color:  inherit;
-}
-
-/* this from google-code-prettify */
-.pln{color:#000}@media screen{.str{color:#080}.kwd{color:#008}.com{color:#800}.typ{color:#606}.lit{color:#066}.pun,.opn,.clo{color:#660}.tag{color:#008}.atn{color:#606}.atv{color:#080}.dec,.var{color:#606}.fun{color:red}}@media print,projection{.str{color:#060}.kwd{color:#006;font-weight:bold}.com{color:#600;font-style:italic}.typ{color:#404;font-weight:bold}.lit{color:#044}.pun,.opn,.clo{color:#440}.tag{color:#006;font-weight:bold}.atn{color:#404}.atv{color:#060}}ol.linenums{margin-top:0;margin-bottom:0}li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8{list-style-type:none}li.L1,li.L3,li.L5,li.L7,li.L9{background:#eee}
-</style><link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script type="application/json" id="initialUserConfig">{
-  "specStatus": "WD",
-  "shortName": "annotation-vocab",
-  "editors": [
-    {
-      "name": "Robert Sanderson",
-      "url": "http://www.stanford.edu/~azaroth/",
-      "company": "Stanford University",
-      "companyURL": "http://www.stanford.edu/",
-      "mailto": "azaroth42@gmail.com"
-    },
-    {
-      "name": "Paolo Ciccarese",
-      "url": "http://www.paolociccarese.info",
-      "company": "Massachusetts General Hospital",
-      "companyUrl": "",
-      "mailto": "paolo.ciccarese@gmail.com "
-    },
-    {
-      "name": "Benjamin Young",
-      "url": "http://bigbluehat.com/",
-      "company": "Invited Expert",
-      "companyURL": "",
-      "mailto": "byoung@bigbluehat.com"
+  </style>
+  <title>Web Annotation Vocabulary</title>
+  <meta charset="utf-8">
+  <style>
+    .model {
+      empty-cells: show;
+      border-collapse: collapse;
+      margin-bottom: .5ex;
+      border: 1px solid black;
+      width: 100%;
     }
-  ],
-  "previousMaturity": "WD",
-  "previousPublishDate": "2015-10-15",
-  "previousURI": "http://www.w3.org/TR/2015/WD-annotation-model-20151015/",
-  "publishDate": "2016-03-31",
-  "edDraftURI": "http://w3c.github.io/web-annotation/",
-  "wg": "Web Annotation Working Group",
-  "wgURI": "http://www.w3.org/annotation/",
-  "wgPublicList": "public-annotation",
-  "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/73180/status",
-  "localBiblio": {
-    "json-ld-framing": {
-      "title": "JSON-LD Framing 1.0",
-      "href": "http://json-ld.org/spec/latest/json-ld-framing/",
-      "publisher": "W3C JSON-LD Community Group",
-      "rawDate": "2016-03-01"
-    },
-    "exif": {
-      "title": "Exif Vocabulary Workspace - RDF Schema",
-      "author": "M. Kanzaki",
-      "href": "https://www.w3.org/2003/12/exif/",
-      "publisher": "W3C",
-      "rawDate": "2004-02-16"
-    },
-    "annotation-model": {
-      "authors": [
-        "Robert Sanderson",
-        "Paolo Ciccarese",
-        "Benjamin Young"
-      ],
-      "title": "Web Annotation Data Model",
-      "href": "http://www.w3.org/TR/2016/WD-annotation-model-20160331/",
-      "publisher": "W3C",
-      "rawDate": "2016-03-31",
-      "status": "WD"
-    },
-    "annotation-protocol": {
-      "authors": [
-        "Robert Sanderson"
-      ],
-      "title": "Web Annotation Protocol",
-      "href": "http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/",
-      "publisher": "W3C",
-      "rawDate": "2016-03-31",
-      "status": "WD"
+    
+    .model th {
+      padding: 3px;
+      border: 1px solid #404040;
+      text-align: center;
+      font-weight: bold;
+      font-family: sans-serif;
     }
-  },
-  "otherLinks": [
+    
+    .model td {
+      padding: 5px;
+      border: 1px solid #404040;
+      text-align: left;
+      font-family: sans-serif;
+    }
+    
+    .termtoc {
+      border: 1px dashed black;
+      background: #f0f0f0;
+      margin-left: 10px;
+      margin-bottom: 10px;
+      font-family: sans-serif;
+      padding: 5px;
+    }
+    
+    .term {
+      border: 1px solid black;
+      margin-left: 10px;
+      padding: 5px;
+      margin-bottom: 5px;
+    }
+    
+    .term h4 {
+      font-family: sans-serif;
+      color: #6060C0;
+      padding-left: 10px;
+      padding-bottom: 5px;
+      border-bottom: 1px solid black;
+    }
+    
+    .tech {
+      border-top: 1px dashed black;
+      border-bottom: 1px dashed black;
+      background: #f0f0f0;
+      margin: 5px;
+    }
+    
+    .example-padding {
+      padding-top: 5px;
+      padding-bottom: 5px;
+    }
+    
+    .tech ul {
+      padding-left: 10px;
+    }
+    
+    .tech ul li {
+      list-style: none;
+      padding-bottom: 2px;
+      padding-left: 0px;
+      margin-left: 0px;
+    }
+    
+    .tech ul li {
+      font-family: sans-serif;
+      font-weight: normal;
+    }
+    
+    .diagram_img {
+      text-align: center;
+    }
+  </style>
+
+
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style>
+    /* --- EXAMPLES --- */
+    
+    div.example-title {
+      min-width: 7.5em;
+      color: #b9ab2d;
+    }
+    
+    div.example-title span {
+      text-transform: uppercase;
+    }
+    
+    aside.example,
+    div.example,
+    div.illegal-example {
+      padding: 0.5em;
+      margin: 1em 0;
+      position: relative;
+      clear: both;
+    }
+    
+    div.illegal-example {
+      color: red
+    }
+    
+    div.illegal-example p {
+      color: black
+    }
+    
+    aside.example,
+    div.example {
+      padding: .5em;
+      border-left-width: .5em;
+      border-left-style: solid;
+      border-color: #e0cb52;
+      background: #fcfaee;
+    }
+    
+    aside.example div.example {
+      border-left-width: .1em;
+      border-color: #999;
+      background: #fff;
+    }
+    
+    aside.example div.example div.example-title {
+      color: #999;
+    }
+  </style>
+  <style>
+    /* --- ISSUES/NOTES --- */
+    
+    div.issue-title,
+    div.note-title,
+    div.ednote-title,
+    div.warning-title {
+      padding-right: 1em;
+      min-width: 7.5em;
+      color: #b9ab2d;
+    }
+    
+    div.issue-title {
+      color: #e05252;
+    }
+    
+    div.note-title,
+    div.ednote-title {
+      color: #2b2;
+    }
+    
+    div.warning-title {
+      color: #f22;
+    }
+    
+    div.issue-title span,
+    div.note-title span,
+    div.ednote-title span,
+    div.warning-title span {
+      text-transform: uppercase;
+    }
+    
+    div.note,
+    div.issue,
+    div.ednote,
+    div.warning {
+      margin-top: 1em;
+      margin-bottom: 1em;
+    }
+    
+    .note > p:first-child,
+    .ednote > p:first-child,
+    .issue > p:first-child,
+    .warning > p:first-child {
+      margin-top: 0
+    }
+    
+    .issue,
+    .note,
+    .ednote,
+    .warning {
+      padding: .5em;
+      border-left-width: .5em;
+      border-left-style: solid;
+    }
+    
+    div.issue,
+    div.note,
+    div.ednote,
+    div.warning {
+      padding: 1em 1.2em 0.5em;
+      margin: 1em 0;
+      position: relative;
+      clear: both;
+    }
+    
+    span.note,
+    span.ednote,
+    span.issue,
+    span.warning {
+      padding: .1em .5em .15em;
+    }
+    
+    .issue {
+      border-color: #e05252;
+      background: #fbe9e9;
+    }
+    
+    .note,
+    .ednote {
+      border-color: #52e052;
+      background: #e9fbe9;
+    }
+    
+    .warning {
+      border-color: #f11;
+      border-width: .2em;
+      border-style: solid;
+      background: #fbe9e9;
+    }
+    
+    .warning-title:before {
+      content: "⚠";
+      /*U+26A0 WARNING SIGN*/
+      font-size: 3em;
+      float: left;
+      height: 100%;
+      padding-right: .3em;
+      vertical-align: top;
+      margin-top: -0.5em;
+    }
+    
+    li.task-list-item {
+      list-style: none;
+    }
+    
+    input.task-list-item-checkbox {
+      margin: 0 0.35em 0.25em -1.6em;
+      vertical-align: middle;
+    }
+  </style>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD">
+  <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
+  <script id="initialUserConfig" type="application/json">
     {
-      "key": "Repository",
-      "data": [
+      "specStatus": "WD",
+      "shortName": "annotation-vocab",
+      "editors": [
+      {
+        "name": "Robert Sanderson",
+        "url": "http://www.stanford.edu/~azaroth/",
+        "company": "Stanford University",
+        "companyURL": "http://www.stanford.edu/",
+        "mailto": "azaroth42@gmail.com"
+      },
+      {
+        "name": "Paolo Ciccarese",
+        "url": "http://www.paolociccarese.info",
+        "company": "Massachusetts General Hospital",
+        "companyUrl": "",
+        "mailto": "paolo.ciccarese@gmail.com "
+      },
+      {
+        "name": "Benjamin Young",
+        "url": "http://bigbluehat.com/",
+        "company": "Invited Expert",
+        "companyURL": "",
+        "mailto": "byoung@bigbluehat.com"
+      }],
+      "previousMaturity": "WD",
+      "previousPublishDate": "2015-10-15",
+      "previousURI": "http://www.w3.org/TR/2015/WD-annotation-model-20151015/",
+      "publishDate": "2016-03-31",
+      "edDraftURI": "http://w3c.github.io/web-annotation/",
+      "wg": "Web Annotation Working Group",
+      "wgURI": "http://www.w3.org/annotation/",
+      "wgPublicList": "public-annotation",
+      "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/73180/status",
+      "localBiblio":
+      {
+        "json-ld-framing":
+        {
+          "title": "JSON-LD Framing 1.0",
+          "href": "http://json-ld.org/spec/latest/json-ld-framing/",
+          "publisher": "W3C JSON-LD Community Group",
+          "rawDate": "2016-03-01"
+        },
+        "exif":
+        {
+          "title": "Exif Vocabulary Workspace - RDF Schema",
+          "author": "M. Kanzaki",
+          "href": "https://www.w3.org/2003/12/exif/",
+          "publisher": "W3C",
+          "rawDate": "2004-02-16"
+        },
+        "annotation-model":
+        {
+          "authors": [
+            "Robert Sanderson",
+            "Paolo Ciccarese",
+            "Benjamin Young"
+          ],
+          "title": "Web Annotation Data Model",
+          "href": "http://www.w3.org/TR/2016/WD-annotation-model-20160331/",
+          "publisher": "W3C",
+          "rawDate": "2016-03-31",
+          "status": "WD"
+        },
+        "annotation-protocol":
+        {
+          "authors": [
+            "Robert Sanderson"
+          ],
+          "title": "Web Annotation Protocol",
+          "href": "http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/",
+          "publisher": "W3C",
+          "rawDate": "2016-03-31",
+          "status": "WD"
+        }
+      },
+      "otherLinks": [
+      {
+        "key": "Repository",
+        "data": [
         {
           "value": "Github Repository",
           "href": "https://github.com/w3c/web-annotation"
-        }
-      ]
+        }]
+      }]
     }
-  ]
-}</script></head>
-    <body id="respecDocument" role="document" class="h-entry toc-inline"><div id="respecHeader" role="contentinfo" class="head">
-  <p>
-            <a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C" height="48" width="72"></a>
-  </p>
-  <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Vocabulary</h1>
-  <h2 id="w3c-working-draft-31-march-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-03-31">31 March 2016</time></h2>
-  <dl>
+  </script>
+</head>
+<body class="h-entry" role="document" id="respecDocument">
+  <div class="head" role="contentinfo" id="respecHeader">
+    <p>
+      <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
+    </p>
+    <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Vocabulary</h1>
+    <h2 id="w3c-working-draft-31-march-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-03-31">31 March 2016</time></h2>
+    <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/">http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/</a></dd>
       <dt>Latest published version:</dt>
@@ -414,2537 +620,3076 @@ code.prettyprint {
       <dd><a href="http://w3c.github.io/web-annotation/">http://w3c.github.io/web-annotation/</a></dd>
       <dt>Previous version:</dt>
       <dd><a rel="dcterms:replaces" href="http://www.w3.org/TR/2015/WD-annotation-vocab-20151015/">http://www.w3.org/TR/2015/WD-annotation-vocab-20151015/</a></dd>
-    <dt>Editors:</dt>
-    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Robert Sanderson"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.stanford.edu/~azaroth/">Robert Sanderson</a>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
-<span property="rdf:rest" resource="_:editor1"></span>
-</dd>
-<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Paolo Ciccarese"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.paolociccarese.info">Paolo Ciccarese</a>, Massachusetts General Hospital, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:paolo.ciccarese@gmail.com ">paolo.ciccarese@gmail.com </a></span></span>
-<span property="rdf:rest" resource="_:editor2"></span>
-</dd>
-<dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Benjamin Young"><a class="u-url url p-name fn" property="foaf:homepage" href="http://bigbluehat.com/">Benjamin Young</a>, Invited Expert, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:byoung@bigbluehat.com">byoung@bigbluehat.com</a></span></span>
-<span property="rdf:rest" resource="rdf:nil"></span>
-</dd>
+      <dt>Editors:</dt>
+      <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Robert Sanderson"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.stanford.edu/~azaroth/">Robert Sanderson</a>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
+        <span property="rdf:rest" resource="_:editor1"></span>
+      </dd>
+      <dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Paolo Ciccarese"><a class="u-url url p-name fn" property="foaf:homepage" href="http://www.paolociccarese.info">Paolo Ciccarese</a>, Massachusetts General Hospital, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:paolo.ciccarese@gmail.com ">paolo.ciccarese@gmail.com </a></span></span>
+        <span property="rdf:rest" resource="_:editor2"></span>
+      </dd>
+      <dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><meta property="foaf:name" content="Benjamin Young"><a class="u-url url p-name fn" property="foaf:homepage" href="http://bigbluehat.com/">Benjamin Young</a>, Invited Expert, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:byoung@bigbluehat.com">byoung@bigbluehat.com</a></span></span>
+        <span property="rdf:rest" resource="rdf:nil"></span>
+      </dd>
 
-          <dt>Repository:</dt>
-                  <dd>
-                    <a href="https://github.com/w3c/web-annotation">
+      <dt>Repository:</dt>
+      <dd>
+        <a href="https://github.com/w3c/web-annotation">
                       Github Repository
                     </a>
-                  </dd>
-  </dl>
-      <p class="copyright">
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2016
-        
-        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
-        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). 
-        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
-        rules apply.
+      </dd>
+    </dl>
+    <p class="copyright">
+      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016
+
+      <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (
+      <a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+      <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+      <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+      <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+    </p>
+    <hr title="Separator for header">
+  </div>
+
+
+  <section id="abstract" class="introductory" property="dc:abstract">
+    <h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+
+    <p>The Web Annotation Vocabulary specifies the set of RDF classes, predicates and named entities that are used by the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>]. It also lists recommended terms from other ontologies that are used in the model, and provides the JSON-LD Context and profile definitions needed to use the Web Annotation JSON serialization in a Linked Data context.</p>
+
+  </section>
+
+  <section id="sotd" class="introductory">
+    <h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+    <p>
+      <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
+    </p>
+
+    <p>
+      <b>This is a work in progress. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future. If you feel something should be covered, please <a href="mailto:public-annotation@w3.org">tell us!</a></b>
+    </p>
+
+    <div class="note">
+      <div class="note-title marker" aria-level="3" role="heading" id="h-note1"><span>Note</span></div>
+      <div class="">
+        The content of this document, along with the latest release of the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>] specification, is the result of the split of the <a href="https://www.w3.org/TR/2015/WD-annotation-model-20151015/">previous release</a> of the Web Annotation Data Model Working Draft into two documents.
+      </div>
+    </div>
+
+    <div class="issue" id="issue-1">
+      <div class="issue-title marker" aria-level="3" role="heading" id="h-issue1"><span>Issue 1</span></div>
+      <p class="">
+        The use of the ActivityStreams terms are considered to be at-risk pending [<cite><a class="bibref" href="#bib-activitystreams-vocabulary">activitystreams-vocabulary</a></cite>] reaching Candidate Recommendation.
       </p>
-  <hr title="Separator for header">
-</div>
+    </div>
 
 
-<section property="dc:abstract" class="introductory" id="abstract"><h2 resource="#h-abstract" id="h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
-
-<p>The Web Annotation Vocabulary specifies the set of RDF classes, predicates and named entities that are used by the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].  It also lists recommended terms from other ontologies that are used in the model, and provides the JSON-LD Context and profile definitions needed to use the Web Annotation JSON serialization in a Linked Data context.</p>
-
-</section><section id="sotd" class="introductory"><h2 resource="#h-sotd" id="h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
-        <p>
-          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
-        </p>
-          
-<p>
-  <b>This is a work in progress. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future. If you feel something should be covered, please <a href="mailto:public-annotation@w3.org">tell us!</a></b>
-</p>
-
-<div class="note"><div id="h-note1" role="heading" aria-level="3" class="note-title marker"><span>Note</span></div><div class="">
-  The content of this document, along with the latest release of the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>] specification, is the result of the split of the <a href="https://www.w3.org/TR/2015/WD-annotation-model-20151015/">previous release</a> of the  Web Annotation Data Model Working Draft into two documents.
-</div></div>
-
-<div id="issue-1" class="issue"><div id="h-issue1" role="heading" aria-level="3" class="issue-title marker"><span>Issue 1</span></div><p class="">
-The use of the W3CDTF format, instead of the more restrictive but more common xsd:datetime format, is considered to be at-risk.
-</p></div>
-
-<div id="issue-2" class="issue"><div id="h-issue2" role="heading" aria-level="3" class="issue-title marker"><span>Issue 2</span></div><p class="">
-The use of the ActivityStreams terms are considered to be at-risk pending [<cite><a href="#bib-activitystreams-vocabulary" class="bibref">activitystreams-vocabulary</a></cite>] reaching Candidate Recommendation.
-</p></div>
-
-
-          <p>
-            This document was published by the <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> as a Working Draft.
-              This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
-              If you wish to make comments regarding this document, please send them to
-              <a href="mailto:public-annotation@w3.org">public-annotation@w3.org</a>
-              (<a href="mailto:public-annotation-request@w3.org?subject=subscribe">subscribe</a>,
-              <a href="http://lists.w3.org/Archives/Public/public-annotation/">archives</a>).
-            
-              All comments are welcome.
-          </p>
-            <p>
-              Publication as a Working Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
-              Membership. This is a draft document and may be updated, replaced or obsoleted by other
-              documents at any time. It is inappropriate to cite this document as other than work in
-              progress.
-            </p>
-          <p>
-              This document was produced by
-              a group
-               operating under the
-              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+    <p>
+      This document was published by the <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> as a Working Draft. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation. If you wish to make comments regarding this document, please send them to
+      <a href="mailto:public-annotation@w3.org">public-annotation@w3.org</a> (
+      <a href="mailto:public-annotation-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="http://lists.w3.org/Archives/Public/public-annotation/">archives</a>). All comments are welcome.
+    </p>
+    <p>
+      Publication as a Working Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.
+    </p>
+    <p>
+      This document was produced by a group operating under the
+      <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
               Policy</a>.
-                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/73180/status" rel="disclosure">public list of any patent
-                disclosures</a>
-              made in connection with the deliverables of
-              the group; that page also includes
-              instructions for disclosing a patent. An individual who has actual knowledge of a patent
-              which the individual believes contains
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+      <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/73180/status" rel="disclosure">public list of any patent
+                disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
               Claim(s)</a> must disclose the information in accordance with
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
               6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-          </p>
-            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
-            </p>
-          
-</section><nav id="toc"><h2 resource="#table-of-contents" id="table-of-contents" class="introductory"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul role="directory" class="toc"><li class="tocline"><a class="tocxref" href="#introduction"><span class="secno">1. </span>Introduction</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#namespaces"><span class="secno">1.1 </span>Namespaces</a></li><li class="tocline"><a class="tocxref" href="#diagrams-and-examples"><span class="secno">1.2 </span>Diagrams and Examples</a></li><li class="tocline"><a class="tocxref" href="#conformance"><span class="secno">1.3 </span>Conformance</a></li></ul></li><li class="tocline"><a class="tocxref" href="#web-annotation-ontology"><span class="secno">2. </span>Web Annotation Ontology</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#classes"><span class="secno">2.1 </span>Classes</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#annotation"><span class="secno">2.1.1 </span>Annotation</a></li><li class="tocline"><a class="tocxref" href="#choice"><span class="secno">2.1.2 </span>Choice</a></li><li class="tocline"><a class="tocxref" href="#composite"><span class="secno">2.1.3 </span>Composite</a></li><li class="tocline"><a class="tocxref" href="#cssselector"><span class="secno">2.1.4 </span>CssSelector</a></li><li class="tocline"><a class="tocxref" href="#cssstyle"><span class="secno">2.1.5 </span>CssStyle</a></li><li class="tocline"><a class="tocxref" href="#datapositionselector"><span class="secno">2.1.6 </span>DataPositionSelector</a></li><li class="tocline"><a class="tocxref" href="#fragmentselector"><span class="secno">2.1.7 </span>FragmentSelector</a></li><li class="tocline"><a class="tocxref" href="#httprequeststate"><span class="secno">2.1.8 </span>HttpRequestState</a></li><li class="tocline"><a class="tocxref" href="#independents"><span class="secno">2.1.9 </span>Independents</a></li><li class="tocline"><a class="tocxref" href="#list"><span class="secno">2.1.10 </span>List</a></li><li class="tocline"><a class="tocxref" href="#motivation"><span class="secno">2.1.11 </span>Motivation</a></li><li class="tocline"><a class="tocxref" href="#rangeselector"><span class="secno">2.1.12 </span>RangeSelector</a></li><li class="tocline"><a class="tocxref" href="#resourceselection"><span class="secno">2.1.13 </span>ResourceSelection</a></li><li class="tocline"><a class="tocxref" href="#selector"><span class="secno">2.1.14 </span>Selector</a></li><li class="tocline"><a class="tocxref" href="#specificresource"><span class="secno">2.1.15 </span>SpecificResource</a></li><li class="tocline"><a class="tocxref" href="#state"><span class="secno">2.1.16 </span>State</a></li><li class="tocline"><a class="tocxref" href="#style"><span class="secno">2.1.17 </span>Style</a></li><li class="tocline"><a class="tocxref" href="#svgselector"><span class="secno">2.1.18 </span>SvgSelector</a></li><li class="tocline"><a class="tocxref" href="#textpositionselector"><span class="secno">2.1.19 </span>TextPositionSelector</a></li><li class="tocline"><a class="tocxref" href="#textquoteselector"><span class="secno">2.1.20 </span>TextQuoteSelector</a></li><li class="tocline"><a class="tocxref" href="#textualbody"><span class="secno">2.1.21 </span>TextualBody</a></li><li class="tocline"><a class="tocxref" href="#timestate"><span class="secno">2.1.22 </span>TimeState</a></li><li class="tocline"><a class="tocxref" href="#xpathselector"><span class="secno">2.1.23 </span>XPathSelector</a></li></ul></li><li class="tocline"><a class="tocxref" href="#properties"><span class="secno">2.2 </span>Properties</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#annotationservice"><span class="secno">2.2.1 </span>annotationService</a></li><li class="tocline"><a class="tocxref" href="#bodyvalue"><span class="secno">2.2.2 </span>bodyValue</a></li><li class="tocline"><a class="tocxref" href="#cachedsource"><span class="secno">2.2.3 </span>cachedSource</a></li><li class="tocline"><a class="tocxref" href="#canonical"><span class="secno">2.2.4 </span>canonical</a></li><li class="tocline"><a class="tocxref" href="#end"><span class="secno">2.2.5 </span>end</a></li><li class="tocline"><a class="tocxref" href="#exact"><span class="secno">2.2.6 </span>exact</a></li><li class="tocline"><a class="tocxref" href="#hasbody"><span class="secno">2.2.7 </span>hasBody</a></li><li class="tocline"><a class="tocxref" href="#hasendselector"><span class="secno">2.2.8 </span>hasEndSelector</a></li><li class="tocline"><a class="tocxref" href="#haspurpose"><span class="secno">2.2.9 </span>hasPurpose</a></li><li class="tocline"><a class="tocxref" href="#hasscope"><span class="secno">2.2.10 </span>hasScope</a></li><li class="tocline"><a class="tocxref" href="#hasselector"><span class="secno">2.2.11 </span>hasSelector</a></li><li class="tocline"><a class="tocxref" href="#hassource"><span class="secno">2.2.12 </span>hasSource</a></li><li class="tocline"><a class="tocxref" href="#hasstartselector"><span class="secno">2.2.13 </span>hasStartSelector</a></li><li class="tocline"><a class="tocxref" href="#hasstate"><span class="secno">2.2.14 </span>hasState</a></li><li class="tocline"><a class="tocxref" href="#hastarget"><span class="secno">2.2.15 </span>hasTarget</a></li><li class="tocline"><a class="tocxref" href="#motivatedby"><span class="secno">2.2.16 </span>motivatedBy</a></li><li class="tocline"><a class="tocxref" href="#prefix"><span class="secno">2.2.17 </span>prefix</a></li><li class="tocline"><a class="tocxref" href="#refinedby"><span class="secno">2.2.18 </span>refinedBy</a></li><li class="tocline"><a class="tocxref" href="#renderedvia"><span class="secno">2.2.19 </span>renderedVia</a></li><li class="tocline"><a class="tocxref" href="#sourcedate"><span class="secno">2.2.20 </span>sourceDate</a></li><li class="tocline"><a class="tocxref" href="#sourcedateend"><span class="secno">2.2.21 </span>sourceDateEnd</a></li><li class="tocline"><a class="tocxref" href="#sourcedatestart"><span class="secno">2.2.22 </span>sourceDateStart</a></li><li class="tocline"><a class="tocxref" href="#start"><span class="secno">2.2.23 </span>start</a></li><li class="tocline"><a class="tocxref" href="#styleclass"><span class="secno">2.2.24 </span>styleClass</a></li><li class="tocline"><a class="tocxref" href="#styledby"><span class="secno">2.2.25 </span>styledBy</a></li><li class="tocline"><a class="tocxref" href="#suffix"><span class="secno">2.2.26 </span>suffix</a></li><li class="tocline"><a class="tocxref" href="#via"><span class="secno">2.2.27 </span>via</a></li></ul></li><li class="tocline"><a class="tocxref" href="#named-individuals"><span class="secno">2.3 </span>Named Individuals</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#bookmarking"><span class="secno">2.3.1 </span>bookmarking</a></li><li class="tocline"><a class="tocxref" href="#classifying"><span class="secno">2.3.2 </span>classifying</a></li><li class="tocline"><a class="tocxref" href="#commenting"><span class="secno">2.3.3 </span>commenting</a></li><li class="tocline"><a class="tocxref" href="#describing"><span class="secno">2.3.4 </span>describing</a></li><li class="tocline"><a class="tocxref" href="#editing"><span class="secno">2.3.5 </span>editing</a></li><li class="tocline"><a class="tocxref" href="#highlighting"><span class="secno">2.3.6 </span>highlighting</a></li><li class="tocline"><a class="tocxref" href="#identifying"><span class="secno">2.3.7 </span>identifying</a></li><li class="tocline"><a class="tocxref" href="#linking"><span class="secno">2.3.8 </span>linking</a></li><li class="tocline"><a class="tocxref" href="#moderating"><span class="secno">2.3.9 </span>moderating</a></li><li class="tocline"><a class="tocxref" href="#questioning"><span class="secno">2.3.10 </span>questioning</a></li><li class="tocline"><a class="tocxref" href="#replying"><span class="secno">2.3.11 </span>replying</a></li><li class="tocline"><a class="tocxref" href="#reviewing"><span class="secno">2.3.12 </span>reviewing</a></li><li class="tocline"><a class="tocxref" href="#tagging"><span class="secno">2.3.13 </span>tagging</a></li></ul></li></ul></li><li class="tocline"><a class="tocxref" href="#recommended-ontologies"><span class="secno">3. </span>Recommended Ontologies</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#classes-1"><span class="secno">3.1 </span>Classes</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#as-application"><span class="secno">3.1.1 </span>as:Application</a></li><li class="tocline"><a class="tocxref" href="#as-orderedcollection"><span class="secno">3.1.2 </span>as:OrderedCollection</a></li><li class="tocline"><a class="tocxref" href="#as-orderedcollectionpage"><span class="secno">3.1.3 </span>as:OrderedCollectionPage</a></li><li class="tocline"><a class="tocxref" href="#dctypes-dataset"><span class="secno">3.1.4 </span>dctypes:Dataset</a></li><li class="tocline"><a class="tocxref" href="#dctypes-movingimage"><span class="secno">3.1.5 </span>dctypes:MovingImage</a></li><li class="tocline"><a class="tocxref" href="#dctypes-stillimage"><span class="secno">3.1.6 </span>dctypes:StillImage</a></li><li class="tocline"><a class="tocxref" href="#dctypes-sound"><span class="secno">3.1.7 </span>dctypes:Sound</a></li><li class="tocline"><a class="tocxref" href="#dctypes-text"><span class="secno">3.1.8 </span>dctypes:Text</a></li><li class="tocline"><a class="tocxref" href="#foaf-organization"><span class="secno">3.1.9 </span>foaf:Organization</a></li><li class="tocline"><a class="tocxref" href="#foaf-person"><span class="secno">3.1.10 </span>foaf:Person</a></li><li class="tocline"><a class="tocxref" href="#schema-audience"><span class="secno">3.1.11 </span>schema:Audience</a></li></ul></li><li class="tocline"><a class="tocxref" href="#properties-1"><span class="secno">3.2 </span>Properties</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#as-first"><span class="secno">3.2.1 </span>as:first</a></li><li class="tocline"><a class="tocxref" href="#as-generator"><span class="secno">3.2.2 </span>as:generator</a></li><li class="tocline"><a class="tocxref" href="#as-items"><span class="secno">3.2.3 </span>as:items</a></li><li class="tocline"><a class="tocxref" href="#as-last"><span class="secno">3.2.4 </span>as:last</a></li><li class="tocline"><a class="tocxref" href="#as-next"><span class="secno">3.2.5 </span>as:next</a></li><li class="tocline"><a class="tocxref" href="#as-partof"><span class="secno">3.2.6 </span>as:partOf</a></li><li class="tocline"><a class="tocxref" href="#as-prev"><span class="secno">3.2.7 </span>as:prev</a></li><li class="tocline"><a class="tocxref" href="#as-startindex"><span class="secno">3.2.8 </span>as:startIndex</a></li><li class="tocline"><a class="tocxref" href="#as-totalitems"><span class="secno">3.2.9 </span>as:totalItems</a></li><li class="tocline"><a class="tocxref" href="#dc-format"><span class="secno">3.2.10 </span>dc:format</a></li><li class="tocline"><a class="tocxref" href="#dc-language"><span class="secno">3.2.11 </span>dc:language</a></li><li class="tocline"><a class="tocxref" href="#dcterms-conformsto"><span class="secno">3.2.12 </span>dcterms:conformsTo</a></li><li class="tocline"><a class="tocxref" href="#dcterms-created"><span class="secno">3.2.13 </span>dcterms:created</a></li><li class="tocline"><a class="tocxref" href="#dcterms-creator"><span class="secno">3.2.14 </span>dcterms:creator</a></li><li class="tocline"><a class="tocxref" href="#dcterms-issued"><span class="secno">3.2.15 </span>dcterms:issued</a></li><li class="tocline"><a class="tocxref" href="#dcterms-modified"><span class="secno">3.2.16 </span>dcterms:modified</a></li><li class="tocline"><a class="tocxref" href="#dcterms-rights"><span class="secno">3.2.17 </span>dcterms:rights</a></li><li class="tocline"><a class="tocxref" href="#foaf-homepage"><span class="secno">3.2.18 </span>foaf:homepage</a></li><li class="tocline"><a class="tocxref" href="#foaf-mbox"><span class="secno">3.2.19 </span>foaf:mbox</a></li><li class="tocline"><a class="tocxref" href="#foaf-mbox_sha1sum"><span class="secno">3.2.20 </span>foaf:mbox_sha1sum</a></li><li class="tocline"><a class="tocxref" href="#foaf-name"><span class="secno">3.2.21 </span>foaf:name</a></li><li class="tocline"><a class="tocxref" href="#foaf-nick"><span class="secno">3.2.22 </span>foaf:nick</a></li><li class="tocline"><a class="tocxref" href="#rdf-type"><span class="secno">3.2.23 </span>rdf:type</a></li><li class="tocline"><a class="tocxref" href="#rdf-value"><span class="secno">3.2.24 </span>rdf:value</a></li><li class="tocline"><a class="tocxref" href="#rdfs-label"><span class="secno">3.2.25 </span>rdfs:label</a></li><li class="tocline"><a class="tocxref" href="#schema-audience-1"><span class="secno">3.2.26 </span>schema:audience</a></li></ul></li></ul></li><li class="tocline"><a class="tocxref" href="#extensions"><span class="secno">4. </span>Extensions</a></li><li class="tocline"><a class="tocxref" href="#json-ld-context"><span class="secno">A. </span>JSON-LD Context</a></li><li class="tocline"><a class="tocxref" href="#json-ld-frames"><span class="secno">B. </span>JSON-LD Frames</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#annotation-frame"><span class="secno">B.1 </span>Annotation Frame</a></li><li class="tocline"><a class="tocxref" href="#annotation-collection-frame"><span class="secno">B.2 </span>Annotation Collection Frame</a></li><li class="tocline"><a class="tocxref" href="#annotation-page-frame"><span class="secno">B.3 </span>Annotation Page Frame</a></li></ul></li><li class="tocline"><a class="tocxref" href="#extending-motivations"><span class="secno">C. </span>Extending Motivations</a></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><span class="secno">D. </span>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#references"><span class="secno">E. </span>References</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><span class="secno">E.1 </span>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><span class="secno">E.2 </span>Informative references</a></li></ul></li></ul></nav>
-
-
-
-<section property="bibo:hasPart" resource="#introduction" typeof="bibo:Chapter" id="introduction" class="informative">
-<!--OddPage--><h2 resource="#h-introduction" id="h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2><p><em>This section is non-normative.</em></p>
-
-<p>
-The specification is divided into two major sections: the terms defined in the Web Annotation ontology, and terms from other ontologies used in the model.
-</p>
-
-<p>
-Each class lists the recommendations from the model for the <em title="REQUIRED" class="rfc2119">REQUIRED</em>, <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> and <em title="OPTIONAL" class="rfc2119">OPTIONAL</em> object and data properties for instances of the class.  Instances may, of course, be the subject of any other triples that implementers find useful, however there is no expectation of interoperability in these cases.
-</p>
-
-<section property="bibo:hasPart" resource="#namespaces" typeof="bibo:Chapter" id="namespaces">
-  <h3 resource="#h-namespaces" id="h-namespaces"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Namespaces</span></h3>
-
-  <table class="model">
-<tbody><tr><th>Prefix</th><th>Namespace</th><th>Description</th></tr>
-<tr><td>oa</td><td>http://www.w3.org/ns/oa#</td> <td>The Web Annotation Data Model</td></tr>
-<tr><td>as</td><td>http://www.w3.org/ns/activitystreams#</td><td>[<cite><a href="#bib-activitystreams-vocabulary" class="bibref">activitystreams-vocabulary</a></cite>]</td></tr>
-<tr><td>dc</td><td>http://purl.org/dc/elements/1.1/</td><td>[<cite><a href="#bib-DC11" class="bibref">DC11</a></cite>]</td></tr>
-<tr><td>dcterms</td><td>http://purl.org/dc/terms/</td><td>[<cite><a href="#bib-DC-TERMS" class="bibref">DC-TERMS</a></cite>]</td></tr>
-<tr><td>dctypes</td><td>http://purl.org/dc/dcmitype/</td><td>[<cite><a href="#bib-DC-TERMS" class="bibref">DC-TERMS</a></cite>]</td></tr>
-<tr><td>foaf</td><td>http://xmlns.com/foaf/0.1/</td><td>[<cite><a href="#bib-FOAF" class="bibref">FOAF</a></cite>]</td></tr>
-<tr><td>rdf</td><td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td><td>[<cite><a href="#bib-rdf-schema" class="bibref">rdf-schema</a></cite>]</td></tr>
-<tr><td>rdfs</td><td>http://www.w3.org/2000/01/rdf-schema#</td><td>[<cite><a href="#bib-rdf-schema" class="bibref">rdf-schema</a></cite>]</td></tr>
-<tr><td>schema</td><td>http://schema.org/</td><td><a href="http://schema.org/">schema.org</a></td></tr>
-<tr><td>skos</td><td>http://www.w3.org/2004/02/skos/core#</td><td>[<cite><a href="#bib-skos-reference" class="bibref">skos-reference</a></cite>]</td></tr>
-<tr><td>xsd</td><td>http://www.w3.org/2001/XMLSchema#</td><td>[<cite><a href="#bib-xmlschema-2" class="bibref">xmlschema-2</a></cite>]</td></tr>
-</tbody></table>
-
-</section>
-
-<section property="bibo:hasPart" resource="#diagrams-and-examples" typeof="bibo:Chapter" id="diagrams-and-examples">
-<h3 resource="#h-diagrams-and-examples" id="h-diagrams-and-examples"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Diagrams and Examples</span></h3>
-
-<p>
-The examples throughout the document are serialized as [<cite><a href="#bib-Turtle" class="bibref">Turtle</a></cite>] with the prefixes taken from the namespace declarations given in <a href="#namespaces">Appendix A</a>.  The examples are informative only.
-</p>
-
-<p>The diagrams use the following style</p>
-
-<ul>
-<li>Instances are depicted as colored ellipses.</li>
-<li>Instances without a URI are depicted as colored ellipses with double lines.</li>
-<li>Classes are depicted as white rectangles.</li>
-<li>Literals are depicted as white lozenges.</li>
-<li>Relationships and properties are depicted as straight, black lines.</li>
-<li>Class instantiation is depicted as a straight black line with white arrow head.</li>
-<li>Example instance identifiers are lowercase and end in a number.<br>  For example, <code>anno1</code> is a specific instance of an Annotation, whereas <code>Annotation</code> is a class.</li>
-<li>Example literals follow the requirements for the model and, thus, must not be interpreted as the only possible value.</li>
-<li>Lists are depicted as vertical braces with a gray background and '...' in the middle (regardless of if there are actually other items in the list or not).</li>
-<li>Conceptual resource boundaries not explicit in the model, but considered important for understanding, are depicted as grey dashed boxes around the components.  They are used to convey spatial parts of the diagrams and may be safely ignored.</li>
-</ul>
-
-<div id="issue-3" class="issue"><div id="h-issue3" role="heading" aria-level="4" class="issue-title marker"><span>Issue 3</span></div><div class="">
-The diagrams have yet to be completed (<a href="https://github.com/w3c/web-annotation/issues/131">Github Issue</a>).
-</div></div>
-
-</section>
-
-<section property="bibo:hasPart" resource="#conformance" typeof="bibo:Chapter" id="conformance"><h3 resource="#h-conformance" id="h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
-<p>
-  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
-  and notes in this specification are non-normative. Everything else in this specification is
-  normative.
-</p>
-<p id="respecRFC2119">The key words <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="OPTIONAL">OPTIONAL</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="REQUIRED">REQUIRED</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are 
-  to be interpreted as described in [<cite><a href="#bib-RFC2119" class="bibref">RFC2119</a></cite>].
-</p>
-
-</section>
-</section> <!-- End Introduction -->
-
-<section property="bibo:hasPart" resource="#web-annotation-ontology" typeof="bibo:Chapter" id="web-annotation-ontology">
-  <!--OddPage--><h2 resource="#h-web-annotation-ontology" id="h-web-annotation-ontology"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Ontology</span></h2>
-
-The namespace used for the Web Annotation Ontology is:
-<code>http://www.w3.org/ns/oa#</code>
-
-<section property="bibo:hasPart" resource="#classes" typeof="bibo:Chapter" id="classes">
-<h3 resource="#h-classes" id="h-classes"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1 </span>Classes</span></h3>
-
-<div class="termtoc">
-<a href="#annotation">Annotation</a> | <a href="#choice">Choice</a> | <a href="#composite">Composite</a> | <a href="#cssselector">CssSelector</a> | <a href="#cssstyle">CssStyle</a> | <a href="#datapositionselector">DataPositionSelector</a> | <a href="#fragmentselector">FragmentSelector</a> | <a href="#httprequeststate">HttpRequestState</a> | <a href="#independents">Independents</a> | <a href="#list">List</a> | <a href="#motivation">Motivation</a> | <a href="#rangeselector">RangeSelector</a> | <a href="#resourceselection">ResourceSelection</a> | <a href="#selector">Selector</a> | <a href="#specificresource">SpecificResource</a> | <a href="#state">State</a> | <a href="#style">Style</a> | <a href="#svgselector">SvgSelector</a> | <a href="#textpositionselector">TextPositionSelector</a> | <a href="#textquoteselector">TextQuoteSelector</a> | <a href="#textualbody">TextualBody</a> | <a href="#timestate">TimeState</a> | <a href="#xpathselector">XPathSelector</a>
-</div>
-
-<section property="bibo:hasPart" resource="#annotation" typeof="bibo:Chapter" id="annotation" class="term">
-  <h4 resource="#h-annotation" id="h-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.1 </span>Annotation</span></h4>
-  <p>The class for Web Annotations.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Annotation</li>
-      <li><strong>Required Predicates:</strong> <a href="#hastarget">oa:hasTarget</a>, <a href="#rdf-type">rdf:type</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#hasbody">oa:hasBody</a>, <a href="#motivatedby">oa:motivatedBy</a>, <a href="#dcterms-creator">dcterms:creator</a>, <a href="#dcterms-created">dcterms:created</a></li>
-      <li><strong>Other Predicates:</strong> <a href="#bodyvalue">oa:bodyValue</a>, <a href="#styledby">oa:styledBy</a>, <a href="#dcterms-issued">dcterms:issued</a>, <a href="#as-generator">as:generator</a> </li>
-    </ul>
-  </div>
-  <div class="diagram_img">
-    <img src="images/examples/annotation.png" alt="oa:Annotation with properties" longdesc="#example_anno">
-  </div>
-  <div id="example_anno">
-    <div class="example"><div class="example-title marker"><span>Example 1</span><span style="text-transform: none">: oa:Annotation</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">post1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:commenting ;
-    dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">person1</span><span class="tag">&gt;</span><span class="pln"> ;
-    dcterms:created "2015-11-18T12:00:00Z" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#choice" typeof="bibo:Chapter" id="choice" class="term">
-  <h4 resource="#h-choice" id="h-choice"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.2 </span>Choice</span></h4>
-  <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that it should select one of the resources in the <code>as:items</code> list to use, rather than all of them.  This is typically used to provide a choice of resources to render to the user, based on further supplied properties.  If the consuming application cannot determine the user's preference, then it should use the first in the list.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Choice</li>
-      <li><strong>Sub Class Of:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#as-items">as:items</a></li>
-    </ul>
-  </div>
-  <div class="diagram_img">
-    <img src="images/examples/choice.png" alt="oa:Choice with list of items" longdesc="#example_choice">
-  </div>
-  <div id="example_choice">
-    <div class="example"><div class="example-title marker"><span>Example 2</span><span style="text-transform: none">: oa:Choice</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno2</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">site1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasBody [
-        a oa:Choice ;
-        as:items (</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note2</span><span class="tag">&gt;</span><span class="pln">) ] .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> dc:language "en" .
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note2</span><span class="tag">&gt;</span><span class="pln"> dc:language "fr" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#composite" typeof="bibo:Chapter" id="composite" class="term">
-  <h4 resource="#h-composite" id="h-composite"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.3 </span>Composite</span></h4>
-  <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that it should use all of the resources in the <code>as:items</code> list, but that order is not important.</p>
-
-  <div class="warning"><div class="warning-title marker"><span>Warning</span></div><p class="">This class is at-risk.</p></div>
-
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Composite</li>
-      <li><strong>Sub Class Of:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#as-items">as:items</a></li>
-    </ul>
-  </div>
-  <div class="diagram_img">
-    <img src="images/examples/" alt="oa:Composite with list of items" longdesc="#example_composite">
-  </div>
-  <div id="example_composite">
-    <div class="example"><div class="example-title marker"><span>Example 3</span><span style="text-transform: none">: oa:Composite</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno3</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:commenting ;
-    oa:hasBody [ 
-        a oa:TextualBody ; 
-        rdf:value "These pages together provide evidence of the conspiracy" ] ;
-    oa:hasTarget [
-        a oa:Composite ;
-        as:items ( </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page6</span><span class="tag">&gt;</span><span class="pln"> </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page4</span><span class="tag">&gt;</span><span class="pln"> ) ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#cssselector" typeof="bibo:Chapter" id="cssselector" class="term">
-  <h4 resource="#h-cssselector" id="h-cssselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.4 </span>CssSelector</span></h4>
-  <p>A CssSelector describes a Segment of interest in a representation that conforms to the Document Object Model through the use of the CSS selector specification.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#CssSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 4</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno4</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:CssSelector ;
-            rdf:value "#elemid &gt; .elemclass + p" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#cssstyle" typeof="bibo:Chapter" id="cssstyle" class="term">
-  <h4 resource="#h-cssstyle" id="h-cssstyle"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.5 </span>CssStyle</span></h4>
-  <p>A resource which describes styles for resources participating in the Annotation using CSS.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#CssStyle</li>
-      <li><strong>Sub Class Of:</strong> <a href="#style">oa:Style</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 5</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno5</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:styledBy </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">style1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">document1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:styleClass "red" ] .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">style1</span><span class="tag">&gt;</span><span class="pln"> a oa:CssStyle .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#datapositionselector" typeof="bibo:Chapter" id="datapositionselector" class="term">
-  <h4 resource="#h-datapositionselector" id="h-datapositionselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.6 </span>DataPositionSelector</span></h4>
-  <p>DataPositionSelector describes a range of data by recording the start and end positions of the selection in the stream. Position 0 would be immediately before the first byte, position 1 would be immediately before the second byte, and so on. The start byte is thus included in the list, but the end byte is not.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#DataPositionSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-type">rdf:type</a>, <a href="#start">oa:start</a>, <a href="#end">oa:end</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: oa:DataPositionSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno6</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">diskimg1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:DataPositionSelector ;
-            oa:start 4096 ;
-            oa:end 4104 ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#fragmentselector" typeof="bibo:Chapter" id="fragmentselector" class="term">
-  <h4 resource="#h-fragmentselector" id="h-fragmentselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.7 </span>FragmentSelector</span></h4>
-  <p>The FragmentSelector class is used to record the segment of a representation using the URI fragment specification defined by the representation's media type.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#FragmentSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#dcterms-conformsto">dcterms:conformsTo</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: oa:FragmentSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno7</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasBody [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">video1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasPurpose oa:describing ;
-        oa:hasSelector [
-            a oa:FragmentSelector ;
-            dcterms:conformsTo </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">www</span><span class="pln">.</span><span class="atn">w3</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">TR</span><span class="pun">/</span><span class="atn">media-frags</span><span class="tag">/&gt;</span><span class="pln"> ;
-            rdf:value "t=30,60" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#httprequeststate" typeof="bibo:Chapter" id="httprequeststate" class="term">
-  <h4 resource="#h-httprequeststate" id="h-httprequeststate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.8 </span>HttpRequestState</span></h4>
-  <p>The HttpRequestState class is used to record the HTTP request headers that a client <em title="SHOULD" class="rfc2119">SHOULD</em> use to request the correct representation from the resource. </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#HttpRequestState</li>
-      <li><strong>Sub Class Of:</strong> <a href="#state">oa:State</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: oa:HttpRequestState</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno8</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">description1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget  [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">target1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasState [
-            a oa:HttpRequestState ;
-            rdf:value "Accept: application/pdf" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#independents" typeof="bibo:Chapter" id="independents" class="term">
-  <h4 resource="#h-independents" id="h-independents"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.9 </span>Independents</span></h4>
-  <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that each of the resources in the <code>as:items</code> list are independently associated with all of the other bodies or targets.</p>
-
-  <div class="warning"><div class="warning-title marker"><span>Warning</span></div><p class="">This class is at-risk.</p></div>
-
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Independents</li>
-      <li><strong>Sub Class Of:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#as-items">as:items</a></li>
-    </ul>
-  </div>
-  <div class="diagram_img">
-    <img src="images/examples/" alt="oa:Independents with list of items" longdesc="#example_independents">
-  </div>
-  <div id="example_independents">
-    <div class="example"><div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: oa:Independents</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno9</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:classifying ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">vocab</span><span class="pun">/</span><span class="atn">art</span><span class="pun">/</span><span class="atn">portrait</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        a oa:Independents ;
-        as:items (
-          </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln">
-          </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">image2</span><span class="tag">&gt;</span><span class="pln">
-          </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">image4</span><span class="tag">&gt;</span><span class="pln">
-          </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image9</span><span class="tag">&gt;</span><span class="pln">
-        ) ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#list" typeof="bibo:Chapter" id="list" class="term">
-  <h4 resource="#h-list" id="h-list"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.10 </span>List</span></h4>
-  <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that it should use each of the resources in the <code>as:items</code> list, and that their order is important.</p>
-
-<div class="warning"><div class="warning-title marker"><span>Warning</span></div><p class="">This class is at-risk.</p></div>
-
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Independents</li>
-      <li><strong>Sub Class Of:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#as-items">as:items</a></li>
-    </ul>
-  </div>
-  <div class="diagram_img">
-    <img src="images/examples/" alt="oa:List with list of items" longdesc="#example_list">
-  </div>
-  <div id="example_list">
-    <div class="example"><div class="example-title marker"><span>Example 10</span><span style="text-transform: none">: oa:List</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno10</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:tagging ;
-    oa:hasBody [ a oa:TextualBody ; rdf:value "important" ] ;
-    oa:hasTarget [
-        a oa:List ;
-        as:items (
-          </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">book</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln">
-          </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">book</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln">
-          </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">book</span><span class="pun">/</span><span class="atn">page3</span><span class="tag">&gt;</span><span class="pln">
-          </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">book</span><span class="pun">/</span><span class="atn">page4</span><span class="tag">&gt;</span><span class="pln">
-        ) ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#motivation" typeof="bibo:Chapter" id="motivation" class="term">
-  <h4 resource="#h-motivation" id="h-motivation"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.11 </span>Motivation</span></h4>
-  <p>The Motivation class is used to record the user's intent or motivation for the creation of the Annotation, or the inclusion of the body or target, that it is associated with.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Motivation</li>
-      <li><strong>Sub Class Of:</strong> <a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a></li>
-      <li><strong>Range Of:</strong> <a href="#motivatedby">oa:motivatedBy</a>, <a href="#haspurpose">oa:hasPurpose</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 11</span><span style="text-transform: none">: oa:Motivation</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno11</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">description1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:describing .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#rangeselector" typeof="bibo:Chapter" id="rangeselector" class="term">
-  <h4 resource="#h-rangeselector" id="h-rangeselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.12 </span>RangeSelector</span></h4>
-  <p>A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors. The selection consists of everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#RangeSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#hasstartselector">oa:hasStartSelector</a>, <a href="#hasendselector">oa:hasEndSelector</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 12</span><span style="text-transform: none">: oa:RangeSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno12</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-          a oa:RangeSelector ;
-          oa:hasStartSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[2]" ] ;
-          oa:hasEndSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#resourceselection" typeof="bibo:Chapter" id="resourceselection" class="term">
-  <h4 resource="#h-resourceselection" id="h-resourceselection"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.13 </span>ResourceSelection</span></h4>
-  <p>Instances of the ResourceSelection class identify part (described by an oa:Selector) of another resource (referenced with oa:hasSource), possibly from a particular representation of a resource (described by an oa:State). Please note that ResourceSelection is not used directly in the Web Annotation model, but is provided as a separate class for further application profiles to use, separate from oa:SpecificResource which has many Annotation specific features.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#ResourceSelection</li>
-      <li><strong>Required Predicates:</strong> <a href="#hassource">oa:hasSource</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#hasselector">oa:hasSelector</a>, <a href="#hasstate">oa:hasState</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 13</span><span style="text-transform: none">: oa:ResourceSelection</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">cell1</span><span class="tag">&gt;</span><span class="pln"> a oa:ResourceSelection ;
-    oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasSelector [
-      a oa:XPathSelector ;
-      rdf:value "//table[1]/tr[1]/td[4]" ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#selector" typeof="bibo:Chapter" id="selector" class="term">
-  <h4 resource="#h-selector" id="h-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.14 </span>Selector</span></h4>
-  <p>A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. This class is not used directly in the Annotation model, only its subclasses.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Selector</li>
-      <li><strong>Super Class Of:</strong> <a href="#fragmentselector">oa:FragmentSelector</a>, <a href="#textquoteselector">oa:TextQuoteSelector</a>, <a href="#textpositionselector">oa:TextPositionSelector</a>, <a href="#datapositionselector">oa:DataPositionSelector</a>, <a href="#svgselector">oa:SvgSelector</a></li>
-      <li><strong>Range Of:</strong> <a href="#hasselector">oa:hasSelector</a></li>
-    </ul>
-  </div>
-  <div class="note"><div id="h-note2" role="heading" aria-level="5" class="note-title marker"><span>Note</span><span style="text-transform: none">: oa:Selector</span></div><div class="">
-    No example is given. The class should only be used to derive subClasses.
-  </div></div>
-</section>
-
-<section property="bibo:hasPart" resource="#specificresource" typeof="bibo:Chapter" id="specificresource" class="term">
-  <h4 resource="#h-specificresource" id="h-specificresource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.15 </span>SpecificResource</span></h4>
-  <p>Instances of the SpecificResource class identify part of another resource (referenced with oa:hasSource), a particular representation of a resource, a resource with styling hints for renders, or any combination of these, as used within an Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#SpecificResource</li>
-      <li><strong>Sub Class Of:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#hassource">oa:hasSource</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#hasselector">oa:hasSelector</a>, <a href="#hasstate">oa:hasState</a>, <a href="#haspurpose">oa:hasPurpose</a></li>
-      <li><strong>Other Predicates:</strong> <a href="#hasscope">oa:hasScope</a>, <a href="#styleclass">oa:styleClass</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 14</span><span style="text-transform: none">: oa:SpecificResource</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno13</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> a oa:SpecificResource ;
-    oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#state" typeof="bibo:Chapter" id="state" class="term">
-  <h4 resource="#h-state" id="h-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.16 </span>State</span></h4>
-  <p>A State describes the intended state of a resource as applied to the particular Annotation, and thus provides the information needed to retrieve the correct representation of that resource.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#State</li>
-      <li><strong>Super Class Of:</strong> <a href="#httprequeststate">oa:HttpRequestState</a>, <a href="#timestate">oa:TimeState</a></li>
-      <li><strong>Range Of:</strong> <a href="#hasstate">oa:hasState</a></li>
-    </ul>
-  </div>
-  <div class="note"><div id="h-note3" role="heading" aria-level="5" class="note-title marker"><span>Note</span><span style="text-transform: none">: oa:State</span></div><div class="">
-    No example is given. The class should only be used in further ontologies to derive subclasses.
-  </div></div>
-</section>
-
-<section property="bibo:hasPart" resource="#style" typeof="bibo:Chapter" id="style" class="term">
-  <h4 resource="#h-style" id="h-style"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.17 </span>Style</span></h4>
-  <p>A Style describes the intended styling of a resource as applied to the particular Annotation, and thus provides the information ndeed to ensure that rendering is consistent across implementations.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#Style</li>
-      <li><strong>Super Class Of:</strong> <a href="#cssstyle">oa:CssStyle</a></li>
-      <li><strong>Range Of:</strong> <a href="#styledby">oa:styledBy</a></li>
-    </ul>
-  </div>
-  <div class="note"><div id="h-note4" role="heading" aria-level="5" class="note-title marker"><span>Note</span><span style="text-transform: none">: oa:Style</span></div><div class="">
-    No example is given. The class should only be used in further ontologies to derive subclasses.
-  </div></div>
-</section>
-
-<section property="bibo:hasPart" resource="#svgselector" typeof="bibo:Chapter" id="svgselector" class="term">
-  <h4 resource="#h-svgselector" id="h-svgselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.18 </span>SvgSelector</span></h4>
-  <p>An SvgSelector defines an area through the use of the Scalable Vector Graphics [SVG] standard. This allows the user to select a non-rectangular area of the content, such as a circle or polygon by describing the region using SVG. The SVG may be either embedded within the Annotation or referenced as an External Resource.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#SvgSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-type">rdf:type</a></li>
-      <li><strong>Other Predicates:</strong> <a href="#value">oa:value</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 15</span><span style="text-transform: none">: oa:SvgSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno14</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">road1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">map1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:SvgSelector ;
-            rdf:value "</span><span class="tag">&lt;svg:svg&gt;</span><span class="pln"> ... </span><span class="tag">&lt;/svg:svg&gt;</span><span class="pln">" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#textpositionselector" typeof="bibo:Chapter" id="textpositionselector" class="term">
-  <h4 resource="#h-textpositionselector" id="h-textpositionselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.19 </span>TextPositionSelector</span></h4>
-  <p>The TextPositionSelector describes a range of text by recording the start and end positions of the selection in the stream. Position 0 would be immediately before the first character, position 1 would be immediately before the second character, and so on.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#TextPositionSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#start">oa:start</a>, <a href="#end">oa:end</a>, <a href="#rdf-type">rdf:type</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 16</span><span style="text-transform: none">: oa:TextPositionSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno15</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">ebook1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:TextPositionSelector ;
-            oa:start 412 ;
-            oa:end 795 ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#textquoteselector" typeof="bibo:Chapter" id="textquoteselector" class="term">
-  <h4 resource="#h-textquoteselector" id="h-textquoteselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.20 </span>TextQuoteSelector</span></h4>
-  <p>The TextQuoteSelector describes a range of text by copying it, and including some of the text immediately before (a prefix) and after (a suffix) it to distinguish between multiple copies of the same sequence of characters.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#TextQuoteSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-type">rdf:type</a>, <a href="#exact">oa:exact</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#prefix">oa:prefix</a>, <a href="#suffix">oa:suffix</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 17</span><span style="text-transform: none">: oa:TextQuoteSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno16</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#textualbody" typeof="bibo:Chapter" id="textualbody" class="term">
-  <h4 resource="#h-textualbody" id="h-textualbody"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.21 </span>TextualBody</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#TextualBody</li>
-      <li><strong>Equivalent Classes:</strong> <a href="http://www.w3.org/ns/activitystreams#Note">as:Note</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#dc-format">dc:format</a>, <a href="#dc-language">dc:language</a></li>
-      <li><strong>Other Predicates:</strong> <a href="#rdf-type">rdf:type</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 18</span><span style="text-transform: none">: oa:TextualBody</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno17</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">photo1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasBody [
-        a oa:TextualBody;
-        rdf:value "</span><span class="tag">&lt;p&gt;</span><span class="pln">Comment text</span><span class="tag">&lt;/p&gt;</span><span class="pln">" ;
-        dc:language "en" ;
-        dc:format "text/html" ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#timestate" typeof="bibo:Chapter" id="timestate" class="term">
-  <h4 resource="#h-timestate" id="h-timestate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.22 </span>TimeState</span></h4>
-  <p>A TimeState records the time at which the resource's state is appropriate for the Annotation, typically the time that the Annotation was created and/or a link to a persistent copy of the current version.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#TimeState</li>
-      <li><strong>Sub Class Of:</strong> <a href="#state">oa:State</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-type">rdf:type</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#sourcedate">oa:sourceDate</a>, <a href="#cachedsource">oa:cachedSource</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 19</span><span style="text-transform: none">: oa:TimeState</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno18</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:cachedSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">copy1</span><span class="tag">&gt;</span><span class="pln"> ;
-            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#xpathselector" typeof="bibo:Chapter" id="xpathselector" class="term">
-  <h4 resource="#h-xpathselector" id="h-xpathselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.23 </span>XPathSelector</span></h4>
-  <p> An XPathSelector is used to select elements and content within a resource that supports the Document Object Model via a specified XPath value.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#XPathSelector</li>
-      <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 20</span><span style="text-transform: none">: oa:TimeState</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno19</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-          a oa:XPathSelector ;
-          rdf:value "/html/body/p[2]/table/tr[2]/td[3]/span" ] ] .</span></pre></div>
-  </div>
-</section>
-
-</section>  <!-- End of oa Classes -->
-
-
-<section property="bibo:hasPart" resource="#properties" typeof="bibo:Chapter" id="properties">
-<h3 resource="#h-properties" id="h-properties"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2 </span>Properties</span></h3>
-
-
-<div class="termtoc">
-<a href="#annotationservice">annotationService</a> | <a href="#bodyvalue">bodyValue</a> | <a href="#cachedsource">cachedSource</a> | <a href="#canonical">canonical</a> | <a href="#end">end</a> | <a href="#exact">exact</a> | <a href="#hasbody">hasBody</a> | <a href="#haspurpose">hasPurpose</a> | <a href="#hasscope">hasScope</a> | <a href="#hasselector">hasSelector</a> | <a href="#hassource">hasSource</a> | <a href="#hasstate">hasState</a> | <a href="#hastarget">hasTarget</a> | <a href="#motivatedby">motivatedBy</a> | <a href="#prefix">prefix</a> | <a href="#refinedby">refinedBy</a> | <a href="#sourcedate">sourceDate</a> | <a href="#sourcedateend">sourceDateEnd</a> | <a href="#sourcedatestart">sourceDateStart</a> | <a href="#start">start</a> | <a href="#styleclass">styleClass</a> | <a href="#styledby">styledBy</a> | <a href="#suffix">suffix</a> | <a href="#via">via</a>
-</div>
-
-<section property="bibo:hasPart" resource="#annotationservice" typeof="bibo:Chapter" id="annotationservice" class="term">
-  <h4 resource="#h-annotationservice" id="h-annotationservice"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.1 </span>annotationService</span></h4>
-  <p>The object of the relationship is the end point of a service that conforms to the [<cite><a href="#bib-annotation-protocol" class="bibref">annotation-protocol</a></cite>], and it may be associated with any resource.  The expectation of asserting the relationship is that the object is the preferred service for maintaining annotations about the subject resource, according to the publisher of the relationship.
-  </p>
-  <p>
-  This relationship is intended to be used both within Linked Data descriptions and as the <code>rel</code> type of a Link, via HTTP Link Headers [<cite><a href="#bib-rfc5988" class="bibref">rfc5988</a></cite>] for binary resources and in HTML &lt;link&gt; elements.  For more information about these, please see the Annotation Protocol specification [<cite><a href="#bib-annotation-protocol" class="bibref">annotation-protocol</a></cite>].
-  </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#annotationService</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 21</span><span style="text-transform: none">: oa:annotationService</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">diagram</span><span class="pln">.</span><span class="atn">jpg</span><span class="tag">&gt;</span><span class="pln"> a dctypes:Image ;
-    oa:annotationService </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">services</span><span class="pun">/</span><span class="atn">annotations</span><span class="tag">/&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#bodyvalue" typeof="bibo:Chapter" id="bodyvalue" class="term">
-  <h4 resource="#h-bodyvalue" id="h-bodyvalue"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.2 </span>bodyValue</span></h4>
-  <p>The object of the predicate is a plain text string to be used as the content of the body of the Annotation.  The value <em title="MUST" class="rfc2119">MUST</em> be an <code>xsd:string</code> and that data type <em title="MUST NOT" class="rfc2119">MUST NOT</em> be expressed in the serialization. Note that language <em title="MUST NOT" class="rfc2119">MUST NOT</em> be associated with the value either as a language tag, as that is only available for <code>rdf:langString</code>.
-  </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#bodyValue</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 22</span><span style="text-transform: none">: oa:bodyValue</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno20</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:bodyValue "Comment text" ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">target1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#cachedsource" typeof="bibo:Chapter" id="cachedsource" class="term">
-  <h4 resource="#h-cachedsource" id="h-cachedsource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.3 </span>cachedSource</span></h4>
-  <p>A object of the relationship is a copy of the Source resource's representation, appropriate for the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#cachedSource</li>
-      <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 23</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno21</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:cachedSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">copy1</span><span class="tag">&gt;</span><span class="pln"> ;
-            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#canonical" typeof="bibo:Chapter" id="canonical" class="term">
-  <h4 resource="#h-canonical" id="h-canonical"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.4 </span>canonical</span></h4>
-  <p>A object of the relationship is the canonical URI that can always be used to deduplicate the Annotation, regardless of the current URI used to access the representation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#canonical</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 24</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno22</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:canonical </span><span class="tag">&lt;urn:uuid:dbfb1861-0ecf-41ad-be94-a584e5c4f1df&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#end" typeof="bibo:Chapter" id="end" class="term">
-  <h4 resource="#h-end" id="h-end"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.5 </span>end</span></h4>
-  <p>The end property is used to convey the 0-based index of the end position of a range of content.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#end</li>
-      <li><strong>Range:</strong> xsd:integer</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 25</span><span style="text-transform: none">: oa:end</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno23</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">diskimg1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:DataPositionSelector ;
-            oa:start 4096 ;
-            oa:end 4104 ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#exact" typeof="bibo:Chapter" id="exact" class="term">
-  <h4 resource="#h-exact" id="h-exact"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.6 </span>exact</span></h4>
-  <p>The object of the predicate is a copy of the text which is being selected, after normalization.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#exact</li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 26</span><span style="text-transform: none">: oa:exact</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno24</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .</span></pre></div>
-  </div>
-</section>
-
-
-<section property="bibo:hasPart" resource="#hasbody" typeof="bibo:Chapter" id="hasbody" class="term">
-  <h4 resource="#h-hasbody" id="h-hasbody"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.7 </span>hasBody</span></h4>
-  <p>The object of the relationship is a resource that is a body of the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasBody</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 27</span><span style="text-transform: none">: oa:hasBody</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno25</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">post1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#hasendselector" typeof="bibo:Chapter" id="hasendselector" class="term">
-  <h4 resource="#h-hasendselector" id="h-hasendselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.8 </span>hasEndSelector</span></h4>
-  <p>The relationship between a RangeSelector and the Selector that describes the end position of the range. </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasEndSelector</li>
-      <li><strong>Domain:</strong> <a href="#rangeselector">oa:RangeSelector</a></li>
-      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 28</span><span style="text-transform: none">: oa:hasEndSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno26</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-          a oa:RangeSelector ;
-          oa:hasStartSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[2]" ] ;
-          oa:hasEndSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#haspurpose" typeof="bibo:Chapter" id="haspurpose" class="term">
-  <h4 resource="#h-haspurpose" id="h-haspurpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.9 </span>hasPurpose</span></h4>
-  <p>The purpose served by the resource in the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasPurpose</li>
-      <li><strong>Range:</strong> <a href="#motivation">oa:Motivation</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 29</span><span style="text-transform: none">: oa:hasPurpose</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno27</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:bookmarking ;
-    oa:hasBody [
-        a oa:TextualBody ;
-        rdf:value "readme" ;
-        oa:hasPurpose oa:tagging ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#hasscope" typeof="bibo:Chapter" id="hasscope" class="term">
-  <h4 resource="#h-hasscope" id="h-hasscope"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.10 </span>hasScope</span></h4>
-  <p>The scope or context in which the resource is used within the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasScope</li>
-      <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
-      <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#context">as:context</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 30</span><span style="text-transform: none">: oa:hasPurpose</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno28</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:bookmarking ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">logo1</span><span class="pln">.</span><span class="atn">jpg</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasScope </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">index</span><span class="pln">.</span><span class="atn">html</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#hasselector" typeof="bibo:Chapter" id="hasselector" class="term">
-  <h4 resource="#h-hasselector" id="h-hasselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.11 </span>hasSelector</span></h4>
-  <p>The object of the relationship is a Selector that describes the segment or region of interest within the source resource.  Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasSelector</li>
-      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
-      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 31</span><span style="text-transform: none">: oa:hasSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno29</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [
-      oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-      oa:hasSelector </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">paraselector1</span><span class="tag">&gt;</span><span class="pln"> ] ;
-    oa:hasTarget [
-      oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">dataset1</span><span class="tag">&gt;</span><span class="pln"> ;
-      oa:hasSelector </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">dataselector1</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#hassource" typeof="bibo:Chapter" id="hassource" class="term">
-  <h4 resource="#h-hassource" id="h-hassource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.12 </span>hasSource</span></h4>
-  <p>The resource that the ResourceSelection, or its subclass SpecificResource, is refined from, or more specific than. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p><p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasSource</li>
-      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 32</span><span style="text-transform: none">: oa:hasSource</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno30</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> a oa:SpecificResource ;
-    oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-    
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#hasstartselector" typeof="bibo:Chapter" id="hasstartselector" class="term">
-  <h4 resource="#h-hasstartselector" id="h-hasstartselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.13 </span>hasStartSelector</span></h4>
-  <p>The relationship between a RangeSelector and the Selector that describes the start position of the range. </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasStartSelector</li>
-      <li><strong>Domain:</strong> <a href="#rangeselector">oa:RangeSelector</a></li>
-      <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 33</span><span style="text-transform: none">: oa:hasStartSelector</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno31</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-          a oa:RangeSelector ;
-          oa:hasStartSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[2]" ] ;
-          oa:hasEndSelector [
-            a oa:XPathSelector ;
-            rdf:value "//table[1]/tr[1]/td[4]" ] ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#hasstate" typeof="bibo:Chapter" id="hasstate" class="term">
-  <h4 resource="#h-hasstate" id="h-hasstate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.14 </span>hasState</span></h4>
-  <p>The relationship between the ResourceSelection, or its subclass SpecificResource, and a State resource. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p><p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasState</li>
-      <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
-      <li><strong>Range:</strong> <a href="#state">oa:State</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 34</span><span style="text-transform: none">: oa:hasState</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno32</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasState </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">state1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#hastarget" typeof="bibo:Chapter" id="hastarget" class="term">
-  <h4 resource="#h-hastarget" id="h-hastarget"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.15 </span>hasTarget</span></h4>
-  <p>The relationship between an Annotation and its Target.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasTarget</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 35</span><span style="text-transform: none">: oa:hasTarget</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno33</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">post1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#motivatedby" typeof="bibo:Chapter" id="motivatedby" class="term">
-  <h4 resource="#h-motivatedby" id="h-motivatedby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.16 </span>motivatedBy</span></h4>
-  <p>The relationship between an Annotation and a Motivation that describes the reason for the Annotation's creation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#motivatedBy</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-      <li><strong>Range:</strong> <a href="#motivation">oa:Motivation</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 36</span><span style="text-transform: none">: oa:motivatedBy</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno34</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">description1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:describing .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#prefix" typeof="bibo:Chapter" id="prefix" class="term">
-  <h4 resource="#h-prefix" id="h-prefix"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.17 </span>prefix</span></h4>
-  <p>The object of the property is a snippet of content that occurs immediately before the content which is being selected by the Selector.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#prefix</li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 37</span><span style="text-transform: none">: oa:prefix</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno35</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#refinedby" typeof="bibo:Chapter" id="refinedby" class="term">
-  <h4 resource="#h-refinedby" id="h-refinedby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.18 </span>refinedBy</span></h4>
-  <p>The relationship between a Selector and another Selector or a State and a Selector or State that should be applied to the results of the first to refine the processing of the source resource. </p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#refinedBy</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 38</span><span style="text-transform: none">: oa:refinedBy</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno36</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        a oa:SpecificResource ;
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-          a oa:FragmentSelector ;
-          rdf:value "para5" ;
-          oa:refinedBy [
-            a oa:TextQuoteSelector ;
-            oa:exact "Selected Text" ;
-            oa:prefix "text before the " ;
-            oa:suffix "and text after it" ] ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#renderedvia" typeof="bibo:Chapter" id="renderedvia" class="term">
-  <h4 resource="#h-renderedvia" id="h-renderedvia"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.19 </span>renderedVia</span></h4>
-  <p>A system that was used by the application that created the Annotation to render the resource.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#renderedVia</li>
-      <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
-      <li><strong>Range:</strong> <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource">rdf:Resource</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 39</span><span style="text-transform: none">: oa:prefix</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno37</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-      a oa:SpecificResource ;
-      oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-      oa:renderedVia [
-        a as:Application ;
-        schema:softwareVersion "2.5" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#sourcedate" typeof="bibo:Chapter" id="sourcedate" class="term">
-  <h4 resource="#h-sourcedate" id="h-sourcedate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.20 </span>sourceDate</span></h4>
-  <p>The timestamp at which the Source resource should be interpreted as being applicable to the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#sourceDate</li>
-      <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
-      <li><strong>Range:</strong> xsd:dateTime</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 40</span><span style="text-transform: none">: oa:sourceDate</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno38</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:sourceDate "2015-07-20T13:30:00Z" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#sourcedateend" typeof="bibo:Chapter" id="sourcedateend" class="term">
-  <h4 resource="#h-sourcedateend" id="h-sourcedateend"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.21 </span>sourceDateEnd</span></h4>
-  <p>The end timestamp of the interval over which the Source resource should be interpreted as being applicable to the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#sourceDate</li>
-      <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
-      <li><strong>Range:</strong> xsd:dateTime</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 41</span><span style="text-transform: none">: oa:sourceDate</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno39</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:sourceDateStart "2015-07-20T13:30:00Z" ;
-            oa:sourceDateEnd   "2015-07-21T19:45:00Z" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#sourcedatestart" typeof="bibo:Chapter" id="sourcedatestart" class="term">
-  <h4 resource="#h-sourcedatestart" id="h-sourcedatestart"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.22 </span>sourceDateStart</span></h4>
-  <p>The start timestamp of the interval over which the Source resource should be interpreted as being applicable to the Annotation.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#sourceDate</li>
-      <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
-      <li><strong>Range:</strong> xsd:dateTime</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 42</span><span style="text-transform: none">: oa:sourceDate</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno40</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasState [
-            a oa:TimeState ;
-            oa:sourceDateStart "2015-07-20T13:30:00Z" ;
-            oa:sourceDateEnd   "2015-07-21T19:45:00Z" ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#start" typeof="bibo:Chapter" id="start" class="term">
-  <h4 resource="#h-start" id="h-start"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.23 </span>start</span></h4>
-  <p>The start position in a 0-based index at which a range of content is selected from the data in the source resource.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#start</li>
-      <li><strong>Range:</strong> xsd:integer</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 43</span><span style="text-transform: none">: oa:start</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno41</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">ebook1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:TextPositionSelector ;
-            oa:start 412 ;
-            oa:end 795 ] ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#styleclass" typeof="bibo:Chapter" id="styleclass" class="term">
-  <h4 resource="#h-styleclass" id="h-styleclass"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.24 </span>styleClass</span></h4>
-  <p>The name of the class used in the CSS description referenced from the Annotation that should be applied to the Specific Resource.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#styleClass</li>
-      <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 44</span><span style="text-transform: none">: oa:styleClass</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno42</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:styledBy </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">style1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">document1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:styleClass "red" ] .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">style1</span><span class="tag">&gt;</span><span class="pln"> a oa:CssStyle .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#styledby" typeof="bibo:Chapter" id="styledby" class="term">
-  <h4 resource="#h-styledby" id="h-styledby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.25 </span>styledBy</span></h4>
-  <p>A reference to a Stylesheet that should be used to apply styles to the Annotation rendering.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#styledBy</li>
-      <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
-      <li><strong>Range:</strong> <a href="#style">oa:Style</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 45</span><span style="text-transform: none">: oa:styledBy</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno43</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">body1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:styledBy [
-        a oa:CssStyle ;
-        rdf:value ".red { color: red }" ] ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">target1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:styleClass "red" ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#suffix" typeof="bibo:Chapter" id="suffix" class="term">
-  <h4 resource="#h-suffix" id="h-suffix"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.26 </span>suffix</span></h4>
-  <p>The snippet of text that occurs immediately after the text which is being selected.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#suffix</li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 46</span><span style="text-transform: none">: oa:suffix</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno44</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget [
-        oa:hasSource </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-        oa:hasSelector [
-            a oa:TextQuoteSelector ;
-            oa:exact "anotation" ;
-            oa:prefix "this is an " ;
-            oa:suffix " that has some" ] ] .</span></pre></div>
-    
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#via" typeof="bibo:Chapter" id="via" class="term">
-  <h4 resource="#h-via" id="h-via"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.27 </span>via</span></h4>
-  <p>A object of the relationship is a resource from which the source resource was retrieved by the providing system.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#via</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 47</span></div><pre style="" class="highlight prettyprint prettyprinted" title=""><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno45</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:via </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">other</span><span class="pln">.</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">anno1b</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-</section>
-
-<section property="bibo:hasPart" resource="#named-individuals" typeof="bibo:Chapter" id="named-individuals">
-  <h3 resource="#h-named-individuals" id="h-named-individuals"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3 </span>Named Individuals</span></h3>
-
-<section property="bibo:hasPart" resource="#bookmarking" typeof="bibo:Chapter" id="bookmarking" class="term">
-  <h4 resource="#h-bookmarking" id="h-bookmarking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.1 </span>bookmarking</span></h4>
-  <p>The motivation for when the user intends to create a bookmark to the Target or part thereof.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#bookmarking</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 48</span><span style="text-transform: none">: oa:bookmarking</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno46</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:bookmarking .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#classifying" typeof="bibo:Chapter" id="classifying" class="term">
-  <h4 resource="#h-classifying" id="h-classifying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.2 </span>classifying</span></h4>
-  <p>The motivation for when the user intends to that classify the Target as something.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#classifying</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 49</span><span style="text-transform: none">: oa:classifying</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno47</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">type1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:classifying .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#commenting" typeof="bibo:Chapter" id="commenting" class="term">
-  <h4 resource="#h-commenting" id="h-commenting"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.3 </span>commenting</span></h4>
-  <p>The motivation for when the user intends to comment about the Target.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#commenting</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 50</span><span style="text-transform: none">: oa:commenting</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno48</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A comment about the page" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:commenting .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#describing" typeof="bibo:Chapter" id="describing" class="term">
-  <h4 resource="#h-describing" id="h-describing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.4 </span>describing</span></h4>
-  <p>The motivation for when the user intends to describe the Target, as opposed to a comment about them.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#describing</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 51</span><span style="text-transform: none">: oa:describing</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno49</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A description of the image" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:describing .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#editing" typeof="bibo:Chapter" id="editing" class="term">
-  <h4 resource="#h-editing" id="h-editing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.5 </span>editing</span></h4>
-  <p>The motivation for when the user intends to request a change or edit to the Target resource.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#editing</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 52</span><span style="text-transform: none">: oa:editing</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno50</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "Editorial suggestion" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">text1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:editing .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#highlighting" typeof="bibo:Chapter" id="highlighting" class="term">
-  <h4 resource="#h-highlighting" id="h-highlighting"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.6 </span>highlighting</span></h4>
-  <p>The motivation for when the user intends to highlight the Target resource or segment of it.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#highlighting</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 53</span><span style="text-transform: none">: oa:highlighting</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno51</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">region1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:highlighting .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#identifying" typeof="bibo:Chapter" id="identifying" class="term">
-  <h4 resource="#h-identifying" id="h-identifying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.7 </span>identifying</span></h4>
-  <p>The motivation for when the user intends to assign an identity to the Target or identify what is being depicted or described in the Target.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#identifying</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 54</span><span style="text-transform: none">: oa:identifying</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno52</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">identities</span><span class="pun">/</span><span class="atn">object1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">image-of-object1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:identifying .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#linking" typeof="bibo:Chapter" id="linking" class="term">
-  <h4 resource="#h-linking" id="h-linking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.8 </span>linking</span></h4>
-  <p>The motivation for when the user intends to link to a resource related to the Target.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#linking</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 55</span><span style="text-transform: none">: oa:linking</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno53</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">from1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">to1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:linking .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#moderating" typeof="bibo:Chapter" id="moderating" class="term">
-  <h4 resource="#h-moderating" id="h-moderating"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.9 </span>moderating</span></h4>
-  <p>The motivation for when the user intends to assign some value or quality to the Target.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#moderating</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 56</span><span style="text-transform: none">: oa:moderating</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno54</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">tags</span><span class="pun">/</span><span class="atn">approved1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:moderating .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#questioning" typeof="bibo:Chapter" id="questioning" class="term">
-  <h4 resource="#h-questioning" id="h-questioning"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.10 </span>questioning</span></h4>
-  <p>The motivation for when the user intends to ask a question about the Target.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#questioning</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 57</span><span style="text-transform: none">: oa:questioning</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno55</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A question about the resource" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:questioning .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#replying" typeof="bibo:Chapter" id="replying" class="term">
-  <h4 resource="#h-replying" id="h-replying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.11 </span>replying</span></h4>
-  <p>The motivation for when the user intends to reply to a previous statement, either an Annotation or another resource.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#replying</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 58</span><span style="text-transform: none">: oa:replying</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno56</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A reply to a question" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:replying .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#reviewing" typeof="bibo:Chapter" id="reviewing" class="term">
-  <h4 resource="#h-reviewing" id="h-reviewing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.12 </span>reviewing</span></h4>
-  <p>The motivation for when the user intends to review the Target in some assessing fashion, rather than simply make a comment about it.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#reviewing</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 59</span><span style="text-transform: none">: oa:reviewing</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno57</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "A review of the resource" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">resource1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:reviewing .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#tagging" typeof="bibo:Chapter" id="tagging" class="term">
-  <h4 resource="#h-tagging" id="h-tagging"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.13 </span>tagging</span></h4>
-  <p>The motivation for when the user intends to associate a tag with the Target.</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> http://www.w3.org/ns/oa#tagging</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 60</span><span style="text-transform: none">: oa:tagging</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno58</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">thing1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:tagging .</span></pre></div>
-  </div>
-</section>
-</section>
-</section>
-
-<section property="bibo:hasPart" resource="#recommended-ontologies" typeof="bibo:Chapter" id="recommended-ontologies">
-<!--OddPage--><h2 resource="#h-recommended-ontologies" id="h-recommended-ontologies"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Recommended Ontologies</span></h2>
-
-<section property="bibo:hasPart" resource="#classes-1" typeof="bibo:Chapter" id="classes-1">
-<h3 resource="#h-classes-1" id="h-classes-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1 </span>Classes</span></h3>
-
-<div class="termtoc">
-<a href="#as-application">as:Application</a> | <a href="#as-orderedcollection">as:OrderedCollection</a> | <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a> | <a href="#dctypes-dataset">dctypes:Dataset</a> | <a href="#dctypes-movingimage">dctypes:MovingImage</a> | <a href="#dctypes-stillimage">dctypes:StillImage</a> | <a href="#dctypes-sound">dctypes:Sound</a> | <a href="#dctypes-text">dctypes:Text</a> | <a href="#foaf-organization">foaf:Organization</a> | <a href="#foaf-person">foaf:Person</a> | <a href="#schema-audience">schema:Audience</a>
-</div>
-
-<section property="bibo:hasPart" resource="#as-application" typeof="bibo:Chapter" id="as-application" class="term">
-  <h4 resource="#h-as-application" id="h-as-application"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.1 </span>as:Application</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#Application">http://www.w3.org/ns/activitystreams#Application</a></li>
-      <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/SoftwareApplication">schema:SoftwareApplication</a></li>
-      <li><strong>Range Of:</strong> <a href="#as-generator">as:generator</a>, <a href="#dcterms-creator">dcterms:creator</a> </li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 61</span><span style="text-transform: none">: as:Application</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno59</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    as:generator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> a as:Application ;
-    foaf:homepage </span><span class="tag">&lt;HomePage1&gt;</span><span class="pln"> ;
-    foaf:name "Code v2.1" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-orderedcollection" typeof="bibo:Chapter" id="as-orderedcollection" class="term">
-  <h4 resource="#h-as-orderedcollection" id="h-as-orderedcollection"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.2 </span>as:OrderedCollection</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#OrderedCollection">http://www.w3.org/ns/activitystreams#OrderedCollection</a></li>
-      <li><strong>Range Of:</strong> <a href="#as-partof">as:partOf</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#as-first">as:first</a> </li>
-      <li><strong>Recommended Predicates:</strong> <a href="#as-last">as:last</a>, <a href="#as-totalitems">as:totalItems</a>, <a href="#rdfs-label">rdfs:label</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 62</span><span style="text-transform: none">: as:OrderedCollection</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
-  rdfs:label "Example Collection" ;
-  as:totalItems 42023 ;
-  as:first </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-orderedcollectionpage" typeof="bibo:Chapter" id="as-orderedcollectionpage" class="term">
-  <h4 resource="#h-as-orderedcollectionpage" id="h-as-orderedcollectionpage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.3 </span>as:OrderedCollectionPage</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#OrderedCollectionPage">http://www.w3.org/ns/activitystreams#OrderedCollectionPage</a></li>
-      <li><strong>Range Of:</strong> <a href="#as-first">as:first</a>, <a href="#as-last">as:last</a>, <a href="#as-next">as:next</a>, <a href="#as-prev">as:prev</a></li>
-      <li><strong>Required Predicates:</strong> <a href="#as-next">as:next</a>, <a href="#as-items">as:items</a></li>
-      <li><strong>Recommended Predicates:</strong> <a href="#as-prev">as:prev</a>, <a href="#as-startindex">as:startIndex</a>, <a href="#as-partof">as:partOf</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 63</span><span style="text-transform: none">: as:OrderedCollectionPage</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
-  as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:startIndex 0 ;
-  as:items (
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno2</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno3</span><span class="tag">&gt;</span><span class="pln"> ) .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dctypes-dataset" typeof="bibo:Chapter" id="dctypes-dataset" class="term">
-  <h4 resource="#h-dctypes-dataset" id="h-dctypes-dataset"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.4 </span>dctypes:Dataset</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/Dataset">http://purl.org/dc/dcmitype/Dataset</a></li>
-      <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/Dataset">schema:Dataset</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 64</span><span style="text-transform: none">: dctypes:Dataset</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno60</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:commenting ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">note1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">dataset1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">dataset1</span><span class="tag">&gt;</span><span class="pln"> a dctypes:Dataset ;
-  dc:format "text/csv" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dctypes-movingimage" typeof="bibo:Chapter" id="dctypes-movingimage" class="term">
-  <h4 resource="#h-dctypes-movingimage" id="h-dctypes-movingimage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.5 </span>dctypes:MovingImage</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/MovingImage">http://purl.org/dc/dcmitype/MovingImage</a></li>
-      <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/VideoObject">schema:VideoObject</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 65</span><span style="text-transform: none">: dctypes:MovingImage</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno61</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">video1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:tagging .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">video1</span><span class="tag">&gt;</span><span class="pln"> a dctypes:MovingImage .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dctypes-stillimage" typeof="bibo:Chapter" id="dctypes-stillimage" class="term">
-  <h4 resource="#h-dctypes-stillimage" id="h-dctypes-stillimage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.6 </span>dctypes:StillImage</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/StillImage">http://purl.org/dc/dcmitype/StillImage</a></li>
-      <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/ImageObject">schema:ImageObject</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 66</span><span style="text-transform: none">: dctypes:StillImage</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno62</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:tagging .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">image1</span><span class="tag">&gt;</span><span class="pln"> a dctypes:StillImage .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dctypes-sound" typeof="bibo:Chapter" id="dctypes-sound" class="term">
-  <h4 resource="#h-dctypes-sound" id="h-dctypes-sound"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.7 </span>dctypes:Sound</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/Sound">http://purl.org/dc/dcmitype/Sound</a></li>
-      <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/AudioObject">schema:AudioObject</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 67</span><span style="text-transform: none">: dctypes:Sound</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno63</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">audio1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:tagging .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">audio1</span><span class="tag">&gt;</span><span class="pln"> a dctypes:Sound .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dctypes-text" typeof="bibo:Chapter" id="dctypes-text" class="term">
-  <h4 resource="#h-dctypes-text" id="h-dctypes-text"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.8 </span>dctypes:Text</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/Text">http://purl.org/dc/dcmitype/Text</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 68</span><span style="text-transform: none">: dctypes:Text</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno64</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody [ rdf:value "tag" ] ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">document1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:motivatedBy oa:tagging .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">document1</span><span class="tag">&gt;</span><span class="pln"> a dctypes:Text .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#foaf-organization" typeof="bibo:Chapter" id="foaf-organization" class="term">
-  <h4 resource="#h-foaf-organization" id="h-foaf-organization"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.9 </span>foaf:Organization</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/Organization">http://xmlns.com/foaf/0.1/Organization</a></li>
-      <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/Organization">schema:Organization</a>, <a href="http://www.w3.org/ns/activitystreams#Organization">as:Organization</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 69</span><span style="text-transform: none">: foaf:Organization</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno65</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:motivatedBy oa:commenting ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">comment1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">org</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">org</span><span class="tag">&gt;</span><span class="pln"> a foaf:Organization ;
-    foaf:name "Example Organization" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#foaf-person" typeof="bibo:Chapter" id="foaf-person" class="term">
-  <h4 resource="#h-foaf-person" id="h-foaf-person"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.10 </span>foaf:Person</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/Person">http://xmlns.com/foaf/0.1/Person</a></li>
-      <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/Person">schema:Person</a>, <a href="http://www.w3.org/ns/activitystreams#Person">as:Person</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 70</span><span style="text-transform: none">: foaf:Person</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno66</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> a foaf:Person ;
-    foaf:nick "pseudo" ;
-    foaf:name "My Pseudonym" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#schema-audience" typeof="bibo:Chapter" id="schema-audience" class="term">
-  <h4 resource="#h-schema-audience" id="h-schema-audience"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.11 </span>schema:Audience</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://schema.org/Audience">http://schema.org/Audience</a></li>
-      <li><strong>Range Of:</strong> <a href="#schema-audience">schema:audience</a> </li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 71</span><span style="text-transform: none">: schema:Audience</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno67</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    schema:audience </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">roles</span><span class="pun">/</span><span class="atn">musician</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">roles</span><span class="pun">/</span><span class="atn">musician</span><span class="tag">&gt;</span><span class="pln"> a schema:Audience ;
-    schema:audienceType "musician" .</span></pre></div>
-  </div>
-</section>
-
-</section>
-
-<section property="bibo:hasPart" resource="#properties-1" typeof="bibo:Chapter" id="properties-1">
-  <h3 resource="#h-properties-1" id="h-properties-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2 </span>Properties</span></h3>
-
-<div class="termtoc">
-<a href="#as-first">as:first</a> | <a href="#as-generator">as:generator</a> | <a href="#as-items">as:items</a> | <a href="#as-last">as:last</a> | <a href="#as-next">as:next</a> | <a href="#as-partof">as:partOf</a> | <a href="#as-prev">as:prev</a> | <a href="#as-startindex">as:startIndex</a> | <a href="#as-totalitems">as:totalItems</a> | <a href="#dc-format">dc:format</a> | <a href="#dc-language">dc:language</a> | <a href="#dcterms-conformsto">dcterms:conformsTo</a> | <a href="#dcterms-created">dcterms:created</a> | <a href="#dcterms-creator">dcterms:creator</a> | <a href="#dcterms-issued">dcterms:issued</a> | <a href="#dcterms-modified">dcterms:modified</a> | <a href="#dcterms-rights">dcterms:rights</a> | <a href="#foaf-homepage">foaf:homepage</a> | <a href="#foaf-mbox">foaf:mbox</a> | <a href="#foaf-mbox_sha1sum">foaf:mbox_sha1sum</a> | <a href="#foaf-name">foaf:name</a> | <a href="#foaf-nick">foaf:nick</a> | <a href="#rdf-type">rdf:type</a> | <a href="#rdf-value">rdf:value</a> | <a href="#rdfs-label">rdfs:label</a> | <a href="#schema-audience">schema:audience</a>
-</div>
-
-
-<section property="bibo:hasPart" resource="#as-first" typeof="bibo:Chapter" id="as-first" class="term">
-  <h4 resource="#h-as-first" id="h-as-first"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.1 </span>as:first</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#first">http://www.w3.org/ns/activitystreams#first</a></li>
-      <li><strong>Domain:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-      <li><strong>Range:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 72</span><span style="text-transform: none">: as:first</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
-  rdfs:label "Example Collection" ;
-  as:totalItems 42023 ;
-  as:first </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-generator" typeof="bibo:Chapter" id="as-generator" class="term">
-  <h4 resource="#h-as-generator" id="h-as-generator"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.2 </span>as:generator</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#generator">http://www.w3.org/ns/activitystreams#generator</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 73</span><span style="text-transform: none">: as:generator</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno68</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    as:generator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> a as:Application ;
-    foaf:homepage </span><span class="tag">&lt;HomePage1&gt;</span><span class="pln"> ;
-    foaf:name "Code v2.1" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-items" typeof="bibo:Chapter" id="as-items" class="term">
-  <h4 resource="#h-as-items" id="h-as-items"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.3 </span>as:items</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#items">http://www.w3.org/ns/activitystreams#items</a></li>
-      <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-      <li><strong>Range:</strong> <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#List">rdf:List</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 74</span><span style="text-transform: none">: as:items</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
-  as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:startIndex 0 ;
-  as:items (
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno2</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno3</span><span class="tag">&gt;</span><span class="pln"> ) .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-last" typeof="bibo:Chapter" id="as-last" class="term">
-  <h4 resource="#h-as-last" id="h-as-last"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.4 </span>as:last</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#last">http://www.w3.org/ns/activitystreams#last</a></li>
-      <li><strong>Domain:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-      <li><strong>Range:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 75</span><span style="text-transform: none">: as:last</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
-  rdfs:label "Example Collection" ;
-  as:totalItems 42023 ;
-  as:first </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-next" typeof="bibo:Chapter" id="as-next" class="term">
-  <h4 resource="#h-as-next" id="h-as-next"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.5 </span>as:next</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#next">http://www.w3.org/ns/activitystreams#next</a></li>
-      <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-      <li><strong>Range:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 76</span><span style="text-transform: none">: as:next</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
-  as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:startIndex 0 ;
-  as:items (
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno2</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno3</span><span class="tag">&gt;</span><span class="pln"> ) .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-partof" typeof="bibo:Chapter" id="as-partof" class="term">
-  <h4 resource="#h-as-partof" id="h-as-partof"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.6 </span>as:partOf</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#partOf">http://www.w3.org/ns/activitystreams#partOf</a></li>
-      <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-      <li><strong>Range:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 77</span><span style="text-transform: none">: as:partOf</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page1 a as:OrderedCollectionPage ;
-  as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page2</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:startIndex 0 ;
-  as:items (
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno1</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno2</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno3</span><span class="tag">&gt;</span><span class="pln"> ) .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-prev" typeof="bibo:Chapter" id="as-prev" class="term">
-  <h4 resource="#h-as-prev" id="h-as-prev"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.7 </span>as:prev</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#prev">http://www.w3.org/ns/activitystreams#prev</a></li>
-      <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-      <li><strong>Range:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 78</span><span style="text-transform: none">: as:prev</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page2 a as:OrderedCollectionPage ;
-  as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:prev </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page3</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:startIndex 3 ;
-  as:items (
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno4</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno5</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno6</span><span class="tag">&gt;</span><span class="pln"> ) .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-startindex" typeof="bibo:Chapter" id="as-startindex" class="term">
-  <h4 resource="#h-as-startindex" id="h-as-startindex"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.8 </span>as:startIndex</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#startIndex">http://www.w3.org/ns/activitystreams#startIndex</a></li>
-      <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
-      <li><strong>Range:</strong> xsd:integer</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 79</span><span style="text-transform: none">: as:startIndex</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1/page2 a as:OrderedCollectionPage ;
-  as:partOf </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:prev </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:next </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page3</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:startIndex 3 ;
-  as:items (
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno4</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno5</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno6</span><span class="tag">&gt;</span><span class="pln"> ) .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#as-totalitems" typeof="bibo:Chapter" id="as-totalitems" class="term">
-  <h4 resource="#h-as-totalitems" id="h-as-totalitems"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.9 </span>as:totalItems</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#totalItems">http://www.w3.org/ns/activitystreams#totalItems</a></li>
-      <li><strong>Domain:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
-      <li><strong>Range:</strong> xsd:integer</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 80</span><span style="text-transform: none">: as:totalItems</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pln">&lt;http://example.org/collection1 a as:OrderedCollection ;
-  rdfs:label "Example Collection" ;
-  as:totalItems 42023 ;
-  as:first </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page1</span><span class="tag">&gt;</span><span class="pln"> ;
-  as:last </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">collection1</span><span class="pun">/</span><span class="atn">page42</span><span class="tag">&gt;</span><span class="pln"> .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dc-format" typeof="bibo:Chapter" id="dc-format" class="term">
-  <h4 resource="#h-dc-format" id="h-dc-format"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.10 </span>dc:format</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/elements/1.1/format">http://purl.org/dc/elements/1.1/format</a></li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 81</span><span style="text-transform: none">: dc:format</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno69</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">photo1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasBody [
-        a oa:TextualBody;
-        rdf:value "</span><span class="tag">&lt;p&gt;</span><span class="pln">Comment text</span><span class="tag">&lt;/p&gt;</span><span class="pln">" ;
-        dc:language "en" ;
-        dc:format "text/html" ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dc-language" typeof="bibo:Chapter" id="dc-language" class="term">
-  <h4 resource="#h-dc-language" id="h-dc-language"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.11 </span>dc:language</span></h4>
-  <p>The dc:language predicate recommends the use of a controlled vocabulary.  The use of dc:language in the Annotation model further specifies that the vocabulary to use is [<cite><a href="#bib-BCP47" class="bibref">BCP47</a></cite>].</p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/elements/1.1/language">http://purl.org/dc/elements/1.1/language</a></li>
-      <li><strong>Range:</strong> xsd:string</li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 82</span><span style="text-transform: none">: dc:language</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno70</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">photo1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasBody [
-        a oa:TextualBody;
-        rdf:value "</span><span class="tag">&lt;p&gt;</span><span class="pln">Comment text</span><span class="tag">&lt;/p&gt;</span><span class="pln">" ;
-        dc:language "en" ;
-        dc:format "text/html" ] .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dcterms-conformsto" typeof="bibo:Chapter" id="dcterms-conformsto" class="term">
-  <h4 resource="#h-dcterms-conformsto" id="h-dcterms-conformsto"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.12 </span>dcterms:conformsTo</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/conformsTo">http://purl.org/dc/terms/conformsTo</a></li>
-      <li><strong>Sub Property Of:</strong> </li>
-      <li><strong>Super Property Of:</strong> </li>
-      <li><strong>Domain:</strong> </li>
-      <li><strong>Range:</strong> </li>
-      <li><strong>Equivalent Properties:</strong> </li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 83</span><span style="text-transform: none">: dcterms:conformsTo</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dcterms-created" typeof="bibo:Chapter" id="dcterms-created" class="term">
-  <h4 resource="#h-dcterms-created" id="h-dcterms-created"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.13 </span>dcterms:created</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/created">http://purl.org/dc/terms/created</a></li>
-      <li><strong>Range:</strong> <a href="http://purl.org/dc/terms/W3CDTF">dcterms:W3CDTF</a></li>
-      <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#published">as:published</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 84</span><span style="text-transform: none">: dcterms:created</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno71</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    dcterms:created "2015-10-13T13:00:00Z" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dcterms-creator" typeof="bibo:Chapter" id="dcterms-creator" class="term">
-  <h4 resource="#h-dcterms-creator" id="h-dcterms-creator"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.14 </span>dcterms:creator</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/creator">http://purl.org/dc/terms/creator</a></li>
-      <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#actor">as:actor</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 85</span><span style="text-transform: none">: dcterms:creator</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno72</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> ;
-    as:generator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> a foaf:Person ;
-    foaf:nick "pseudo" ;
-    foaf:name "My Pseudonym" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dcterms-issued" typeof="bibo:Chapter" id="dcterms-issued" class="term">
-  <h4 resource="#h-dcterms-issued" id="h-dcterms-issued"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.15 </span>dcterms:issued</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/issued">http://purl.org/dc/terms/issued</a></li>
-      <li><strong>Range:</strong> <a href="http://purl.org/dc/terms/W3CDTF">dcterms:W3CDTF</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 86</span><span style="text-transform: none">: dcterms:issued</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno73</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    dcterms:issued "2015-10-14T15:13:28Z" ;
-    as:generated </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client2</span><span class="tag">&gt;</span><span class="pln"> a as:Application ;
-    foaf:homepage </span><span class="tag">&lt;HomePage2&gt;</span><span class="pln"> ;
-    foaf:name "Code v1" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dcterms-modified" typeof="bibo:Chapter" id="dcterms-modified" class="term">
-  <h4 resource="#h-dcterms-modified" id="h-dcterms-modified"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.16 </span>dcterms:modified</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/modified">http://purl.org/dc/terms/modified</a></li>
-      <li><strong>Range:</strong> <a href="http://purl.org/dc/terms/W3CDTF">dcterms:W3CDTF</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 87</span><span style="text-transform: none">: dcterms:modified</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#dcterms-rights" typeof="bibo:Chapter" id="dcterms-rights" class="term">
-  <h4 resource="#h-dcterms-rights" id="h-dcterms-rights"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.17 </span>dcterms:rights</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/rights">http://purl.org/dc/terms/rights</a></li>
-      <li><strong>Sub Property Of:</strong> </li>
-      <li><strong>Super Property Of:</strong> </li>
-      <li><strong>Domain:</strong> </li>
-      <li><strong>Range:</strong> </li>
-      <li><strong>Equivalent Properties:</strong> </li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 88</span><span style="text-transform: none">: dcterms:rights</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#foaf-homepage" typeof="bibo:Chapter" id="foaf-homepage" class="term">
-  <h4 resource="#h-foaf-homepage" id="h-foaf-homepage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.18 </span>foaf:homepage</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/homepage">http://xmlns.com/foaf/0.1/homepage</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 89</span><span style="text-transform: none">: foaf:homepage</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno74</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    as:generator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">client1</span><span class="tag">&gt;</span><span class="pln"> a as:Application ;
-    foaf:homepage </span><span class="tag">&lt;HomePage1&gt;</span><span class="pln"> ;
-    foaf:name "Code v2.1" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#foaf-mbox" typeof="bibo:Chapter" id="foaf-mbox" class="term">
-  <h4 resource="#h-foaf-mbox" id="h-foaf-mbox"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.19 </span>foaf:mbox</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/mbox">http://xmlns.com/foaf/0.1/mbox</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 90</span><span style="text-transform: none">: foaf:mbox</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#foaf-mbox_sha1sum" typeof="bibo:Chapter" id="foaf-mbox_sha1sum" class="term">
-  <h4 resource="#h-foaf-mbox_sha1sum" id="h-foaf-mbox_sha1sum"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.20 </span>foaf:mbox_sha1sum</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/mbox_sha1sum">http://xmlns.com/foaf/0.1/mbox_sha1sum</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 91</span><span style="text-transform: none">: foaf:mbox_sha1sum</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#foaf-name" typeof="bibo:Chapter" id="foaf-name" class="term">
-  <h4 resource="#h-foaf-name" id="h-foaf-name"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.21 </span>foaf:name</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/name">http://xmlns.com/foaf/0.1/name</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 92</span><span style="text-transform: none">: foaf:name</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno75</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> a foaf:Person ;
-    foaf:nick "pseudo" ;
-    foaf:name "My Pseudonym" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#foaf-nick" typeof="bibo:Chapter" id="foaf-nick" class="term">
-  <h4 resource="#h-foaf-nick" id="h-foaf-nick"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.22 </span>foaf:nick</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/nick">http://xmlns.com/foaf/0.1/nick</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 93</span><span style="text-transform: none">: foaf:nick</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno76</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    dcterms:creator </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">user1</span><span class="tag">&gt;</span><span class="pln"> a foaf:Person ;
-    foaf:nick "pseudo" ;
-    foaf:name "My Pseudonym" .</span></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#rdf-type" typeof="bibo:Chapter" id="rdf-type" class="term">
-  <h4 resource="#h-rdf-type" id="h-rdf-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.23 </span>rdf:type</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">http://www.w3.org/1999/02/22-rdf-syntax-ns#type</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 94</span><span style="text-transform: none">: rdf:type</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#rdf-value" typeof="bibo:Chapter" id="rdf-value" class="term">
-  <h4 resource="#h-rdf-value" id="h-rdf-value"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.24 </span>rdf:value</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#value">http://www.w3.org/1999/02/22-rdf-syntax-ns#value</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 95</span><span style="text-transform: none">: rdf:value</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#rdfs-label" typeof="bibo:Chapter" id="rdfs-label" class="term">
-  <h4 resource="#h-rdfs-label" id="h-rdfs-label"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.25 </span>rdfs:label</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://www.w3.org/2000/01/rdf-schema#label">http://www.w3.org/2000/01/rdf-schema#label</a></li>
-      <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#name">as:name</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 96</span><span style="text-transform: none">: rdfs:label</span></div><pre style="" class="highlight prettyprint prettyprinted"></pre></div>
-  </div>
-</section>
-
-<section property="bibo:hasPart" resource="#schema-audience-1" typeof="bibo:Chapter" id="schema-audience-1" class="term">
-  <h4 resource="#h-schema-audience-1" id="h-schema-audience-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.26 </span>schema:audience</span></h4>
-  <p></p>
-  <div class="tech">
-    <ul>
-      <li><strong>URI:</strong> <a href="http://schema.org/audience">http://schema.org/audience</a></li>
-    </ul>
-  </div>
-  <div>
-    <div class="example"><div class="example-title marker"><span>Example 97</span><span style="text-transform: none">: schema:Audience</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">org</span><span class="pun">/</span><span class="atn">anno77</span><span class="tag">&gt;</span><span class="pln"> a oa:Annotation ;
-    oa:hasBody </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">review1</span><span class="tag">&gt;</span><span class="pln"> ;
-    oa:hasTarget </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">com</span><span class="pun">/</span><span class="atn">restaurant1</span><span class="tag">&gt;</span><span class="pln"> ;
-    schema:audience </span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">roles</span><span class="pun">/</span><span class="atn">musician</span><span class="tag">&gt;</span><span class="pln"> .
-
-</span><span class="tag">&lt;http</span><span class="pln">:</span><span class="pun">//</span><span class="atn">example</span><span class="pln">.</span><span class="atn">net</span><span class="pun">/</span><span class="atn">roles</span><span class="pun">/</span><span class="atn">musician</span><span class="tag">&gt;</span><span class="pln"> a schema:Audience ;
-    schema:audienceType "musician" .</span></pre></div>
-  </div>
-</section>
-
-</section> <!-- /Recommended Properties -->
-</section> <!-- /Recommended Ontologies -->
-
-<section property="bibo:hasPart" resource="#extensions" typeof="bibo:Chapter" id="extensions">
-<!--OddPage--><h2 resource="#h-extensions" id="h-extensions"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Extensions</span></h2>
-
-<p>This vocabulary may be extended in the regular way, by creating new or importing existing predicates and classes from other RDF based ontologies. Extensions may be made to any resource, including adding new objects as well as properties. If there is a property in one of the ontologies that are already included in the context, then it is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> to use a CURIE, the namespace and property name separated by a <code>:</code> character, as the JSON-LD key rather than creating a new context.</p>
-
-<p>For example, it is easier to add <code>skos:prefLabel</code> to the Annotation rather than requiring clients to download a new context document to discover the mapping.</p>
-
-  <div class="example"><div class="example-title marker"><span>Example 98</span><span style="text-transform: none">: Extension Example 1</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno78"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"skos:prefLabel"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Picture Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I love this picture!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/images/picture1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Image"</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-
-<p>In order to ensure a lack of collision between key names, a JSON-LD context document <em title="SHOULD" class="rfc2119">SHOULD</em> be made available when the term is not from an ontology that is already in the Web Annotation context. Extension contexts <em title="MUST NOT" class="rfc2119">MUST NOT</em> redefine existing JSON-LD keys from the Web Annotation context.  Implementations <em title="MUST" class="rfc2119">MUST</em> ignore unfamiliar properties when processing the data, but servers <em title="SHOULD" class="rfc2119">SHOULD</em> preserve them if they are part of a valid and included context.</p>
-
-<p>The context <em title="SHOULD" class="rfc2119">SHOULD</em> be associated with the resource that most closely encapsulates the extension properties. This is to try to ensure that extensions which define the same key do not collide unexpectedly. If there is more than one context document for a particular resource, then they must be included in an array.</p>
-
-<p>For example, adding height and width for the target image using the EXIF vocabulary [<cite><a href="#bib-exif" class="bibref">exif</a></cite>] could be done by defining a JSON-LD context, including the <code>height</code> and <code>width</code> properties, and linking to the newly defined context in the target resource.</p>
-
-  <div class="example"><div class="example-title marker"><span>Example 99</span><span style="text-transform: none">: Extension Example 2</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno79"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"skos:prefLabel"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Picture Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I love this picture!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/images/ns/extension.jsonld"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.com/images/picture1"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Image"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"height"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">768</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"width"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">1024</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-<p>Note that the current JSON-LD [<cite><a href="#bib-JSON-LD" class="bibref">JSON-LD</a></cite>] specification does not allow arrays to contain other arrays directly.  As JSON-LD is the <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization format, extensions <em title="SHOULD" class="rfc2119">SHOULD</em> avoid the use of this pattern.</p>
-
-<p>Finally, new classes can be defined to further extend the model for specific communities and use cases.  New Selectors and States are particularly valuable for extension for new ways of defining representations, and for selecting segments of those representations.</p>
-
-<p>For example, an annotation on a three dimensional model would require the addition of depth and the starting position on the z axis, along with x, y, width, and height.  These might be kept together in a new ThreeDSelector resource.</p>
-
-  <div class="example"><div class="example-title marker"><span>Example 100</span><span style="text-transform: none">: Extension Example 3</span></div><pre style="" class="highlight prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/anno80"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"skos:prefLabel"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"3d Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"I love this part of the model!"</span><span class="pln">
-  </span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/models/robot.3d"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-      </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://example.org/3d/ns/extension.jsonld"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"ThreeDSelector"</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"x"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">1035</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"y"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">245</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"z"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">782</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"w"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">120</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"h"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">180</span><span class="pun">,</span><span class="pln">
-      </span><span class="str">"d"</span><span class="pun">:</span><span class="pln"> </span><span class="lit">90</span><span class="pln">
-    </span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre></div>
-
-</section>
-
-
-<section property="bibo:hasPart" resource="#json-ld-context" typeof="bibo:Chapter" id="json-ld-context" class="appendix">
-  <!--OddPage--><h2 resource="#h-json-ld-context" id="h-json-ld-context"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>JSON-LD Context</span></h2>
-
-<p>
-The <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> serialization format is [<cite><a href="#bib-JSON-LD" class="bibref">JSON-LD</a></cite>]. The JSON-LD context presented below is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> to ensure consistency between implementations, and <em title="SHOULD" class="rfc2119">SHOULD</em> be referenced as <code>http://www.w3.org/ns/anno.jsonld</code>.  The same URI <em title="SHOULD" class="rfc2119">SHOULD</em> be used as the profile URI for representations that conform to the model and context.</p>
-
-<pre style="" class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
- </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="pln">
-    </span><span class="str">"oa"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"http://www.w3.org/ns/oa#"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"dc"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"http://purl.org/dc/elements/1.1/"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"dcterms"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://purl.org/dc/terms/"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"dctypes"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://purl.org/dc/dcmitype/"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"foaf"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"http://xmlns.com/foaf/0.1/"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"rdf"</span><span class="pun">:</span><span class="pln">     </span><span class="str">"http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"rdfs"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"http://www.w3.org/2000/01/rdf-schema#"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"skos"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"http://www.w3.org/2004/02/skos/core#"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"xsd"</span><span class="pun">:</span><span class="pln">     </span><span class="str">"http://www.w3.org/2001/XMLSchema#"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"iana"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"http://www.iana.org/assignments/relation/"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"owl"</span><span class="pun">:</span><span class="pln">     </span><span class="str">"http://www.w3.org/2002/07/owl#"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"as"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"http://www.w3.org/ns/activitystreams#"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"schema"</span><span class="pun">:</span><span class="pln">  </span><span class="str">"http://schema.org/"</span><span class="pun">,</span><span class="pln">
-
-    </span><span class="str">"id"</span><span class="pun">:</span><span class="pln">      </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln">    </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">},</span><span class="pln">
-
-    </span><span class="str">"Annotation"</span><span class="pun">:</span><span class="pln">           </span><span class="str">"oa:Annotation"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Dataset"</span><span class="pun">:</span><span class="pln">              </span><span class="str">"dctypes:Dataset"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Image"</span><span class="pun">:</span><span class="pln">                </span><span class="str">"dctypes:StillImage"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Video"</span><span class="pun">:</span><span class="pln">                </span><span class="str">"dctypes:MovingImage"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Audio"</span><span class="pun">:</span><span class="pln">                </span><span class="str">"dctypes:Sound"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Text"</span><span class="pun">:</span><span class="pln">                 </span><span class="str">"dctypes:Text"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"TextualBody"</span><span class="pun">:</span><span class="pln">          </span><span class="str">"oa:TextualBody"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"ResourceSelection"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"oa:ResourceSelection"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"SpecificResource"</span><span class="pun">:</span><span class="pln">     </span><span class="str">"oa:SpecificResource"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"FragmentSelector"</span><span class="pun">:</span><span class="pln">     </span><span class="str">"oa:FragmentSelector"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"CssSelector"</span><span class="pun">:</span><span class="pln">          </span><span class="str">"oa:CssSelector"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"XPathSelector"</span><span class="pun">:</span><span class="pln">        </span><span class="str">"oa:XPathSelector"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"TextQuoteSelector"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"oa:TextQuoteSelector"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"TextPositionSelector"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:TextPositionSelector"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"DataPositionSelector"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:DataPositionSelector"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"SvgSelector"</span><span class="pun">:</span><span class="pln">          </span><span class="str">"oa:SvgSelector"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"RangeSelector"</span><span class="pun">:</span><span class="pln">        </span><span class="str">"oa:RangeSelector"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"TimeState"</span><span class="pun">:</span><span class="pln">            </span><span class="str">"oa:TimeState"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"HttpState"</span><span class="pun">:</span><span class="pln">            </span><span class="str">"oa:HttpRequestState"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"CssStylesheet"</span><span class="pun">:</span><span class="pln">        </span><span class="str">"oa:CssStyle"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Choice"</span><span class="pun">:</span><span class="pln">               </span><span class="str">"oa:Choice"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Composite"</span><span class="pun">:</span><span class="pln">            </span><span class="str">"oa:Composite"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"List"</span><span class="pun">:</span><span class="pln">                 </span><span class="str">"oa:List"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Independents"</span><span class="pun">:</span><span class="pln">         </span><span class="str">"oa:Independents"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Person"</span><span class="pun">:</span><span class="pln">               </span><span class="str">"foaf:Person"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Software"</span><span class="pun">:</span><span class="pln">             </span><span class="str">"as:Application"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Organization"</span><span class="pun">:</span><span class="pln">         </span><span class="str">"foaf:Organization"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"AnnotationCollection"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:OrderedCollection"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"AnnotationPage"</span><span class="pun">:</span><span class="pln">       </span><span class="str">"as:OrderedCollectionPage"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"Audience"</span><span class="pun">:</span><span class="pln">             </span><span class="str">"schema:Audience"</span><span class="pun">,</span><span class="pln"> 
-
-    </span><span class="str">"Motivation"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"oa:Motivation"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"bookmarking"</span><span class="pun">:</span><span class="pln">   </span><span class="str">"oa:bookmarking"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"classifying"</span><span class="pun">:</span><span class="pln">   </span><span class="str">"oa:classifying"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"commenting"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"oa:commenting"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"describing"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"oa:describing"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"editing"</span><span class="pun">:</span><span class="pln">       </span><span class="str">"oa:editing"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"highlighting"</span><span class="pun">:</span><span class="pln">  </span><span class="str">"oa:highlighting"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"identifying"</span><span class="pun">:</span><span class="pln">   </span><span class="str">"oa:identifying"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"linking"</span><span class="pun">:</span><span class="pln">       </span><span class="str">"oa:linking"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"moderating"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"oa:moderating"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"questioning"</span><span class="pun">:</span><span class="pln">   </span><span class="str">"oa:questioning"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"replying"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"oa:replying"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"reviewing"</span><span class="pun">:</span><span class="pln">     </span><span class="str">"oa:reviewing"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"tagging"</span><span class="pun">:</span><span class="pln">       </span><span class="str">"oa:tagging"</span><span class="pun">,</span><span class="pln">
-
-    </span><span class="str">"body"</span><span class="pun">:</span><span class="pln">          </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasBody"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"target"</span><span class="pun">:</span><span class="pln">        </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasTarget"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"source"</span><span class="pun">:</span><span class="pln">        </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasSource"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"selector"</span><span class="pun">:</span><span class="pln">      </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasSelector"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"state"</span><span class="pun">:</span><span class="pln">         </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasState"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"scope"</span><span class="pun">:</span><span class="pln">         </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasScope"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"refinedBy"</span><span class="pun">:</span><span class="pln">     </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:refinedBy"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"startSelector"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasStartSelector"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"endSelector"</span><span class="pun">:</span><span class="pln">   </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasEndSelector"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"renderedVia"</span><span class="pun">:</span><span class="pln">   </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:renderedVia"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln">       </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"dcterms:creator"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln">     </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:generator"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"rights"</span><span class="pun">:</span><span class="pln">        </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"dcterms:rights"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"homepage"</span><span class="pun">:</span><span class="pln">      </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"foaf:homepage"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"via"</span><span class="pun">:</span><span class="pln">           </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:via"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"canonical"</span><span class="pun">:</span><span class="pln">     </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:canonical"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"stylesheet"</span><span class="pun">:</span><span class="pln">    </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:styledBy"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"cached"</span><span class="pun">:</span><span class="pln">        </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:cachedSource"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"conformsTo"</span><span class="pun">:</span><span class="pln">    </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"dcterms:conformsTo"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"items"</span><span class="pun">:</span><span class="pln">         </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:items"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@container"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@list"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"partOf"</span><span class="pun">:</span><span class="pln">        </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:partOf"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"first"</span><span class="pun">:</span><span class="pln">         </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:first"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"last"</span><span class="pun">:</span><span class="pln">          </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:last"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"next"</span><span class="pun">:</span><span class="pln">          </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:next"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"prev"</span><span class="pun">:</span><span class="pln">          </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:prev"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"audience"</span><span class="pun">:</span><span class="pln">      </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"schema:audience"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln">    </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@vocab"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:motivatedBy"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"purpose"</span><span class="pun">:</span><span class="pln">       </span><span class="pun">{</span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"@vocab"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:hasPurpose"</span><span class="pun">},</span><span class="pln">
-
-    </span><span class="str">"bodyValue"</span><span class="pun">:</span><span class="pln">     </span><span class="str">"oa:bodyValue"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"format"</span><span class="pun">:</span><span class="pln">        </span><span class="str">"dc:format"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"language"</span><span class="pun">:</span><span class="pln">      </span><span class="str">"dc:language"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"value"</span><span class="pun">:</span><span class="pln">         </span><span class="str">"rdf:value"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"exact"</span><span class="pun">:</span><span class="pln">         </span><span class="str">"oa:exact"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"prefix"</span><span class="pun">:</span><span class="pln">        </span><span class="str">"oa:prefix"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"suffix"</span><span class="pun">:</span><span class="pln">        </span><span class="str">"oa:suffix"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"styleClass"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"oa:styleClass"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"name"</span><span class="pun">:</span><span class="pln">          </span><span class="str">"foaf:name"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"email"</span><span class="pun">:</span><span class="pln">         </span><span class="str">"foaf:mbox"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"email_sha1"</span><span class="pun">:</span><span class="pln">    </span><span class="str">"foaf:mbox_sha1sum"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"account"</span><span class="pun">:</span><span class="pln">       </span><span class="str">"foaf:nick"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"label"</span><span class="pun">:</span><span class="pln">         </span><span class="str">"rdfs:label"</span><span class="pun">,</span><span class="pln">
-
-    </span><span class="str">"created"</span><span class="pun">:</span><span class="pln">       </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"dcterms:created"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:dateTime"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"modified"</span><span class="pun">:</span><span class="pln">      </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"dcterms:modified"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:dateTime"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"generated"</span><span class="pun">:</span><span class="pln">     </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"dcterms:issued"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:dateTime"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"sourceDate"</span><span class="pun">:</span><span class="pln">    </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:sourceDate"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:dateTime"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"sourceDateStart"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:sourceDateStart"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:dateTime"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"sourceDateEnd"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:sourceDateEnd"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:dateTime"</span><span class="pun">},</span><span class="pln">
-
-    </span><span class="str">"start"</span><span class="pun">:</span><span class="pln">         </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"oa:start"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:nonNegativeInteger"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"end"</span><span class="pun">:</span><span class="pln">           </span><span class="str">"oa:end"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:nonNegativeInteger"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"total"</span><span class="pun">:</span><span class="pln">         </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:totalItems"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:nonNegativeInteger"</span><span class="pun">},</span><span class="pln">
-    </span><span class="str">"startIndex"</span><span class="pun">:</span><span class="pln">    </span><span class="pun">{</span><span class="str">"@id"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"as:startIndex"</span><span class="pun">,</span><span class="pln"> </span><span class="str">"@type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"xsd:nonNegativeInteger"</span><span class="pun">}</span><span class="pln">
-  </span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span><span class="pln">
-</span></pre>
-</section>
-
-<section property="bibo:hasPart" resource="#json-ld-frames" typeof="bibo:Chapter" id="json-ld-frames" class="appendix">
-  <!--OddPage--><h2 resource="#h-json-ld-frames" id="h-json-ld-frames"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>JSON-LD Frames</span></h2>
-
-<p>There is an unofficial, yet well implemented, JSON-LD specification [<cite><a href="#bib-json-ld-framing" class="bibref">json-ld-framing</a></cite>] that describes a deterministic layout for serializing an RDF graph into a particular JSON-LD document layout.  Applying the following frames to the graph of information will generate JSON as close as possible to the serialization recommended by the Web Annotation Data Model.</p>
-
-<section property="bibo:hasPart" resource="#annotation-frame" typeof="bibo:Chapter" id="annotation-frame">
-  <h3 resource="#h-annotation-frame" id="h-annotation-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.1 </span>Annotation Frame</span></h3>
-<p>
-A Frame for serializing a single Annotation.</p>
-
-<pre style="" class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@omitDefault"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Annotation"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"via"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">false</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"canonical"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">false</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"rights"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">false</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"motivation"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">false</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"body"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"target"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"creator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"generator"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"audience"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span><span class="pln">
-</span></pre>
-</section>
-
-<section property="bibo:hasPart" resource="#annotation-collection-frame" typeof="bibo:Chapter" id="annotation-collection-frame">
-  <h3 resource="#h-annotation-collection-frame" id="h-annotation-collection-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.2 </span>Annotation Collection Frame</span></h3>
-
-<p>A Frame for serializing a Collection of Annotations.</p>
-
-<pre style="" class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-    </span><span class="str">"@context"</span><span class="pln"> </span><span class="pun">:</span><span class="pln"> </span><span class="pun">[</span><span class="pln">
-    	</span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-    	</span><span class="str">"http://www.w3.org/ns/ldp.jsonld"</span><span class="pln">
-  	</span><span class="pun">],</span><span class="pln">
-    </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"Collection"</span><span class="pun">,</span><span class="pln">
-    </span><span class="str">"first"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"False"</span><span class="pun">}],</span><span class="pln">
-    </span><span class="str">"last"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">[{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"False"</span><span class="pun">}]</span><span class="pln">
-</span><span class="pun">}</span><span class="pln">
-</span></pre>
-
-<div class="note"><div id="h-note5" role="heading" aria-level="4" class="note-title marker"><span>Note</span></div><div class="">If it is instead desirable to embed the first page of the Collection, change the <code>false</code> for <code>first</code> to <code>true</code>.</div></div>
-
-</section>
-<section property="bibo:hasPart" resource="#annotation-page-frame" typeof="bibo:Chapter" id="annotation-page-frame">
-  <h3 resource="#h-annotation-page-frame" id="h-annotation-page-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.3 </span>Annotation Page Frame</span></h3>
-
-<p>A Frame for serializing a Page from a Collection of Annotations.</p>
-
-<pre style="" class="highlight tech example-padding prettyprint prettyprinted"><span class="pun">{</span><span class="pln">
-  </span><span class="str">"@context"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"http://www.w3.org/ns/anno.jsonld"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"@omitDefault"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"type"</span><span class="pun">:</span><span class="pln"> </span><span class="str">"AnnotationPage"</span><span class="pun">,</span><span class="pln">
-  </span><span class="str">"next"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">false</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"prev"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">false</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"partOf"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">false</span><span class="pun">},</span><span class="pln">
-  </span><span class="str">"items"</span><span class="pun">:</span><span class="pln"> </span><span class="pun">{</span><span class="str">"@embed"</span><span class="pun">:</span><span class="pln"> </span><span class="kwd">true</span><span class="pun">}</span><span class="pln">
-</span><span class="pun">}</span></pre>
-
-</section>
-</section>
-
-<section property="bibo:hasPart" resource="#extending-motivations" typeof="bibo:Chapter" id="extending-motivations" class="appendix">
-  <!--OddPage--><h2 resource="#h-extending-motivations" id="h-extending-motivations"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>Extending Motivations</span></h2>
-
-<p>Although the list of Motivations in the specification is derived from an extensive survey of the annotation landscape, there are many situations where more precise definitions are required or desirable. In these cases it is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> to create a new Motivation resource and relate it to one or more that already exist.</p>
-
-<p>New Motivations <em title="MUST" class="rfc2119">MUST</em> be instances of <code>oa:Motivation</code>, which is a subClass of <code>skos:Concept</code>.
-The <code>skos:broader</code> relationship <em title="SHOULD" class="rfc2119">SHOULD</em> be asserted between the new Motivation and at least one existing Motivation, if there are any that are broader in scope.  Other relationships, such as <code>skos:relatedMatch</code>, <code>skos:exactMatch</code> and <code>skos:closeMatch</code>, <em title="SHOULD" class="rfc2119">SHOULD</em> also be asserted to concepts created by other communities.
-</p>
-
-<h2 id="model">Model</h2>
-<figure id="fig-extending-motivations">
-        <img src="images/skosmotivations.png" alt="Use of SKOS to extend motivations">
-        <figcaption>Fig. <span class="figno">1</span> <span class="fig-title">Extending Motivations</span></figcaption>
+    </p>
+    <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+    </p>
+
+  </section>
+  <nav id="toc">
+    <h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
+    <ul class="toc" role="directory">
+      <li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#namespaces" class="tocxref"><span class="secno">1.1 </span>Namespaces</a></li>
+          <li class="tocline"><a href="#diagrams-and-examples" class="tocxref"><span class="secno">1.2 </span>Diagrams and Examples</a></li>
+          <li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">1.3 </span>Conformance</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#web-annotation-ontology" class="tocxref"><span class="secno">2. </span>Web Annotation Ontology</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#classes" class="tocxref"><span class="secno">2.1 </span>Classes</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#annotation" class="tocxref"><span class="secno">2.1.1 </span>Annotation</a></li>
+              <li class="tocline"><a href="#choice" class="tocxref"><span class="secno">2.1.2 </span>Choice</a></li>
+              <li class="tocline"><a href="#composite" class="tocxref"><span class="secno">2.1.3 </span>Composite</a></li>
+              <li class="tocline"><a href="#cssselector" class="tocxref"><span class="secno">2.1.4 </span>CssSelector</a></li>
+              <li class="tocline"><a href="#cssstyle" class="tocxref"><span class="secno">2.1.5 </span>CssStyle</a></li>
+              <li class="tocline"><a href="#datapositionselector" class="tocxref"><span class="secno">2.1.6 </span>DataPositionSelector</a></li>
+              <li class="tocline"><a href="#direction" class="tocxref"><span class="secno">2.1.7 </span>Direction</a></li>
+              <li class="tocline"><a href="#fragmentselector" class="tocxref"><span class="secno">2.1.8 </span>FragmentSelector</a></li>
+              <li class="tocline"><a href="#httprequeststate" class="tocxref"><span class="secno">2.1.9 </span>HttpRequestState</a></li>
+              <li class="tocline"><a href="#independents" class="tocxref"><span class="secno">2.1.10 </span>Independents</a></li>
+              <li class="tocline"><a href="#list" class="tocxref"><span class="secno">2.1.11 </span>List</a></li>
+              <li class="tocline"><a href="#motivation" class="tocxref"><span class="secno">2.1.12 </span>Motivation</a></li>
+              <li class="tocline"><a href="#rangeselector" class="tocxref"><span class="secno">2.1.13 </span>RangeSelector</a></li>
+              <li class="tocline"><a href="#resourceselection" class="tocxref"><span class="secno">2.1.14 </span>ResourceSelection</a></li>
+              <li class="tocline"><a href="#selector" class="tocxref"><span class="secno">2.1.15 </span>Selector</a></li>
+              <li class="tocline"><a href="#specificresource" class="tocxref"><span class="secno">2.1.16 </span>SpecificResource</a></li>
+              <li class="tocline"><a href="#state" class="tocxref"><span class="secno">2.1.17 </span>State</a></li>
+              <li class="tocline"><a href="#style" class="tocxref"><span class="secno">2.1.18 </span>Style</a></li>
+              <li class="tocline"><a href="#svgselector" class="tocxref"><span class="secno">2.1.19 </span>SvgSelector</a></li>
+              <li class="tocline"><a href="#textpositionselector" class="tocxref"><span class="secno">2.1.20 </span>TextPositionSelector</a></li>
+              <li class="tocline"><a href="#textquoteselector" class="tocxref"><span class="secno">2.1.21 </span>TextQuoteSelector</a></li>
+              <li class="tocline"><a href="#textualbody" class="tocxref"><span class="secno">2.1.22 </span>TextualBody</a></li>
+              <li class="tocline"><a href="#timestate" class="tocxref"><span class="secno">2.1.23 </span>TimeState</a></li>
+              <li class="tocline"><a href="#xpathselector" class="tocxref"><span class="secno">2.1.24 </span>XPathSelector</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#properties" class="tocxref"><span class="secno">2.2 </span>Properties</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#annotationservice" class="tocxref"><span class="secno">2.2.1 </span>annotationService</a></li>
+              <li class="tocline"><a href="#bodyvalue" class="tocxref"><span class="secno">2.2.2 </span>bodyValue</a></li>
+              <li class="tocline"><a href="#cachedsource" class="tocxref"><span class="secno">2.2.3 </span>cachedSource</a></li>
+              <li class="tocline"><a href="#canonical" class="tocxref"><span class="secno">2.2.4 </span>canonical</a></li>
+              <li class="tocline"><a href="#end" class="tocxref"><span class="secno">2.2.5 </span>end</a></li>
+              <li class="tocline"><a href="#exact" class="tocxref"><span class="secno">2.2.6 </span>exact</a></li>
+              <li class="tocline"><a href="#hasbody" class="tocxref"><span class="secno">2.2.7 </span>hasBody</a></li>
+              <li class="tocline"><a href="#hasendselector" class="tocxref"><span class="secno">2.2.8 </span>hasEndSelector</a></li>
+              <li class="tocline"><a href="#haspurpose" class="tocxref"><span class="secno">2.2.9 </span>hasPurpose</a></li>
+              <li class="tocline"><a href="#hasscope" class="tocxref"><span class="secno">2.2.10 </span>hasScope</a></li>
+              <li class="tocline"><a href="#hasselector" class="tocxref"><span class="secno">2.2.11 </span>hasSelector</a></li>
+              <li class="tocline"><a href="#hassource" class="tocxref"><span class="secno">2.2.12 </span>hasSource</a></li>
+              <li class="tocline"><a href="#hasstartselector" class="tocxref"><span class="secno">2.2.13 </span>hasStartSelector</a></li>
+              <li class="tocline"><a href="#hasstate" class="tocxref"><span class="secno">2.2.14 </span>hasState</a></li>
+              <li class="tocline"><a href="#hastarget" class="tocxref"><span class="secno">2.2.15 </span>hasTarget</a></li>
+              <li class="tocline"><a href="#motivatedby" class="tocxref"><span class="secno">2.2.16 </span>motivatedBy</a></li>
+              <li class="tocline"><a href="#prefix" class="tocxref"><span class="secno">2.2.17 </span>prefix</a></li>
+              <li class="tocline"><a href="#refinedby" class="tocxref"><span class="secno">2.2.18 </span>refinedBy</a></li>
+              <li class="tocline"><a href="#renderedvia" class="tocxref"><span class="secno">2.2.19 </span>renderedVia</a></li>
+              <li class="tocline"><a href="#sourcedate" class="tocxref"><span class="secno">2.2.20 </span>sourceDate</a></li>
+              <li class="tocline"><a href="#sourcedateend" class="tocxref"><span class="secno">2.2.21 </span>sourceDateEnd</a></li>
+              <li class="tocline"><a href="#sourcedatestart" class="tocxref"><span class="secno">2.2.22 </span>sourceDateStart</a></li>
+              <li class="tocline"><a href="#start" class="tocxref"><span class="secno">2.2.23 </span>start</a></li>
+              <li class="tocline"><a href="#styleclass" class="tocxref"><span class="secno">2.2.24 </span>styleClass</a></li>
+              <li class="tocline"><a href="#styledby" class="tocxref"><span class="secno">2.2.25 </span>styledBy</a></li>
+              <li class="tocline"><a href="#suffix" class="tocxref"><span class="secno">2.2.26 </span>suffix</a></li>
+              <li class="tocline"><a href="#textdirection" class="tocxref"><span class="secno">2.2.27 </span>textDirection</a></li>
+              <li class="tocline"><a href="#via" class="tocxref"><span class="secno">2.2.28 </span>via</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#named-individuals" class="tocxref"><span class="secno">2.3 </span>Named Individuals</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#bookmarking" class="tocxref"><span class="secno">2.3.1 </span>bookmarking</a></li>
+              <li class="tocline"><a href="#classifying" class="tocxref"><span class="secno">2.3.2 </span>classifying</a></li>
+              <li class="tocline"><a href="#commenting" class="tocxref"><span class="secno">2.3.3 </span>commenting</a></li>
+              <li class="tocline"><a href="#describing" class="tocxref"><span class="secno">2.3.4 </span>describing</a></li>
+              <li class="tocline"><a href="#editing" class="tocxref"><span class="secno">2.3.5 </span>editing</a></li>
+              <li class="tocline"><a href="#highlighting" class="tocxref"><span class="secno">2.3.6 </span>highlighting</a></li>
+              <li class="tocline"><a href="#identifying" class="tocxref"><span class="secno">2.3.7 </span>identifying</a></li>
+              <li class="tocline"><a href="#linking" class="tocxref"><span class="secno">2.3.8 </span>linking</a></li>
+              <li class="tocline"><a href="#moderating" class="tocxref"><span class="secno">2.3.9 </span>moderating</a></li>
+              <li class="tocline"><a href="#questioning" class="tocxref"><span class="secno">2.3.10 </span>questioning</a></li>
+              <li class="tocline"><a href="#replying" class="tocxref"><span class="secno">2.3.11 </span>replying</a></li>
+              <li class="tocline"><a href="#reviewing" class="tocxref"><span class="secno">2.3.12 </span>reviewing</a></li>
+              <li class="tocline"><a href="#tagging" class="tocxref"><span class="secno">2.3.13 </span>tagging</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#ltr" class="tocxref"><span class="secno">2.4 </span>ltr</a></li>
+          <li class="tocline"><a href="#rtl" class="tocxref"><span class="secno">2.5 </span>rtl</a></li>
+          <li class="tocline"><a href="#prefercontaineddescriptions" class="tocxref"><span class="secno">2.6 </span>PreferContainedDescriptions</a></li>
+          <li class="tocline"><a href="#prefercontainediris" class="tocxref"><span class="secno">2.7 </span>PreferContainedIRIs</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#recommended-ontologies" class="tocxref"><span class="secno">3. </span>Recommended Ontologies</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#classes-1" class="tocxref"><span class="secno">3.1 </span>Classes</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#as-application" class="tocxref"><span class="secno">3.1.1 </span>as:Application</a></li>
+              <li class="tocline"><a href="#as-orderedcollection" class="tocxref"><span class="secno">3.1.2 </span>as:OrderedCollection</a></li>
+              <li class="tocline"><a href="#as-orderedcollectionpage" class="tocxref"><span class="secno">3.1.3 </span>as:OrderedCollectionPage</a></li>
+              <li class="tocline"><a href="#dctypes-dataset" class="tocxref"><span class="secno">3.1.4 </span>dctypes:Dataset</a></li>
+              <li class="tocline"><a href="#dctypes-movingimage" class="tocxref"><span class="secno">3.1.5 </span>dctypes:MovingImage</a></li>
+              <li class="tocline"><a href="#dctypes-stillimage" class="tocxref"><span class="secno">3.1.6 </span>dctypes:StillImage</a></li>
+              <li class="tocline"><a href="#dctypes-sound" class="tocxref"><span class="secno">3.1.7 </span>dctypes:Sound</a></li>
+              <li class="tocline"><a href="#dctypes-text" class="tocxref"><span class="secno">3.1.8 </span>dctypes:Text</a></li>
+              <li class="tocline"><a href="#foaf-organization" class="tocxref"><span class="secno">3.1.9 </span>foaf:Organization</a></li>
+              <li class="tocline"><a href="#foaf-person" class="tocxref"><span class="secno">3.1.10 </span>foaf:Person</a></li>
+              <li class="tocline"><a href="#schema-audience" class="tocxref"><span class="secno">3.1.11 </span>schema:Audience</a></li>
+            </ul>
+          </li>
+          <li class="tocline"><a href="#properties-1" class="tocxref"><span class="secno">3.2 </span>Properties</a>
+            <ul class="toc">
+              <li class="tocline"><a href="#as-first" class="tocxref"><span class="secno">3.2.1 </span>as:first</a></li>
+              <li class="tocline"><a href="#as-generator" class="tocxref"><span class="secno">3.2.2 </span>as:generator</a></li>
+              <li class="tocline"><a href="#as-items" class="tocxref"><span class="secno">3.2.3 </span>as:items</a></li>
+              <li class="tocline"><a href="#as-last" class="tocxref"><span class="secno">3.2.4 </span>as:last</a></li>
+              <li class="tocline"><a href="#as-next" class="tocxref"><span class="secno">3.2.5 </span>as:next</a></li>
+              <li class="tocline"><a href="#as-partof" class="tocxref"><span class="secno">3.2.6 </span>as:partOf</a></li>
+              <li class="tocline"><a href="#as-prev" class="tocxref"><span class="secno">3.2.7 </span>as:prev</a></li>
+              <li class="tocline"><a href="#as-startindex" class="tocxref"><span class="secno">3.2.8 </span>as:startIndex</a></li>
+              <li class="tocline"><a href="#as-totalitems" class="tocxref"><span class="secno">3.2.9 </span>as:totalItems</a></li>
+              <li class="tocline"><a href="#dc-format" class="tocxref"><span class="secno">3.2.10 </span>dc:format</a></li>
+              <li class="tocline"><a href="#dc-language" class="tocxref"><span class="secno">3.2.11 </span>dc:language</a></li>
+              <li class="tocline"><a href="#dcterms-conformsto" class="tocxref"><span class="secno">3.2.12 </span>dcterms:conformsTo</a></li>
+              <li class="tocline"><a href="#dcterms-created" class="tocxref"><span class="secno">3.2.13 </span>dcterms:created</a></li>
+              <li class="tocline"><a href="#dcterms-creator" class="tocxref"><span class="secno">3.2.14 </span>dcterms:creator</a></li>
+              <li class="tocline"><a href="#dcterms-issued" class="tocxref"><span class="secno">3.2.15 </span>dcterms:issued</a></li>
+              <li class="tocline"><a href="#dcterms-modified" class="tocxref"><span class="secno">3.2.16 </span>dcterms:modified</a></li>
+              <li class="tocline"><a href="#dcterms-rights" class="tocxref"><span class="secno">3.2.17 </span>dcterms:rights</a></li>
+              <li class="tocline"><a href="#foaf-homepage" class="tocxref"><span class="secno">3.2.18 </span>foaf:homepage</a></li>
+              <li class="tocline"><a href="#foaf-mbox" class="tocxref"><span class="secno">3.2.19 </span>foaf:mbox</a></li>
+              <li class="tocline"><a href="#foaf-mbox_sha1sum" class="tocxref"><span class="secno">3.2.20 </span>foaf:mbox_sha1sum</a></li>
+              <li class="tocline"><a href="#foaf-name" class="tocxref"><span class="secno">3.2.21 </span>foaf:name</a></li>
+              <li class="tocline"><a href="#foaf-nick" class="tocxref"><span class="secno">3.2.22 </span>foaf:nick</a></li>
+              <li class="tocline"><a href="#rdf-type" class="tocxref"><span class="secno">3.2.23 </span>rdf:type</a></li>
+              <li class="tocline"><a href="#rdf-value" class="tocxref"><span class="secno">3.2.24 </span>rdf:value</a></li>
+              <li class="tocline"><a href="#rdfs-label" class="tocxref"><span class="secno">3.2.25 </span>rdfs:label</a></li>
+              <li class="tocline"><a href="#schema-accessibilityfeature" class="tocxref"><span class="secno">3.2.26 </span>schema:accessibilityFeature</a></li>
+              <li class="tocline"><a href="#schema-audience-1" class="tocxref"><span class="secno">3.2.27 </span>schema:audience</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#extensions" class="tocxref"><span class="secno">4. </span>Extensions</a></li>
+      <li class="tocline"><a href="#json-ld-context" class="tocxref"><span class="secno">A. </span>JSON-LD Context</a></li>
+      <li class="tocline"><a href="#json-ld-frames" class="tocxref"><span class="secno">B. </span>JSON-LD Frames</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#annotation-frame" class="tocxref"><span class="secno">B.1 </span>Annotation Frame</a></li>
+          <li class="tocline"><a href="#annotation-collection-frame" class="tocxref"><span class="secno">B.2 </span>Annotation Collection Frame</a></li>
+          <li class="tocline"><a href="#annotation-page-frame" class="tocxref"><span class="secno">B.3 </span>Annotation Page Frame</a></li>
+        </ul>
+      </li>
+      <li class="tocline"><a href="#extending-motivations" class="tocxref"><span class="secno">C. </span>Extending Motivations</a></li>
+      <li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">D. </span>Acknowledgements</a></li>
+      <li class="tocline"><a href="#references" class="tocxref"><span class="secno">E. </span>References</a>
+        <ul class="toc">
+          <li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">E.1 </span>Normative references</a></li>
+          <li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">E.2 </span>Informative references</a></li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+
+
+  <section class="informative" id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
+    <p><em>This section is non-normative.</em></p>
+
+    <p>
+      The specification is divided into two major sections: the terms defined in the Web Annotation ontology, and terms from other ontologies used in the model.
+    </p>
+
+    <p>
+      Each class lists the recommendations from the model for the <em class="rfc2119" title="REQUIRED">REQUIRED</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> and <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> object and data properties for instances of the class. Instances may, of course, be the subject of any other triples that implementers find useful, however there is no expectation of interoperability in these cases.
+    </p>
+
+    <section id="namespaces" typeof="bibo:Chapter" resource="#namespaces" property="bibo:hasPart">
+      <h3 id="h-namespaces" resource="#h-namespaces"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Namespaces</span></h3>
+
+      <table class="model">
+        <tbody>
+          <tr>
+            <th>Prefix</th>
+            <th>Namespace</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>oa</td>
+            <td>http://www.w3.org/ns/oa#</td>
+            <td>The Web Annotation Data Model</td>
+          </tr>
+          <tr>
+            <td>as</td>
+            <td>http://www.w3.org/ns/activitystreams#</td>
+            <td>[<cite><a class="bibref" href="#bib-activitystreams-vocabulary">activitystreams-vocabulary</a></cite>]</td>
+          </tr>
+          <tr>
+            <td>dc</td>
+            <td>http://purl.org/dc/elements/1.1/</td>
+            <td>[<cite><a class="bibref" href="#bib-DC11">DC11</a></cite>]</td>
+          </tr>
+          <tr>
+            <td>dcterms</td>
+            <td>http://purl.org/dc/terms/</td>
+            <td>[<cite><a class="bibref" href="#bib-DC-TERMS">DC-TERMS</a></cite>]</td>
+          </tr>
+          <tr>
+            <td>dctypes</td>
+            <td>http://purl.org/dc/dcmitype/</td>
+            <td>[<cite><a class="bibref" href="#bib-DC-TERMS">DC-TERMS</a></cite>]</td>
+          </tr>
+          <tr>
+            <td>foaf</td>
+            <td>http://xmlns.com/foaf/0.1/</td>
+            <td>[<cite><a class="bibref" href="#bib-FOAF">FOAF</a></cite>]</td>
+          </tr>
+          <tr>
+            <td>rdf</td>
+            <td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td>
+            <td>[<cite><a class="bibref" href="#bib-rdf-schema">rdf-schema</a></cite>]</td>
+          </tr>
+          <tr>
+            <td>rdfs</td>
+            <td>http://www.w3.org/2000/01/rdf-schema#</td>
+            <td>[<cite><a class="bibref" href="#bib-rdf-schema">rdf-schema</a></cite>]</td>
+          </tr>
+          <tr>
+            <td>schema</td>
+            <td>http://schema.org/</td>
+            <td><a href="http://schema.org/">schema.org</a></td>
+          </tr>
+          <tr>
+            <td>skos</td>
+            <td>http://www.w3.org/2004/02/skos/core#</td>
+            <td>[<cite><a class="bibref" href="#bib-skos-reference">skos-reference</a></cite>]</td>
+          </tr>
+          <tr>
+            <td>xsd</td>
+            <td>http://www.w3.org/2001/XMLSchema#</td>
+            <td>[<cite><a class="bibref" href="#bib-xmlschema-2">xmlschema-2</a></cite>]</td>
+          </tr>
+        </tbody>
+      </table>
+
+    </section>
+
+    <section id="diagrams-and-examples" typeof="bibo:Chapter" resource="#diagrams-and-examples" property="bibo:hasPart">
+      <h3 id="h-diagrams-and-examples" resource="#h-diagrams-and-examples"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Diagrams and Examples</span></h3>
+
+      <p>
+        The examples throughout the document are serialized as [<cite><a class="bibref" href="#bib-Turtle">Turtle</a></cite>] with the prefixes taken from the namespace declarations given in <a href="#namespaces">Appendix A</a>. The examples are informative only.
+      </p>
+
+      <p>The diagrams use the following style</p>
+
+      <ul>
+        <li>Instances are depicted as colored ellipses.</li>
+        <li>Instances without a URI are depicted as colored ellipses with double lines.</li>
+        <li>Classes are depicted as white rectangles.</li>
+        <li>Literals are depicted as white lozenges.</li>
+        <li>Relationships and properties are depicted as straight, black lines.</li>
+        <li>Class instantiation is depicted as a straight black line with white arrow head.</li>
+        <li>Example instance identifiers are lowercase and end in a number.<br> For example, <code>anno1</code> is a specific instance of an Annotation, whereas <code>Annotation</code> is a class.</li>
+        <li>Example literals follow the requirements for the model and, thus, must not be interpreted as the only possible value.</li>
+        <li>Lists are depicted as vertical braces with a gray background and '...' in the middle (regardless of if there are actually other items in the list or not).</li>
+        <li>Conceptual resource boundaries not explicit in the model, but considered important for understanding, are depicted as grey dashed boxes around the components. They are used to convey spatial parts of the diagrams and may be safely ignored.</li>
+      </ul>
+
+      <div class="issue" id="issue-2">
+        <div class="issue-title marker" aria-level="4" role="heading" id="h-issue2"><span>Issue 2</span></div>
+        <div class="">
+          The diagrams have yet to be completed (<a href="https://github.com/w3c/web-annotation/issues/131">Github Issue</a>).
+        </div>
+      </div>
+
+    </section>
+
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart">
+      <h3 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
+      <p>
+        As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
+      </p>
+      <p id="respecRFC2119">The key words <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="OPTIONAL">OPTIONAL</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="REQUIRED">REQUIRED</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+      </p>
+
+    </section>
+  </section>
+  <!-- End Introduction -->
+
+  <section id="web-annotation-ontology" typeof="bibo:Chapter" resource="#web-annotation-ontology" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-web-annotation-ontology" resource="#h-web-annotation-ontology"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Ontology</span></h2> The namespace used for the Web Annotation Ontology is:
+    <code>http://www.w3.org/ns/oa#</code>
+
+    <section id="classes" typeof="bibo:Chapter" resource="#classes" property="bibo:hasPart">
+      <h3 id="h-classes" resource="#h-classes"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1 </span>Classes</span></h3>
+
+      <div class="termtoc">
+        <a href="#annotation">Annotation</a> | <a href="#choice">Choice</a> | <a href="#composite">Composite</a> | <a href="#cssselector">CssSelector</a> | <a href="#cssstyle">CssStyle</a> | <a href="#datapositionselector">DataPositionSelector</a> | <a href="#direction">Direction</a> | <a href="#fragmentselector">FragmentSelector</a> | <a href="#httprequeststate">HttpRequestState</a> | <a href="#independents">Independents</a> | <a href="#list">List</a> | <a href="#motivation">Motivation</a> | <a href="#rangeselector">RangeSelector</a> | <a href="#resourceselection">ResourceSelection</a> | <a href="#selector">Selector</a> | <a href="#specificresource">SpecificResource</a> | <a href="#state">State</a> | <a href="#style">Style</a> | <a href="#svgselector">SvgSelector</a> | <a href="#textpositionselector">TextPositionSelector</a> | <a href="#textquoteselector">TextQuoteSelector</a> | <a href="#textualbody">TextualBody</a> | <a href="#timestate">TimeState</a> | <a href="#xpathselector">XPathSelector</a>
+      </div>
+
+      <section class="term" id="annotation" typeof="bibo:Chapter" resource="#annotation" property="bibo:hasPart">
+        <h4 id="h-annotation" resource="#h-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.1 </span>Annotation</span></h4>
+        <p>The class for Web Annotations.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Annotation</li>
+            <li><strong>Required Predicates:</strong> <a href="#hastarget">oa:hasTarget</a>, <a href="#rdf-type">rdf:type</a></li>
+            <li><strong>Recommended Predicates:</strong> <a href="#hasbody">oa:hasBody</a>, <a href="#motivatedby">oa:motivatedBy</a>, <a href="#dcterms-creator">dcterms:creator</a>, <a href="#dcterms-created">dcterms:created</a></li>
+            <li><strong>Other Predicates:</strong> <a href="#bodyvalue">oa:bodyValue</a>, <a href="#styledby">oa:styledBy</a>, <a href="#dcterms-issued">dcterms:issued</a>, <a href="#as-generator">as:generator</a> </li>
+          </ul>
+        </div>
+        <div class="diagram_img">
+          <img src="images/examples/annotation.png" alt="oa:Annotation with properties" longdesc="#example_anno">
+        </div>
+        <div id="example_anno">
+          <div class="example">
+            <div class="example-title marker"><span>Example 1</span><span style="text-transform: none">: oa:Annotation</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno1&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/post1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/page1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:commenting </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">creator &lt;http://example.org/person1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">created <span class="hljs-string">"2015-11-18T12:00:00Z"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="choice" typeof="bibo:Chapter" resource="#choice" property="bibo:hasPart">
+        <h4 id="h-choice" resource="#h-choice"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.2 </span>Choice</span></h4>
+        <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that it should select one of the resources in the <code>as:items</code> list to use, rather than all of them. This is typically used to provide a choice of resources to render to the user, based on further supplied properties. If the consuming application cannot determine the user's preference, then it should use the first in the list.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Choice</li>
+            <li><strong>Sub Class Of:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#as-items">as:items</a></li>
+          </ul>
+        </div>
+        <div class="diagram_img">
+          <img src="images/examples/choice.png" alt="oa:Choice with list of items" longdesc="#example_choice">
+        </div>
+        <div id="example_choice">
+          <div class="example">
+            <div class="example-title marker"><span>Example 2</span><span style="text-transform: none">: oa:Choice</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno2&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/site1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+        a oa:Choice </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items (&lt;http://example.org/note1&gt; &lt;http://example.org/note2&gt;) ] .
+
+&lt;http://example.org/note1&gt; dc:language <span class="hljs-string">"en"</span> .
+&lt;http://example.org/note2&gt; dc:language <span class="hljs-string">"fr"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="composite" typeof="bibo:Chapter" resource="#composite" property="bibo:hasPart">
+        <h4 id="h-composite" resource="#h-composite"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.3 </span>Composite</span></h4>
+        <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that it should use all of the resources in the <code>as:items</code> list, but that order is not important.</p>
+
+        <div class="warning">
+          <div class="warning-title marker"><span>Warning</span></div>
+          <p class="">This class is at-risk.</p>
+        </div>
+
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Composite</li>
+            <li><strong>Sub Class Of:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#as-items">as:items</a></li>
+          </ul>
+        </div>
+        <div class="diagram_img">
+          <img src="images/examples/" alt="oa:Composite with list of items" longdesc="#example_composite">
+        </div>
+        <div id="example_composite">
+          <div class="example">
+            <div class="example-title marker"><span>Example 3</span><span style="text-transform: none">: oa:Composite</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno3&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:commenting </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ 
+        a oa:TextualBody </span></span>; 
+        <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"These pages together provide evidence of the conspiracy"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        a oa:Composite </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items ( &lt;http://example.org/page1&gt; &lt;http://example.org/page6&gt; &lt;http://example.org/page4&gt; ) ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="cssselector" typeof="bibo:Chapter" resource="#cssselector" property="bibo:hasPart">
+        <h4 id="h-cssselector" resource="#h-cssselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.4 </span>CssSelector</span></h4>
+        <p>A CssSelector describes a Segment of interest in a representation that conforms to the Document Object Model through the use of the CSS selector specification.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#CssSelector</li>
+            <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 4</span></div><pre class="highlight hljs css" title="">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno4&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:CssSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"#elemid &gt; .elemclass + p"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="cssstyle" typeof="bibo:Chapter" resource="#cssstyle" property="bibo:hasPart">
+        <h4 id="h-cssstyle" resource="#h-cssstyle"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.5 </span>CssStyle</span></h4>
+        <p>A resource which describes styles for resources participating in the Annotation using CSS.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#CssStyle</li>
+            <li><strong>Sub Class Of:</strong> <a href="#style">oa:Style</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 5</span></div><pre class="highlight hljs css" title="">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno5&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">styledBy &lt;http://example.org/style1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/document1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">styleClass <span class="hljs-string">"red"</span> ] .
+
+&lt;http://example.org/style1&gt; a oa:CssStyle .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="datapositionselector" typeof="bibo:Chapter" resource="#datapositionselector" property="bibo:hasPart">
+        <h4 id="h-datapositionselector" resource="#h-datapositionselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.6 </span>DataPositionSelector</span></h4>
+        <p>DataPositionSelector describes a range of data by recording the start and end positions of the selection in the stream. Position 0 would be immediately before the first byte, position 1 would be immediately before the second byte, and so on. The start byte is thus included in the list, but the end byte is not.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#DataPositionSelector</li>
+            <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#rdf-type">rdf:type</a>, <a href="#start">oa:start</a>, <a href="#end">oa:end</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: oa:DataPositionSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno6&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/diskimg1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:DataPositionSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">start <span class="hljs-number">4096</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">end <span class="hljs-number">4104</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="direction" typeof="bibo:Chapter" resource="#direction" property="bibo:hasPart">
+        <h4 id="h-direction" resource="#h-direction"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.7 </span>Direction</span></h4>
+        <p>A class to encapsulate the different text directions that a textual resource might take. It is not used directly in the Annotation Model, only its three instances.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Direction</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: oa:Direction</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno7&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+        rdfs:value <span class="hljs-string">"This is a comment"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">language <span class="hljs-string">"en"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">format <span class="hljs-string">"text/plain"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">textDirection oa:ltr ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/page1&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+
+      <section class="term" id="fragmentselector" typeof="bibo:Chapter" resource="#fragmentselector" property="bibo:hasPart">
+        <h4 id="h-fragmentselector" resource="#h-fragmentselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.8 </span>FragmentSelector</span></h4>
+        <p>The FragmentSelector class is used to record the segment of a representation using the URI fragment specification defined by the representation's media type.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#FragmentSelector</li>
+            <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
+            <li><strong>Recommended Predicates:</strong> <a href="#dcterms-conformsto">dcterms:conformsTo</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: oa:FragmentSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno8&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/image1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+        oa:hasSource &lt;http://example.org/video1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasPurpose oa:describing </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:FragmentSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">conformsTo &lt;http://www.w3.org/TR/media-frags/&gt; </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"t=30,60"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="httprequeststate" typeof="bibo:Chapter" resource="#httprequeststate" property="bibo:hasPart">
+        <h4 id="h-httprequeststate" resource="#h-httprequeststate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.9 </span>HttpRequestState</span></h4>
+        <p>The HttpRequestState class is used to record the HTTP request headers that a client <em class="rfc2119" title="SHOULD">SHOULD</em> use to request the correct representation from the resource. </p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#HttpRequestState</li>
+            <li><strong>Sub Class Of:</strong> <a href="#state">oa:State</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: oa:HttpRequestState</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno9&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/description1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget  [
+        oa:hasSource &lt;http://example.org/target1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasState [
+            a oa:HttpRequestState </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"Accept: application/pdf"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="independents" typeof="bibo:Chapter" resource="#independents" property="bibo:hasPart">
+        <h4 id="h-independents" resource="#h-independents"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.10 </span>Independents</span></h4>
+        <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that each of the resources in the <code>as:items</code> list are independently associated with all of the other bodies or targets.</p>
+
+        <div class="warning">
+          <div class="warning-title marker"><span>Warning</span></div>
+          <p class="">This class is at-risk.</p>
+        </div>
+
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Independents</li>
+            <li><strong>Sub Class Of:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#as-items">as:items</a></li>
+          </ul>
+        </div>
+        <div class="diagram_img">
+          <img src="images/examples/" alt="oa:Independents with list of items" longdesc="#example_independents">
+        </div>
+        <div id="example_independents">
+          <div class="example">
+            <div class="example-title marker"><span>Example 10</span><span style="text-transform: none">: oa:Independents</span></div><pre class="highlight hljs groovy">&lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/anno10&gt; a oa:Annotation ;</span>
+<span class="hljs-label">    oa:</span>motivatedBy <span class="hljs-string">oa:</span>classifying ;
+<span class="hljs-label">    oa:</span>hasBody &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/vocab/art/portrait&gt; ;</span>
+<span class="hljs-label">    oa:</span>hasTarget [
+        a <span class="hljs-string">oa:</span>Independents ;
+<span class="hljs-label">        as:</span>items (
+          &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.com/image1&gt;</span>
+          &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.net/image2&gt;</span>
+          &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.com/image4&gt;</span>
+          &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/image9&gt;</span>
+        ) ] .</pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="list" typeof="bibo:Chapter" resource="#list" property="bibo:hasPart">
+        <h4 id="h-list" resource="#h-list"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.11 </span>List</span></h4>
+        <p>A subClass of <code>as:OrderedCollection</code> that conveys to a consuming application that it should use each of the resources in the <code>as:items</code> list, and that their order is important.</p>
+
+        <div class="warning">
+          <div class="warning-title marker"><span>Warning</span></div>
+          <p class="">This class is at-risk.</p>
+        </div>
+
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Independents</li>
+            <li><strong>Sub Class Of:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#as-items">as:items</a></li>
+          </ul>
+        </div>
+        <div class="diagram_img">
+          <img src="images/examples/" alt="oa:List with list of items" longdesc="#example_list">
+        </div>
+        <div id="example_list">
+          <div class="example">
+            <div class="example-title marker"><span>Example 11</span><span style="text-transform: none">: oa:List</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno11&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:tagging </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ a oa:TextualBody </span></span>; <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"important"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        a oa:List </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items (
+          &lt;http://example.com/book/page1&gt;
+          &lt;http://example.net/book/page2&gt;
+          &lt;http://example.com/book/page3&gt;
+          &lt;http://example.org/book/page4&gt;
+        ) ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="motivation" typeof="bibo:Chapter" resource="#motivation" property="bibo:hasPart">
+        <h4 id="h-motivation" resource="#h-motivation"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.12 </span>Motivation</span></h4>
+        <p>The Motivation class is used to record the user's intent or motivation for the creation of the Annotation, or the inclusion of the body or target, that it is associated with.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Motivation</li>
+            <li><strong>Sub Class Of:</strong> <a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a></li>
+            <li><strong>Range Of:</strong> <a href="#motivatedby">oa:motivatedBy</a>, <a href="#haspurpose">oa:hasPurpose</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 12</span><span style="text-transform: none">: oa:Motivation</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno12&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/description1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/resource1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:describing .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="rangeselector" typeof="bibo:Chapter" resource="#rangeselector" property="bibo:hasPart">
+        <h4 id="h-rangeselector" resource="#h-rangeselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.13 </span>RangeSelector</span></h4>
+        <p>A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors. The selection consists of everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#RangeSelector</li>
+            <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#hasstartselector">oa:hasStartSelector</a>, <a href="#hasendselector">oa:hasEndSelector</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 13</span><span style="text-transform: none">: oa:RangeSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno13&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+          a oa:RangeSelector </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasStartSelector [
+            a oa:XPathSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"//table[1]/tr[1]/td[2]"</span> ] </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasEndSelector [
+            a oa:XPathSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"//table[1]/tr[1]/td[4]"</span> ] ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="resourceselection" typeof="bibo:Chapter" resource="#resourceselection" property="bibo:hasPart">
+        <h4 id="h-resourceselection" resource="#h-resourceselection"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.14 </span>ResourceSelection</span></h4>
+        <p>Instances of the ResourceSelection class identify part (described by an oa:Selector) of another resource (referenced with oa:hasSource), possibly from a particular representation of a resource (described by an oa:State). Please note that ResourceSelection is not used directly in the Web Annotation model, but is provided as a separate class for further application profiles to use, separate from oa:SpecificResource which has many Annotation specific features.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#ResourceSelection</li>
+            <li><strong>Required Predicates:</strong> <a href="#hassource">oa:hasSource</a></li>
+            <li><strong>Recommended Predicates:</strong> <a href="#hasselector">oa:hasSelector</a>, <a href="#hasstate">oa:hasState</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 14</span><span style="text-transform: none">: oa:ResourceSelection</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/cell1&gt; a oa:ResourceSelection </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSource &lt;http://example.org/image1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+      a oa:XPathSelector </span></span>;
+      <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"//table[1]/tr[1]/td[4]"</span> ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="selector" typeof="bibo:Chapter" resource="#selector" property="bibo:hasPart">
+        <h4 id="h-selector" resource="#h-selector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.15 </span>Selector</span></h4>
+        <p>A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. This class is not used directly in the Annotation model, only its subclasses.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Selector</li>
+            <li><strong>Super Class Of:</strong> <a href="#fragmentselector">oa:FragmentSelector</a>, <a href="#textquoteselector">oa:TextQuoteSelector</a>, <a href="#textpositionselector">oa:TextPositionSelector</a>, <a href="#datapositionselector">oa:DataPositionSelector</a>, <a href="#svgselector">oa:SvgSelector</a></li>
+            <li><strong>Range Of:</strong> <a href="#hasselector">oa:hasSelector</a></li>
+          </ul>
+        </div>
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note2"><span>Note</span><span style="text-transform: none">: oa:Selector</span></div>
+          <div class="">
+            No example is given. The class should only be used to derive subClasses.
+          </div>
+        </div>
+      </section>
+
+      <section class="term" id="specificresource" typeof="bibo:Chapter" resource="#specificresource" property="bibo:hasPart">
+        <h4 id="h-specificresource" resource="#h-specificresource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.16 </span>SpecificResource</span></h4>
+        <p>Instances of the SpecificResource class identify part of another resource (referenced with oa:hasSource), a particular representation of a resource, a resource with styling hints for renders, or any combination of these, as used within an Annotation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#SpecificResource</li>
+            <li><strong>Sub Class Of:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#hassource">oa:hasSource</a></li>
+            <li><strong>Recommended Predicates:</strong> <a href="#hasselector">oa:hasSelector</a>, <a href="#hasstate">oa:hasState</a>, <a href="#haspurpose">oa:hasPurpose</a></li>
+            <li><strong>Other Predicates:</strong> <a href="#hasscope">oa:hasScope</a>, <a href="#styleclass">oa:styleClass</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 15</span><span style="text-transform: none">: oa:SpecificResource</span></div><pre class="highlight hljs groovy">&lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/anno14&gt; a oa:Annotation ;</span>
+<span class="hljs-label">    oa:</span>hasBody &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/comment1&gt; ;</span>
+<span class="hljs-label">    oa:</span>hasTarget &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/region1&gt; .</span>
+
+&lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/region1&gt; a oa:SpecificResource ;</span>
+<span class="hljs-label">    oa:</span>hasSource &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/image1&gt; .</span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="state" typeof="bibo:Chapter" resource="#state" property="bibo:hasPart">
+        <h4 id="h-state" resource="#h-state"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.17 </span>State</span></h4>
+        <p>A State describes the intended state of a resource as applied to the particular Annotation, and thus provides the information needed to retrieve the correct representation of that resource.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#State</li>
+            <li><strong>Super Class Of:</strong> <a href="#httprequeststate">oa:HttpRequestState</a>, <a href="#timestate">oa:TimeState</a></li>
+            <li><strong>Range Of:</strong> <a href="#hasstate">oa:hasState</a></li>
+          </ul>
+        </div>
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note3"><span>Note</span><span style="text-transform: none">: oa:State</span></div>
+          <div class="">
+            No example is given. The class should only be used in further ontologies to derive subclasses.
+          </div>
+        </div>
+      </section>
+
+      <section class="term" id="style" typeof="bibo:Chapter" resource="#style" property="bibo:hasPart">
+        <h4 id="h-style" resource="#h-style"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.18 </span>Style</span></h4>
+        <p>A Style describes the intended styling of a resource as applied to the particular Annotation, and thus provides the information ndeed to ensure that rendering is consistent across implementations.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#Style</li>
+            <li><strong>Super Class Of:</strong> <a href="#cssstyle">oa:CssStyle</a></li>
+            <li><strong>Range Of:</strong> <a href="#styledby">oa:styledBy</a></li>
+          </ul>
+        </div>
+        <div class="note">
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note4"><span>Note</span><span style="text-transform: none">: oa:Style</span></div>
+          <div class="">
+            No example is given. The class should only be used in further ontologies to derive subclasses.
+          </div>
+        </div>
+      </section>
+
+      <section class="term" id="svgselector" typeof="bibo:Chapter" resource="#svgselector" property="bibo:hasPart">
+        <h4 id="h-svgselector" resource="#h-svgselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.19 </span>SvgSelector</span></h4>
+        <p>An SvgSelector defines an area through the use of the Scalable Vector Graphics [SVG] standard. This allows the user to select a non-rectangular area of the content, such as a circle or polygon by describing the region using SVG. The SVG may be either embedded within the Annotation or referenced as an External Resource.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#SvgSelector</li>
+            <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#rdf-type">rdf:type</a></li>
+            <li><strong>Other Predicates:</strong> <a href="#value">oa:value</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 16</span><span style="text-transform: none">: oa:SvgSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno15&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/road1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/map1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:SvgSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"&lt;svg:svg&gt; ... &lt;/svg:svg&gt;"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="textpositionselector" typeof="bibo:Chapter" resource="#textpositionselector" property="bibo:hasPart">
+        <h4 id="h-textpositionselector" resource="#h-textpositionselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.20 </span>TextPositionSelector</span></h4>
+        <p>The TextPositionSelector describes a range of text by recording the start and end positions of the selection in the stream. Position 0 would be immediately before the first character, position 1 would be immediately before the second character, and so on.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#TextPositionSelector</li>
+            <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#start">oa:start</a>, <a href="#end">oa:end</a>, <a href="#rdf-type">rdf:type</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 17</span><span style="text-transform: none">: oa:TextPositionSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno16&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/ebook1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:TextPositionSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">start <span class="hljs-number">412</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">end <span class="hljs-number">795</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="textquoteselector" typeof="bibo:Chapter" resource="#textquoteselector" property="bibo:hasPart">
+        <h4 id="h-textquoteselector" resource="#h-textquoteselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.21 </span>TextQuoteSelector</span></h4>
+        <p>The TextQuoteSelector describes a range of text by copying it, and including some of the text immediately before (a prefix) and after (a suffix) it to distinguish between multiple copies of the same sequence of characters.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#TextQuoteSelector</li>
+            <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#rdf-type">rdf:type</a>, <a href="#exact">oa:exact</a></li>
+            <li><strong>Recommended Predicates:</strong> <a href="#prefix">oa:prefix</a>, <a href="#suffix">oa:suffix</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 18</span><span style="text-transform: none">: oa:TextQuoteSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno17&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:TextQuoteSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">exact <span class="hljs-string">"anotation"</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">prefix <span class="hljs-string">"this is an "</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">suffix <span class="hljs-string">" that has some"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="textualbody" typeof="bibo:Chapter" resource="#textualbody" property="bibo:hasPart">
+        <h4 id="h-textualbody" resource="#h-textualbody"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.22 </span>TextualBody</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#TextualBody</li>
+            <li><strong>Equivalent Classes:</strong> <a href="http://www.w3.org/ns/activitystreams#Note">as:Note</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
+            <li><strong>Recommended Predicates:</strong> <a href="#dc-format">dc:format</a>, <a href="#dc-language">dc:language</a></li>
+            <li><strong>Other Predicates:</strong> <a href="#rdf-type">rdf:type</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 19</span><span style="text-transform: none">: oa:TextualBody</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno18&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/photo1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+        a oa:TextualBody</span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"&lt;p&gt;Comment text&lt;/p&gt;"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">language <span class="hljs-string">"en"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">format <span class="hljs-string">"text/html"</span> ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="timestate" typeof="bibo:Chapter" resource="#timestate" property="bibo:hasPart">
+        <h4 id="h-timestate" resource="#h-timestate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.23 </span>TimeState</span></h4>
+        <p>A TimeState records the time at which the resource's state is appropriate for the Annotation, typically the time that the Annotation was created and/or a link to a persistent copy of the current version.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#TimeState</li>
+            <li><strong>Sub Class Of:</strong> <a href="#state">oa:State</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#rdf-type">rdf:type</a></li>
+            <li><strong>Recommended Predicates:</strong> <a href="#sourcedate">oa:sourceDate</a>, <a href="#cachedsource">oa:cachedSource</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 20</span><span style="text-transform: none">: oa:TimeState</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno19&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasState [
+            a oa:TimeState </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">cachedSource &lt;http://example.org/copy1&gt; </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">sourceDate <span class="hljs-string">"2015-07-20T13:30:00Z"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="xpathselector" typeof="bibo:Chapter" resource="#xpathselector" property="bibo:hasPart">
+        <h4 id="h-xpathselector" resource="#h-xpathselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.1.24 </span>XPathSelector</span></h4>
+        <p> An XPathSelector is used to select elements and content within a resource that supports the Document Object Model via a specified XPath value.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#XPathSelector</li>
+            <li><strong>Sub Class Of:</strong> <a href="#selector">oa:Selector</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#rdf-value">rdf:value</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 21</span><span style="text-transform: none">: oa:TimeState</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno20&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+          a oa:XPathSelector </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"/html/body/p[2]/table/tr[2]/td[3]/span"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+    </section>
+    <!-- End of oa Classes -->
+
+
+    <section id="properties" typeof="bibo:Chapter" resource="#properties" property="bibo:hasPart">
+      <h3 id="h-properties" resource="#h-properties"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2 </span>Properties</span></h3>
+
+
+      <div class="termtoc">
+        <a href="#annotationservice">annotationService</a> | <a href="#bodyvalue">bodyValue</a> | <a href="#cachedsource">cachedSource</a> | <a href="#canonical">canonical</a> | <a href="#end">end</a> | <a href="#exact">exact</a> | <a href="#hasbody">hasBody</a> | <a href="#haspurpose">hasPurpose</a> | <a href="#hasscope">hasScope</a> | <a href="#hasselector">hasSelector</a> | <a href="#hassource">hasSource</a> | <a href="#hasstate">hasState</a> | <a href="#hastarget">hasTarget</a> | <a href="#motivatedby">motivatedBy</a> | <a href="#prefix">prefix</a> | <a href="#refinedby">refinedBy</a> | <a href="#sourcedate">sourceDate</a> | <a href="#sourcedateend">sourceDateEnd</a> | <a href="#sourcedatestart">sourceDateStart</a> | <a href="#start">start</a> | <a href="#styleclass">styleClass</a> | <a href="#styledby">styledBy</a> | <a href="#suffix">suffix</a> | <a href="#textdirection">textDirection</a> | <a href="#via">via</a>
+      </div>
+
+      <section class="term" id="annotationservice" typeof="bibo:Chapter" resource="#annotationservice" property="bibo:hasPart">
+        <h4 id="h-annotationservice" resource="#h-annotationservice"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.1 </span>annotationService</span></h4>
+        <p>The object of the relationship is the end point of a service that conforms to the [<cite><a class="bibref" href="#bib-annotation-protocol">annotation-protocol</a></cite>], and it may be associated with any resource. The expectation of asserting the relationship is that the object is the preferred service for maintaining annotations about the subject resource, according to the publisher of the relationship.
+        </p>
+        <p>
+          This relationship is intended to be used both within Linked Data descriptions and as the <code>rel</code> type of a Link, via HTTP Link Headers [<cite><a class="bibref" href="#bib-rfc5988">rfc5988</a></cite>] for binary resources and in HTML &lt;link&gt; elements. For more information about these, please see the Annotation Protocol specification [<cite><a class="bibref" href="#bib-annotation-protocol">annotation-protocol</a></cite>].
+        </p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#annotationService</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 22</span><span style="text-transform: none">: oa:annotationService</span></div><pre class="highlight hljs groovy">&lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/diagram.jpg&gt; a dctypes:Image ;</span>
+<span class="hljs-label">    oa:</span>annotationService &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/services/annotations/&gt; .</span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="bodyvalue" typeof="bibo:Chapter" resource="#bodyvalue" property="bibo:hasPart">
+        <h4 id="h-bodyvalue" resource="#h-bodyvalue"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.2 </span>bodyValue</span></h4>
+        <p>The object of the predicate is a plain text string to be used as the content of the body of the Annotation. The value <em class="rfc2119" title="MUST">MUST</em> be an <code>xsd:string</code> and that data type <em class="rfc2119" title="MUST NOT">MUST NOT</em> be expressed in the serialization. Note that language <em class="rfc2119" title="MUST NOT">MUST NOT</em> be associated with the value either as a language tag, as that is only available for <code>rdf:langString</code>.
+        </p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#bodyValue</li>
+            <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+            <li><strong>Range:</strong> xsd:string</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 23</span><span style="text-transform: none">: oa:bodyValue</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno21&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">bodyValue <span class="hljs-string">"Comment text"</span> </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/target1&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="cachedsource" typeof="bibo:Chapter" resource="#cachedsource" property="bibo:hasPart">
+        <h4 id="h-cachedsource" resource="#h-cachedsource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.3 </span>cachedSource</span></h4>
+        <p>A object of the relationship is a copy of the Source resource's representation, appropriate for the Annotation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#cachedSource</li>
+            <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 24</span></div><pre class="highlight hljs css" title="">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno22&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasState [
+            a oa:TimeState </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">cachedSource &lt;http://example.org/copy1&gt; </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">sourceDate <span class="hljs-string">"2015-07-20T13:30:00Z"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="canonical" typeof="bibo:Chapter" resource="#canonical" property="bibo:hasPart">
+        <h4 id="h-canonical" resource="#h-canonical"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.4 </span>canonical</span></h4>
+        <p>A object of the relationship is the canonical URI that can always be used to deduplicate the Annotation, regardless of the current URI used to access the representation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#canonical</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 25</span></div><pre class="highlight hljs css" title="">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno23&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/page1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">canonical &lt;urn:uuid:dbfb1861-<span class="hljs-number">0</span>ecf-<span class="hljs-number">41</span>ad-be94-a584e5c4f1df&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="end" typeof="bibo:Chapter" resource="#end" property="bibo:hasPart">
+        <h4 id="h-end" resource="#h-end"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.5 </span>end</span></h4>
+        <p>The end property is used to convey the 0-based index of the end position of a range of content.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#end</li>
+            <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 26</span><span style="text-transform: none">: oa:end</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno24&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/diskimg1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:DataPositionSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">start <span class="hljs-number">4096</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">end <span class="hljs-number">4104</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="exact" typeof="bibo:Chapter" resource="#exact" property="bibo:hasPart">
+        <h4 id="h-exact" resource="#h-exact"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.6 </span>exact</span></h4>
+        <p>The object of the predicate is a copy of the text which is being selected, after normalization.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#exact</li>
+            <li><strong>Range:</strong> xsd:string</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 27</span><span style="text-transform: none">: oa:exact</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno25&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:TextQuoteSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">exact <span class="hljs-string">"anotation"</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">prefix <span class="hljs-string">"this is an "</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">suffix <span class="hljs-string">" that has some"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+
+      <section class="term" id="hasbody" typeof="bibo:Chapter" resource="#hasbody" property="bibo:hasPart">
+        <h4 id="h-hasbody" resource="#h-hasbody"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.7 </span>hasBody</span></h4>
+        <p>The object of the relationship is a resource that is a body of the Annotation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasBody</li>
+            <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 28</span><span style="text-transform: none">: oa:hasBody</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno26&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/post1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/page1&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="hasendselector" typeof="bibo:Chapter" resource="#hasendselector" property="bibo:hasPart">
+        <h4 id="h-hasendselector" resource="#h-hasendselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.8 </span>hasEndSelector</span></h4>
+        <p>The relationship between a RangeSelector and the Selector that describes the end position of the range. </p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasEndSelector</li>
+            <li><strong>Domain:</strong> <a href="#rangeselector">oa:RangeSelector</a></li>
+            <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 29</span><span style="text-transform: none">: oa:hasEndSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno27&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+          a oa:RangeSelector </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasStartSelector [
+            a oa:XPathSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"//table[1]/tr[1]/td[2]"</span> ] </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasEndSelector [
+            a oa:XPathSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"//table[1]/tr[1]/td[4]"</span> ] ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="haspurpose" typeof="bibo:Chapter" resource="#haspurpose" property="bibo:hasPart">
+        <h4 id="h-haspurpose" resource="#h-haspurpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.9 </span>hasPurpose</span></h4>
+        <p>The purpose served by the resource in the Annotation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasPurpose</li>
+            <li><strong>Range:</strong> <a href="#motivation">oa:Motivation</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 30</span><span style="text-transform: none">: oa:hasPurpose</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno28&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:bookmarking </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+        a oa:TextualBody </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"readme"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasPurpose oa:tagging ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/page1&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="hasscope" typeof="bibo:Chapter" resource="#hasscope" property="bibo:hasPart">
+        <h4 id="h-hasscope" resource="#h-hasscope"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.10 </span>hasScope</span></h4>
+        <p>The scope or context in which the resource is used within the Annotation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasScope</li>
+            <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
+            <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#context">as:context</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 31</span><span style="text-transform: none">: oa:hasPurpose</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno29&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:bookmarking </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/logo1.jpg&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasScope &lt;http://example.org/index.html&gt; ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="hasselector" typeof="bibo:Chapter" resource="#hasselector" property="bibo:hasPart">
+        <h4 id="h-hasselector" resource="#h-hasselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.11 </span>hasSelector</span></h4>
+        <p>The object of the relationship is a Selector that describes the segment or region of interest within the source resource. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasSelector</li>
+            <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
+            <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 32</span><span style="text-transform: none">: oa:hasSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno30&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+      oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+      <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector &lt;http://example.org/paraselector1&gt; ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+      oa:hasSource &lt;http://example.com/dataset1&gt; </span></span>;
+      <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector &lt;http://example.org/dataselector1&gt; ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="hassource" typeof="bibo:Chapter" resource="#hassource" property="bibo:hasPart">
+        <h4 id="h-hassource" resource="#h-hassource"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.12 </span>hasSource</span></h4>
+        <p>The resource that the ResourceSelection, or its subclass SpecificResource, is refined from, or more specific than. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasSource</li>
+            <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 33</span><span style="text-transform: none">: oa:hasSource</span></div><pre class="highlight hljs groovy">&lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/anno31&gt; a oa:Annotation ;</span>
+<span class="hljs-label">    oa:</span>hasBody &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/comment1&gt; ;</span>
+<span class="hljs-label">    oa:</span>hasTarget &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/region1&gt; .</span>
+
+&lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/region1&gt; a oa:SpecificResource ;</span>
+<span class="hljs-label">    oa:</span>hasSource &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/image1&gt; .</span></pre></div>
+
+        </div>
+      </section>
+
+      <section class="term" id="hasstartselector" typeof="bibo:Chapter" resource="#hasstartselector" property="bibo:hasPart">
+        <h4 id="h-hasstartselector" resource="#h-hasstartselector"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.13 </span>hasStartSelector</span></h4>
+        <p>The relationship between a RangeSelector and the Selector that describes the start position of the range. </p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasStartSelector</li>
+            <li><strong>Domain:</strong> <a href="#rangeselector">oa:RangeSelector</a></li>
+            <li><strong>Range:</strong> <a href="#selector">oa:Selector</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 34</span><span style="text-transform: none">: oa:hasStartSelector</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno32&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+          a oa:RangeSelector </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasStartSelector [
+            a oa:XPathSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"//table[1]/tr[1]/td[2]"</span> ] </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasEndSelector [
+            a oa:XPathSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"//table[1]/tr[1]/td[4]"</span> ] ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="hasstate" typeof="bibo:Chapter" resource="#hasstate" property="bibo:hasPart">
+        <h4 id="h-hasstate" resource="#h-hasstate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.14 </span>hasState</span></h4>
+        <p>The relationship between the ResourceSelection, or its subclass SpecificResource, and a State resource. Please note that the domain (<a href="#resourceselection">oa:ResourceSelection</a>) is not used directly in the Web Annotation model.</p>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasState</li>
+            <li><strong>Domain:</strong> <a href="#resourceselection">oa:ResourceSelection</a></li>
+            <li><strong>Range:</strong> <a href="#state">oa:State</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 35</span><span style="text-transform: none">: oa:hasState</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno33&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasState &lt;http://example.org/state1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSource &lt;http://example.org/page1&gt; ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="hastarget" typeof="bibo:Chapter" resource="#hastarget" property="bibo:hasPart">
+        <h4 id="h-hastarget" resource="#h-hastarget"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.15 </span>hasTarget</span></h4>
+        <p>The relationship between an Annotation and its Target.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#hasTarget</li>
+            <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 36</span><span style="text-transform: none">: oa:hasTarget</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno34&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/post1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/page1&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="motivatedby" typeof="bibo:Chapter" resource="#motivatedby" property="bibo:hasPart">
+        <h4 id="h-motivatedby" resource="#h-motivatedby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.16 </span>motivatedBy</span></h4>
+        <p>The relationship between an Annotation and a Motivation that describes the reason for the Annotation's creation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#motivatedBy</li>
+            <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+            <li><strong>Range:</strong> <a href="#motivation">oa:Motivation</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 37</span><span style="text-transform: none">: oa:motivatedBy</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno35&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/description1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/resource1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:describing .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="prefix" typeof="bibo:Chapter" resource="#prefix" property="bibo:hasPart">
+        <h4 id="h-prefix" resource="#h-prefix"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.17 </span>prefix</span></h4>
+        <p>The object of the property is a snippet of content that occurs immediately before the content which is being selected by the Selector.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#prefix</li>
+            <li><strong>Range:</strong> xsd:string</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 38</span><span style="text-transform: none">: oa:prefix</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno36&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:TextQuoteSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">exact <span class="hljs-string">"anotation"</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">prefix <span class="hljs-string">"this is an "</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">suffix <span class="hljs-string">" that has some"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="refinedby" typeof="bibo:Chapter" resource="#refinedby" property="bibo:hasPart">
+        <h4 id="h-refinedby" resource="#h-refinedby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.18 </span>refinedBy</span></h4>
+        <p>The relationship between a Selector and another Selector or a State and a Selector or State that should be applied to the results of the first to refine the processing of the source resource. </p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#refinedBy</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 39</span><span style="text-transform: none">: oa:refinedBy</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno37&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        a oa:SpecificResource </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+          a oa:FragmentSelector </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"para5"</span> </span></span>;
+          <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">refinedBy [
+            a oa:TextQuoteSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">exact <span class="hljs-string">"Selected Text"</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">prefix <span class="hljs-string">"text before the "</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">suffix <span class="hljs-string">"and text after it"</span> ] ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="renderedvia" typeof="bibo:Chapter" resource="#renderedvia" property="bibo:hasPart">
+        <h4 id="h-renderedvia" resource="#h-renderedvia"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.19 </span>renderedVia</span></h4>
+        <p>A system that was used by the application that created the Annotation to render the resource.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#renderedVia</li>
+            <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
+            <li><strong>Range:</strong> <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Resource">rdf:Resource</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 40</span><span style="text-transform: none">: oa:prefix</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno38&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+      a oa:SpecificResource </span></span>;
+      <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSource &lt;http://example.org/page1&gt; </span></span>;
+      <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">renderedVia [
+        a as:Application </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">schema</span>:<span class="hljs-value">softwareVersion <span class="hljs-string">"2.5"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="sourcedate" typeof="bibo:Chapter" resource="#sourcedate" property="bibo:hasPart">
+        <h4 id="h-sourcedate" resource="#h-sourcedate"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.20 </span>sourceDate</span></h4>
+        <p>The timestamp at which the Source resource should be interpreted as being applicable to the Annotation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#sourceDate</li>
+            <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
+            <li><strong>Range:</strong> xsd:dateTime</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 41</span><span style="text-transform: none">: oa:sourceDate</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno39&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasState [
+            a oa:TimeState </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">sourceDate <span class="hljs-string">"2015-07-20T13:30:00Z"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="sourcedateend" typeof="bibo:Chapter" resource="#sourcedateend" property="bibo:hasPart">
+        <h4 id="h-sourcedateend" resource="#h-sourcedateend"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.21 </span>sourceDateEnd</span></h4>
+        <p>The end timestamp of the interval over which the Source resource should be interpreted as being applicable to the Annotation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#sourceDate</li>
+            <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
+            <li><strong>Range:</strong> xsd:dateTime</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 42</span><span style="text-transform: none">: oa:sourceDate</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno40&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasState [
+            a oa:TimeState </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">sourceDateStart <span class="hljs-string">"2015-07-20T13:30:00Z"</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">sourceDateEnd   <span class="hljs-string">"2015-07-21T19:45:00Z"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="sourcedatestart" typeof="bibo:Chapter" resource="#sourcedatestart" property="bibo:hasPart">
+        <h4 id="h-sourcedatestart" resource="#h-sourcedatestart"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.22 </span>sourceDateStart</span></h4>
+        <p>The start timestamp of the interval over which the Source resource should be interpreted as being applicable to the Annotation.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#sourceDate</li>
+            <li><strong>Domain:</strong> <a href="#timestate">oa:TimeState</a></li>
+            <li><strong>Range:</strong> xsd:dateTime</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 43</span><span style="text-transform: none">: oa:sourceDate</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno41&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasState [
+            a oa:TimeState </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">sourceDateStart <span class="hljs-string">"2015-07-20T13:30:00Z"</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">sourceDateEnd   <span class="hljs-string">"2015-07-21T19:45:00Z"</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="start" typeof="bibo:Chapter" resource="#start" property="bibo:hasPart">
+        <h4 id="h-start" resource="#h-start"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.23 </span>start</span></h4>
+        <p>The start position in a 0-based index at which a range of content is selected from the data in the source resource.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#start</li>
+            <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 44</span><span style="text-transform: none">: oa:start</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno42&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/ebook1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:TextPositionSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">start <span class="hljs-number">412</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">end <span class="hljs-number">795</span> ] ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="styleclass" typeof="bibo:Chapter" resource="#styleclass" property="bibo:hasPart">
+        <h4 id="h-styleclass" resource="#h-styleclass"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.24 </span>styleClass</span></h4>
+        <p>The name of the class used in the CSS description referenced from the Annotation that should be applied to the Specific Resource.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#styleClass</li>
+            <li><strong>Domain:</strong> <a href="#specificresource">oa:SpecificResource</a></li>
+            <li><strong>Range:</strong> xsd:string</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 45</span><span style="text-transform: none">: oa:styleClass</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno43&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">styledBy &lt;http://example.org/style1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/document1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">styleClass <span class="hljs-string">"red"</span> ] .
+
+&lt;http://example.org/style1&gt; a oa:CssStyle .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="styledby" typeof="bibo:Chapter" resource="#styledby" property="bibo:hasPart">
+        <h4 id="h-styledby" resource="#h-styledby"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.25 </span>styledBy</span></h4>
+        <p>A reference to a Stylesheet that should be used to apply styles to the Annotation rendering.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#styledBy</li>
+            <li><strong>Domain:</strong> <a href="#annotation">oa:Annotation</a></li>
+            <li><strong>Range:</strong> <a href="#style">oa:Style</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 46</span><span style="text-transform: none">: oa:styledBy</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno44&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/body1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">styledBy [
+        a oa:CssStyle </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">".red { color: red }"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/target1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">styleClass <span class="hljs-string">"red"</span> ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="suffix" typeof="bibo:Chapter" resource="#suffix" property="bibo:hasPart">
+        <h4 id="h-suffix" resource="#h-suffix"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.26 </span>suffix</span></h4>
+        <p>The snippet of text that occurs immediately after the text which is being selected.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#suffix</li>
+            <li><strong>Range:</strong> xsd:string</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 47</span><span style="text-transform: none">: oa:suffix</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno45&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget [
+        oa:hasSource &lt;http://example.org/page1&gt; </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasSelector [
+            a oa:TextQuoteSelector </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">exact <span class="hljs-string">"anotation"</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">prefix <span class="hljs-string">"this is an "</span> </span></span>;
+            <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">suffix <span class="hljs-string">" that has some"</span> ] ] .</span></span></pre></div>
+
+        </div>
+      </section>
+
+      <section class="term" id="textdirection" typeof="bibo:Chapter" resource="#textdirection" property="bibo:hasPart">
+        <h4 id="h-textdirection" resource="#h-textdirection"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.27 </span>textDirection</span></h4>
+        <p>The direction of the text of the subject resource. There <em class="rfc2119" title="MUST">MUST</em> only be one text direction associated with any given resource.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#textDirection</li>
+            <li><strong>Range:</strong> <a href="#direction">oa:Direction</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 48</span><span style="text-transform: none">: oa:suffix</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno46&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+        rdfs:value <span class="hljs-string">"This is a comment"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">language <span class="hljs-string">"en"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">format <span class="hljs-string">"text/plain"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">textDirection oa:ltr ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/page1&gt; .</span></span></pre></div>
+
+        </div>
+      </section>
+
+      <section class="term" id="via" typeof="bibo:Chapter" resource="#via" property="bibo:hasPart">
+        <h4 id="h-via" resource="#h-via"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.2.28 </span>via</span></h4>
+        <p>A object of the relationship is a resource from which the source resource was retrieved by the providing system.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#via</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 49</span></div><pre class="highlight hljs css" title="">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno47&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/page1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">via &lt;http://other.example.com/anno1b&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+    </section>
+
+    <section id="named-individuals" typeof="bibo:Chapter" resource="#named-individuals" property="bibo:hasPart">
+      <h3 id="h-named-individuals" resource="#h-named-individuals"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3 </span>Named Individuals</span></h3>
+
+      <section class="term" id="bookmarking" typeof="bibo:Chapter" resource="#bookmarking" property="bibo:hasPart">
+        <h4 id="h-bookmarking" resource="#h-bookmarking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.1 </span>bookmarking</span></h4>
+        <p>The motivation for when the user intends to create a bookmark to the Target or part thereof.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#bookmarking</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 50</span><span style="text-transform: none">: oa:bookmarking</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno48&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/page1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:bookmarking .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="classifying" typeof="bibo:Chapter" resource="#classifying" property="bibo:hasPart">
+        <h4 id="h-classifying" resource="#h-classifying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.2 </span>classifying</span></h4>
+        <p>The motivation for when the user intends to that classify the Target as something.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#classifying</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 51</span><span style="text-transform: none">: oa:classifying</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno49&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/type1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/resource1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:classifying .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="commenting" typeof="bibo:Chapter" resource="#commenting" property="bibo:hasPart">
+        <h4 id="h-commenting" resource="#h-commenting"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.3 </span>commenting</span></h4>
+        <p>The motivation for when the user intends to comment about the Target.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#commenting</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 52</span><span style="text-transform: none">: oa:commenting</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno50&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"A comment about the page"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/page1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:commenting .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="describing" typeof="bibo:Chapter" resource="#describing" property="bibo:hasPart">
+        <h4 id="h-describing" resource="#h-describing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.4 </span>describing</span></h4>
+        <p>The motivation for when the user intends to describe the Target, as opposed to a comment about them.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#describing</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 53</span><span style="text-transform: none">: oa:describing</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno51&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"A description of the image"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/image1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:describing .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="editing" typeof="bibo:Chapter" resource="#editing" property="bibo:hasPart">
+        <h4 id="h-editing" resource="#h-editing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.5 </span>editing</span></h4>
+        <p>The motivation for when the user intends to request a change or edit to the Target resource.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#editing</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 54</span><span style="text-transform: none">: oa:editing</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno52&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"Editorial suggestion"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/text1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:editing .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="highlighting" typeof="bibo:Chapter" resource="#highlighting" property="bibo:hasPart">
+        <h4 id="h-highlighting" resource="#h-highlighting"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.6 </span>highlighting</span></h4>
+        <p>The motivation for when the user intends to highlight the Target resource or segment of it.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#highlighting</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 55</span><span style="text-transform: none">: oa:highlighting</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno53&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/region1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:highlighting .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="identifying" typeof="bibo:Chapter" resource="#identifying" property="bibo:hasPart">
+        <h4 id="h-identifying" resource="#h-identifying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.7 </span>identifying</span></h4>
+        <p>The motivation for when the user intends to assign an identity to the Target or identify what is being depicted or described in the Target.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#identifying</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 56</span><span style="text-transform: none">: oa:identifying</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno54&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.com/identities/object1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/image-of-object1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:identifying .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="linking" typeof="bibo:Chapter" resource="#linking" property="bibo:hasPart">
+        <h4 id="h-linking" resource="#h-linking"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.8 </span>linking</span></h4>
+        <p>The motivation for when the user intends to link to a resource related to the Target.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#linking</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 57</span><span style="text-transform: none">: oa:linking</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno55&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/from1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/to1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:linking .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="moderating" typeof="bibo:Chapter" resource="#moderating" property="bibo:hasPart">
+        <h4 id="h-moderating" resource="#h-moderating"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.9 </span>moderating</span></h4>
+        <p>The motivation for when the user intends to assign some value or quality to the Target.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#moderating</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 58</span><span style="text-transform: none">: oa:moderating</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno56&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.org/tags/approved1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/anno1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:moderating .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="questioning" typeof="bibo:Chapter" resource="#questioning" property="bibo:hasPart">
+        <h4 id="h-questioning" resource="#h-questioning"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.10 </span>questioning</span></h4>
+        <p>The motivation for when the user intends to ask a question about the Target.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#questioning</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 59</span><span style="text-transform: none">: oa:questioning</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno57&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"A question about the resource"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/resource1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:questioning .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="replying" typeof="bibo:Chapter" resource="#replying" property="bibo:hasPart">
+        <h4 id="h-replying" resource="#h-replying"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.11 </span>replying</span></h4>
+        <p>The motivation for when the user intends to reply to a previous statement, either an Annotation or another resource.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#replying</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 60</span><span style="text-transform: none">: oa:replying</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno58&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"A reply to a question"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/anno1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:replying .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="reviewing" typeof="bibo:Chapter" resource="#reviewing" property="bibo:hasPart">
+        <h4 id="h-reviewing" resource="#h-reviewing"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.12 </span>reviewing</span></h4>
+        <p>The motivation for when the user intends to review the Target in some assessing fashion, rather than simply make a comment about it.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#reviewing</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 61</span><span style="text-transform: none">: oa:reviewing</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno59&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"A review of the resource"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/resource1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:reviewing .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="tagging" typeof="bibo:Chapter" resource="#tagging" property="bibo:hasPart">
+        <h4 id="h-tagging" resource="#h-tagging"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.3.13 </span>tagging</span></h4>
+        <p>The motivation for when the user intends to associate a tag with the Target.</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> http://www.w3.org/ns/oa#tagging</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 62</span><span style="text-transform: none">: oa:tagging</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno60&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"tag"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/thing1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:tagging .</span></span></pre></div>
+        </div>
+      </section>
+
+      <h4 id="autodirection">autoDirection</h4>
+      <p>The direction of text that should be automatically determined from the content.</p>
+      <div class="tech">
+        <ul>
+          <li><strong>URI:</strong> http://www.w3.org/ns/oa#autoDirection</li>
+          <li><strong>Instance Of:</strong> <a href="#direction">oa:Direction</a></li>
+        </ul>
+      </div>
+      <div>
+        <div class="example">
+          <div class="example-title marker"><span>Example 63</span><span style="text-transform: none">: oa:tagging</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno61&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ 
+        rdf:value <span class="hljs-string">"Some text"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">textDirection oa:auto ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/thing1&gt;  .</span></span></pre></div>
+      </div>
+    </section>
+
+    <section class="term" id="ltr" typeof="bibo:Chapter" resource="#ltr" property="bibo:hasPart">
+      <h3 id="h-ltr" resource="#h-ltr"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4 </span>ltr</span></h3>
+      <p>The direction of text that is read from left to right.</p>
+      <div class="tech">
+        <ul>
+          <li><strong>URI:</strong> http://www.w3.org/ns/oa#ltrDirection</li>
+          <li><strong>Instance Of:</strong> <a href="#direction">oa:Direction</a></li>
+        </ul>
+      </div>
+      <div>
+        <div class="example">
+          <div class="example-title marker"><span>Example 64</span><span style="text-transform: none">: oa:tagging</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno62&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ 
+        rdf:value <span class="hljs-string">"Left to Right text"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">textDirection oa:ltr ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/thing1&gt;  .</span></span></pre></div>
+      </div>
+    </section>
+
+    <section class="term" id="rtl" typeof="bibo:Chapter" resource="#rtl" property="bibo:hasPart">
+      <h3 id="h-rtl" resource="#h-rtl"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.5 </span>rtl</span></h3>
+      <p>The direction of text that is read from right to left.</p>
+      <div class="tech">
+        <ul>
+          <li><strong>URI:</strong> http://www.w3.org/ns/oa#rtlDirection</li>
+          <li><strong>Instance Of:</strong> <a href="#direction">oa:Direction</a></li>
+        </ul>
+      </div>
+      <div>
+        <div class="example">
+          <div class="example-title marker"><span>Example 65</span><span style="text-transform: none">: oa:tagging</span></div><pre class="highlight hljs groovy">&lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/anno63&gt; a oa:Annotation ;</span>
+<span class="hljs-label">    oa:</span>hasBody &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/ar/comment1&gt; ;</span>
+<span class="hljs-label">    oa:</span>hasTarget &lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.com/thing1&gt;  .</span>
+
+&lt;<span class="hljs-string">http:</span><span class="hljs-comment">//example.org/ar/comment1&gt; a dctypes:Text ; </span>
+<span class="hljs-label">    oa:</span>textDirection <span class="hljs-string">oa:</span>rtl .   </pre></div>
+      </div>
+    </section>
+
+    <section class="term" id="prefercontaineddescriptions" typeof="bibo:Chapter" resource="#prefercontaineddescriptions" property="bibo:hasPart">
+      <h3 id="h-prefercontaineddescriptions" resource="#h-prefercontaineddescriptions"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.6 </span>PreferContainedDescriptions</span></h3>
+      <p>An IRI to signal the client prefers to receive full descriptions of the Annotations from a container, not just their IRIs.</p>
+      <div class="tech">
+        <ul>
+          <li><strong>URI:</strong> http://www.w3.org/ns/oa#PreferContainedDescriptions</li>
+        </ul>
+      </div>
+      <div>
+        <div class="example">
+          <div class="example-title marker"><span>Example 66</span><span style="text-transform: none">: oa:PreferContainedDescriptions</span></div><pre class="highlight hljs http"><span class="hljs-request">GET <span class="hljs-string">/annotations/</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Prefer</span>: <span class="hljs-string">return=representation;include="http://www.w3.org/ns/ldp#PreferContainedDescriptions"</span></pre></div>
+      </div>
+    </section>
+
+    <section class="term" id="prefercontainediris" typeof="bibo:Chapter" resource="#prefercontainediris" property="bibo:hasPart">
+      <h3 id="h-prefercontainediris" resource="#h-prefercontainediris"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.7 </span>PreferContainedIRIs</span></h3>
+      <p>An IRI to signal that the client prefers to receive only the IRIs of the Annotations from a container, not their full descriptions.</p>
+      <div class="tech">
+        <ul>
+          <li><strong>URI:</strong> http://www.w3.org/ns/oa#PreferContainedIRIs</li>
+        </ul>
+      </div>
+      <div>
+        <div class="example">
+          <div class="example-title marker"><span>Example 67</span><span style="text-transform: none">: oa:PreferContainedIRIs</span></div><pre class="highlight hljs http"><span class="hljs-request">GET <span class="hljs-string">/annotations/</span> HTTP/1.1</span>
+<span class="hljs-attribute">Host</span>: <span class="hljs-string">example.org</span>
+<span class="hljs-attribute">Accept</span>: <span class="hljs-string">application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</span>
+<span class="hljs-attribute">Prefer</span>: <span class="hljs-string">return=representation;include="http://www.w3.org/ns/ldp#PreferContainedIRIs"</span></pre></div>
+      </div>
+    </section>
+
+  </section>
+
+
+  <section id="recommended-ontologies" typeof="bibo:Chapter" resource="#recommended-ontologies" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-recommended-ontologies" resource="#h-recommended-ontologies"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Recommended Ontologies</span></h2>
+
+    <section id="classes-1" typeof="bibo:Chapter" resource="#classes-1" property="bibo:hasPart">
+      <h3 id="h-classes-1" resource="#h-classes-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1 </span>Classes</span></h3>
+
+      <div class="termtoc">
+        <a href="#as-application">as:Application</a> | <a href="#as-orderedcollection">as:OrderedCollection</a> | <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a> | <a href="#dctypes-dataset">dctypes:Dataset</a> | <a href="#dctypes-movingimage">dctypes:MovingImage</a> | <a href="#dctypes-stillimage">dctypes:StillImage</a> | <a href="#dctypes-sound">dctypes:Sound</a> | <a href="#dctypes-text">dctypes:Text</a> | <a href="#foaf-organization">foaf:Organization</a> | <a href="#foaf-person">foaf:Person</a> | <a href="#schema-audience">schema:Audience</a>
+      </div>
+
+      <section class="term" id="as-application" typeof="bibo:Chapter" resource="#as-application" property="bibo:hasPart">
+        <h4 id="h-as-application" resource="#h-as-application"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.1 </span>as:Application</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#Application">http://www.w3.org/ns/activitystreams#Application</a></li>
+            <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/SoftwareApplication">schema:SoftwareApplication</a></li>
+            <li><strong>Range Of:</strong> <a href="#as-generator">as:generator</a>, <a href="#dcterms-creator">dcterms:creator</a> </li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 68</span><span style="text-transform: none">: as:Application</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno64&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">generator &lt;http://example.org/client1&gt; .
+
+&lt;http://example.org/client1&gt; a as:Application </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">homepage &lt;HomePage1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"Code v2.1"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-orderedcollection" typeof="bibo:Chapter" resource="#as-orderedcollection" property="bibo:hasPart">
+        <h4 id="h-as-orderedcollection" resource="#h-as-orderedcollection"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.2 </span>as:OrderedCollection</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#OrderedCollection">http://www.w3.org/ns/activitystreams#OrderedCollection</a></li>
+            <li><strong>Range Of:</strong> <a href="#as-partof">as:partOf</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#as-first">as:first</a> </li>
+            <li><strong>Recommended Predicates:</strong> <a href="#as-last">as:last</a>, <a href="#as-totalitems">as:totalItems</a>, <a href="#rdfs-label">rdfs:label</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 69</span><span style="text-transform: none">: as:OrderedCollection</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1 a as:OrderedCollection </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">rdfs</span>:<span class="hljs-value">label <span class="hljs-string">"Example Collection"</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">totalItems <span class="hljs-number">42023</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">first &lt;http://example.org/collection1/page1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">last &lt;http://example.org/collection1/page42&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-orderedcollectionpage" typeof="bibo:Chapter" resource="#as-orderedcollectionpage" property="bibo:hasPart">
+        <h4 id="h-as-orderedcollectionpage" resource="#h-as-orderedcollectionpage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.3 </span>as:OrderedCollectionPage</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#OrderedCollectionPage">http://www.w3.org/ns/activitystreams#OrderedCollectionPage</a></li>
+            <li><strong>Range Of:</strong> <a href="#as-first">as:first</a>, <a href="#as-last">as:last</a>, <a href="#as-next">as:next</a>, <a href="#as-prev">as:prev</a></li>
+            <li><strong>Required Predicates:</strong> <a href="#as-next">as:next</a>, <a href="#as-items">as:items</a></li>
+            <li><strong>Recommended Predicates:</strong> <a href="#as-prev">as:prev</a>, <a href="#as-startindex">as:startIndex</a>, <a href="#as-partof">as:partOf</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 70</span><span style="text-transform: none">: as:OrderedCollectionPage</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1/page1 a as:OrderedCollectionPage </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">partOf &lt;http://example.org/collection1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">next &lt;http://example.org/collection1/page2&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">startIndex <span class="hljs-number">0</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items (
+    &lt;http://example.org/anno1&gt;
+    &lt;http://example.org/anno2&gt;
+    &lt;http://example.org/anno3&gt; ) .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dctypes-dataset" typeof="bibo:Chapter" resource="#dctypes-dataset" property="bibo:hasPart">
+        <h4 id="h-dctypes-dataset" resource="#h-dctypes-dataset"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.4 </span>dctypes:Dataset</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/Dataset">http://purl.org/dc/dcmitype/Dataset</a></li>
+            <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/Dataset">schema:Dataset</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 71</span><span style="text-transform: none">: dctypes:Dataset</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno65&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:commenting </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.com/note1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/dataset1&gt; .
+
+&lt;http://example.com/dataset1&gt; a dctypes:Dataset </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">format <span class="hljs-string">"text/csv"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dctypes-movingimage" typeof="bibo:Chapter" resource="#dctypes-movingimage" property="bibo:hasPart">
+        <h4 id="h-dctypes-movingimage" resource="#h-dctypes-movingimage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.5 </span>dctypes:MovingImage</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/MovingImage">http://purl.org/dc/dcmitype/MovingImage</a></li>
+            <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/VideoObject">schema:VideoObject</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 72</span><span style="text-transform: none">: dctypes:MovingImage</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno66&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"tag"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/video1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:tagging .
+
+&lt;http://example.org/video1&gt; a dctypes:MovingImage .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dctypes-stillimage" typeof="bibo:Chapter" resource="#dctypes-stillimage" property="bibo:hasPart">
+        <h4 id="h-dctypes-stillimage" resource="#h-dctypes-stillimage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.6 </span>dctypes:StillImage</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/StillImage">http://purl.org/dc/dcmitype/StillImage</a></li>
+            <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/ImageObject">schema:ImageObject</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 73</span><span style="text-transform: none">: dctypes:StillImage</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno67&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"tag"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/image1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:tagging .
+
+&lt;http://example.org/image1&gt; a dctypes:StillImage .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dctypes-sound" typeof="bibo:Chapter" resource="#dctypes-sound" property="bibo:hasPart">
+        <h4 id="h-dctypes-sound" resource="#h-dctypes-sound"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.7 </span>dctypes:Sound</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/Sound">http://purl.org/dc/dcmitype/Sound</a></li>
+            <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/AudioObject">schema:AudioObject</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 74</span><span style="text-transform: none">: dctypes:Sound</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno68&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"tag"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/audio1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:tagging .
+
+&lt;http://example.org/audio1&gt; a dctypes:Sound .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dctypes-text" typeof="bibo:Chapter" resource="#dctypes-text" property="bibo:hasPart">
+        <h4 id="h-dctypes-text" resource="#h-dctypes-text"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.8 </span>dctypes:Text</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/dcmitype/Text">http://purl.org/dc/dcmitype/Text</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 75</span><span style="text-transform: none">: dctypes:Text</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno69&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [ rdf:value <span class="hljs-string">"tag"</span> ] </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/document1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:tagging .
+
+&lt;http://example.org/document1&gt; a dctypes:Text .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="foaf-organization" typeof="bibo:Chapter" resource="#foaf-organization" property="bibo:hasPart">
+        <h4 id="h-foaf-organization" resource="#h-foaf-organization"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.9 </span>foaf:Organization</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/Organization">http://xmlns.com/foaf/0.1/Organization</a></li>
+            <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/Organization">schema:Organization</a>, <a href="http://www.w3.org/ns/activitystreams#Organization">as:Organization</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 76</span><span style="text-transform: none">: foaf:Organization</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno70&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">motivatedBy oa:commenting </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/comment1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">creator &lt;http://example.org/org&gt; .
+
+&lt;http://example.org/org&gt; a foaf:Organization </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"Example Organization"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="foaf-person" typeof="bibo:Chapter" resource="#foaf-person" property="bibo:hasPart">
+        <h4 id="h-foaf-person" resource="#h-foaf-person"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.10 </span>foaf:Person</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/Person">http://xmlns.com/foaf/0.1/Person</a></li>
+            <li><strong>Equivalent Classes:</strong> <a href="http://schema.org/Person">schema:Person</a>, <a href="http://www.w3.org/ns/activitystreams#Person">as:Person</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 77</span><span style="text-transform: none">: foaf:Person</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno71&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">creator &lt;http://example.org/user1&gt; .
+
+&lt;http://example.org/user1&gt; a foaf:Person </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">nick <span class="hljs-string">"pseudo"</span> </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"My Pseudonym"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="schema-audience" typeof="bibo:Chapter" resource="#schema-audience" property="bibo:hasPart">
+        <h4 id="h-schema-audience" resource="#h-schema-audience"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.11 </span>schema:Audience</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://schema.org/Audience">http://schema.org/Audience</a></li>
+            <li><strong>Range Of:</strong> <a href="#schema-audience">schema:audience</a> </li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 78</span><span style="text-transform: none">: schema:Audience</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno72&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">schema</span>:<span class="hljs-value">audience &lt;http://example.net/roles/musician&gt; .
+
+&lt;http://example.net/roles/musician&gt; a schema:Audience </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">schema</span>:<span class="hljs-value">audienceType <span class="hljs-string">"musician"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+    </section>
+
+    <section id="properties-1" typeof="bibo:Chapter" resource="#properties-1" property="bibo:hasPart">
+      <h3 id="h-properties-1" resource="#h-properties-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2 </span>Properties</span></h3>
+
+      <div class="termtoc">
+        <a href="#as-first">as:first</a> | <a href="#as-generator">as:generator</a> | <a href="#as-items">as:items</a> | <a href="#as-last">as:last</a> | <a href="#as-next">as:next</a> | <a href="#as-partof">as:partOf</a> | <a href="#as-prev">as:prev</a> | <a href="#as-startindex">as:startIndex</a> | <a href="#as-totalitems">as:totalItems</a> | <a href="#dc-format">dc:format</a> | <a href="#dc-language">dc:language</a> | <a href="#dcterms-conformsto">dcterms:conformsTo</a> | <a href="#dcterms-created">dcterms:created</a> | <a href="#dcterms-creator">dcterms:creator</a> | <a href="#dcterms-issued">dcterms:issued</a> | <a href="#dcterms-modified">dcterms:modified</a> | <a href="#dcterms-rights">dcterms:rights</a> | <a href="#foaf-homepage">foaf:homepage</a> | <a href="#foaf-mbox">foaf:mbox</a> | <a href="#foaf-mbox_sha1sum">foaf:mbox_sha1sum</a> | <a href="#foaf-name">foaf:name</a> | <a href="#foaf-nick">foaf:nick</a> | <a href="#rdf-type">rdf:type</a> | <a href="#rdf-value">rdf:value</a> | <a href="#rdfs-label">rdfs:label</a> | <a href="#schema-accessibilityfeature">schema:accessibilityFeature</a> | <a href="#schema-audience">schema:audience</a>
+      </div>
+
+
+      <section class="term" id="as-first" typeof="bibo:Chapter" resource="#as-first" property="bibo:hasPart">
+        <h4 id="h-as-first" resource="#h-as-first"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.1 </span>as:first</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#first">http://www.w3.org/ns/activitystreams#first</a></li>
+            <li><strong>Domain:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
+            <li><strong>Range:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 79</span><span style="text-transform: none">: as:first</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1 a as:OrderedCollection </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">rdfs</span>:<span class="hljs-value">label <span class="hljs-string">"Example Collection"</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">totalItems <span class="hljs-number">42023</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">first &lt;http://example.org/collection1/page1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">last &lt;http://example.org/collection1/page42&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-generator" typeof="bibo:Chapter" resource="#as-generator" property="bibo:hasPart">
+        <h4 id="h-as-generator" resource="#h-as-generator"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.2 </span>as:generator</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#generator">http://www.w3.org/ns/activitystreams#generator</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 80</span><span style="text-transform: none">: as:generator</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno73&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">generator &lt;http://example.org/client1&gt; .
+
+&lt;http://example.org/client1&gt; a as:Application </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">homepage &lt;HomePage1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"Code v2.1"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-items" typeof="bibo:Chapter" resource="#as-items" property="bibo:hasPart">
+        <h4 id="h-as-items" resource="#h-as-items"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.3 </span>as:items</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#items">http://www.w3.org/ns/activitystreams#items</a></li>
+            <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+            <li><strong>Range:</strong> <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#List">rdf:List</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 81</span><span style="text-transform: none">: as:items</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1/page1 a as:OrderedCollectionPage </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">partOf &lt;http://example.org/collection1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">next &lt;http://example.org/collection1/page2&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">startIndex <span class="hljs-number">0</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items (
+    &lt;http://example.org/anno1&gt;
+    &lt;http://example.org/anno2&gt;
+    &lt;http://example.org/anno3&gt; ) .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-last" typeof="bibo:Chapter" resource="#as-last" property="bibo:hasPart">
+        <h4 id="h-as-last" resource="#h-as-last"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.4 </span>as:last</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#last">http://www.w3.org/ns/activitystreams#last</a></li>
+            <li><strong>Domain:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
+            <li><strong>Range:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 82</span><span style="text-transform: none">: as:last</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1 a as:OrderedCollection </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">rdfs</span>:<span class="hljs-value">label <span class="hljs-string">"Example Collection"</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">totalItems <span class="hljs-number">42023</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">first &lt;http://example.org/collection1/page1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">last &lt;http://example.org/collection1/page42&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-next" typeof="bibo:Chapter" resource="#as-next" property="bibo:hasPart">
+        <h4 id="h-as-next" resource="#h-as-next"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.5 </span>as:next</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#next">http://www.w3.org/ns/activitystreams#next</a></li>
+            <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+            <li><strong>Range:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 83</span><span style="text-transform: none">: as:next</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1/page1 a as:OrderedCollectionPage </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">partOf &lt;http://example.org/collection1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">next &lt;http://example.org/collection1/page2&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">startIndex <span class="hljs-number">0</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items (
+    &lt;http://example.org/anno1&gt;
+    &lt;http://example.org/anno2&gt;
+    &lt;http://example.org/anno3&gt; ) .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-partof" typeof="bibo:Chapter" resource="#as-partof" property="bibo:hasPart">
+        <h4 id="h-as-partof" resource="#h-as-partof"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.6 </span>as:partOf</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#partOf">http://www.w3.org/ns/activitystreams#partOf</a></li>
+            <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+            <li><strong>Range:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 84</span><span style="text-transform: none">: as:partOf</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1/page1 a as:OrderedCollectionPage </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">partOf &lt;http://example.org/collection1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">next &lt;http://example.org/collection1/page2&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">startIndex <span class="hljs-number">0</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items (
+    &lt;http://example.org/anno1&gt;
+    &lt;http://example.org/anno2&gt;
+    &lt;http://example.org/anno3&gt; ) .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-prev" typeof="bibo:Chapter" resource="#as-prev" property="bibo:hasPart">
+        <h4 id="h-as-prev" resource="#h-as-prev"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.7 </span>as:prev</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#prev">http://www.w3.org/ns/activitystreams#prev</a></li>
+            <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+            <li><strong>Range:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 85</span><span style="text-transform: none">: as:prev</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1/page2 a as:OrderedCollectionPage </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">partOf &lt;http://example.org/collection1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">prev &lt;http://example.org/collection1/page1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">next &lt;http://example.org/collection1/page3&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">startIndex <span class="hljs-number">3</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items (
+    &lt;http://example.org/anno4&gt;
+    &lt;http://example.org/anno5&gt;
+    &lt;http://example.org/anno6&gt; ) .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-startindex" typeof="bibo:Chapter" resource="#as-startindex" property="bibo:hasPart">
+        <h4 id="h-as-startindex" resource="#h-as-startindex"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.8 </span>as:startIndex</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#startIndex">http://www.w3.org/ns/activitystreams#startIndex</a></li>
+            <li><strong>Domain:</strong> <a href="#as-orderedcollectionpage">as:OrderedCollectionPage</a></li>
+            <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 86</span><span style="text-transform: none">: as:startIndex</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1/page2 a as:OrderedCollectionPage </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">partOf &lt;http://example.org/collection1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">prev &lt;http://example.org/collection1/page1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">next &lt;http://example.org/collection1/page3&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">startIndex <span class="hljs-number">3</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">items (
+    &lt;http://example.org/anno4&gt;
+    &lt;http://example.org/anno5&gt;
+    &lt;http://example.org/anno6&gt; ) .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="as-totalitems" typeof="bibo:Chapter" resource="#as-totalitems" property="bibo:hasPart">
+        <h4 id="h-as-totalitems" resource="#h-as-totalitems"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.9 </span>as:totalItems</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/ns/activitystreams#totalItems">http://www.w3.org/ns/activitystreams#totalItems</a></li>
+            <li><strong>Domain:</strong> <a href="#as-orderedcollection">as:OrderedCollection</a></li>
+            <li><strong>Range:</strong> xsd:nonNegativeInteger</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 87</span><span style="text-transform: none">: as:totalItems</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/collection1 a as:OrderedCollection </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">rdfs</span>:<span class="hljs-value">label <span class="hljs-string">"Example Collection"</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">totalItems <span class="hljs-number">42023</span> </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">first &lt;http://example.org/collection1/page1&gt; </span></span>;
+  <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">last &lt;http://example.org/collection1/page42&gt; .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dc-format" typeof="bibo:Chapter" resource="#dc-format" property="bibo:hasPart">
+        <h4 id="h-dc-format" resource="#h-dc-format"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.10 </span>dc:format</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/elements/1.1/format">http://purl.org/dc/elements/1.1/format</a></li>
+            <li><strong>Range:</strong> xsd:string</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 88</span><span style="text-transform: none">: dc:format</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno74&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/photo1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+        a oa:TextualBody</span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"&lt;p&gt;Comment text&lt;/p&gt;"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">language <span class="hljs-string">"en"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">format <span class="hljs-string">"text/html"</span> ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dc-language" typeof="bibo:Chapter" resource="#dc-language" property="bibo:hasPart">
+        <h4 id="h-dc-language" resource="#h-dc-language"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.11 </span>dc:language</span></h4>
+        <p>The dc:language predicate recommends the use of a controlled vocabulary. The use of dc:language in the Annotation model further specifies that the vocabulary to use is [<cite><a class="bibref" href="#bib-BCP47">BCP47</a></cite>].</p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/elements/1.1/language">http://purl.org/dc/elements/1.1/language</a></li>
+            <li><strong>Range:</strong> xsd:string</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 89</span><span style="text-transform: none">: dc:language</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno75&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.org/photo1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody [
+        a oa:TextualBody</span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">rdf</span>:<span class="hljs-value">value <span class="hljs-string">"&lt;p&gt;Comment text&lt;/p&gt;"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">language <span class="hljs-string">"en"</span> </span></span>;
+        <span class="hljs-rule"><span class="hljs-attribute">dc</span>:<span class="hljs-value">format <span class="hljs-string">"text/html"</span> ] .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dcterms-conformsto" typeof="bibo:Chapter" resource="#dcterms-conformsto" property="bibo:hasPart">
+        <h4 id="h-dcterms-conformsto" resource="#h-dcterms-conformsto"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.12 </span>dcterms:conformsTo</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/conformsTo">http://purl.org/dc/terms/conformsTo</a></li>
+            <li><strong>Sub Property Of:</strong> </li>
+            <li><strong>Super Property Of:</strong> </li>
+            <li><strong>Domain:</strong> </li>
+            <li><strong>Range:</strong> </li>
+            <li><strong>Equivalent Properties:</strong> </li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 90</span><span style="text-transform: none">: dcterms:conformsTo</span></div><pre class="highlight hljs"></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dcterms-created" typeof="bibo:Chapter" resource="#dcterms-created" property="bibo:hasPart">
+        <h4 id="h-dcterms-created" resource="#h-dcterms-created"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.13 </span>dcterms:created</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/created">http://purl.org/dc/terms/created</a></li>
+            <li><strong>Range:</strong> xsd:dateTime</li>
+            <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#published">as:published</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 91</span><span style="text-transform: none">: dcterms:created</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno76&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">created <span class="hljs-string">"2015-10-13T13:00:00Z"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dcterms-creator" typeof="bibo:Chapter" resource="#dcterms-creator" property="bibo:hasPart">
+        <h4 id="h-dcterms-creator" resource="#h-dcterms-creator"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.14 </span>dcterms:creator</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/creator">http://purl.org/dc/terms/creator</a></li>
+            <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#actor">as:actor</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 92</span><span style="text-transform: none">: dcterms:creator</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno77&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">creator &lt;http://example.org/user1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">generator &lt;http://example.org/client1&gt; .
+
+&lt;http://example.org/user1&gt; a foaf:Person </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">nick <span class="hljs-string">"pseudo"</span> </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"My Pseudonym"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dcterms-issued" typeof="bibo:Chapter" resource="#dcterms-issued" property="bibo:hasPart">
+        <h4 id="h-dcterms-issued" resource="#h-dcterms-issued"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.15 </span>dcterms:issued</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/issued">http://purl.org/dc/terms/issued</a></li>
+            <li><strong>Range:</strong> xsd:dateTime</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 93</span><span style="text-transform: none">: dcterms:issued</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno78&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">issued <span class="hljs-string">"2015-10-14T15:13:28Z"</span> </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">generated &lt;http://example.org/client1&gt; .
+
+&lt;http://example.org/client2&gt; a as:Application </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">homepage &lt;HomePage2&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"Code v1"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dcterms-modified" typeof="bibo:Chapter" resource="#dcterms-modified" property="bibo:hasPart">
+        <h4 id="h-dcterms-modified" resource="#h-dcterms-modified"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.16 </span>dcterms:modified</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/modified">http://purl.org/dc/terms/modified</a></li>
+            <li><strong>Range:</strong> xsd:dateTime</li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 94</span><span style="text-transform: none">: dcterms:modified</span></div><pre class="highlight hljs"></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="dcterms-rights" typeof="bibo:Chapter" resource="#dcterms-rights" property="bibo:hasPart">
+        <h4 id="h-dcterms-rights" resource="#h-dcterms-rights"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.17 </span>dcterms:rights</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://purl.org/dc/terms/rights">http://purl.org/dc/terms/rights</a></li>
+            <li><strong>Sub Property Of:</strong> </li>
+            <li><strong>Super Property Of:</strong> </li>
+            <li><strong>Domain:</strong> </li>
+            <li><strong>Range:</strong> </li>
+            <li><strong>Equivalent Properties:</strong> </li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 95</span><span style="text-transform: none">: dcterms:rights</span></div><pre class="highlight hljs"></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="foaf-homepage" typeof="bibo:Chapter" resource="#foaf-homepage" property="bibo:hasPart">
+        <h4 id="h-foaf-homepage" resource="#h-foaf-homepage"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.18 </span>foaf:homepage</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/homepage">http://xmlns.com/foaf/0.1/homepage</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 96</span><span style="text-transform: none">: foaf:homepage</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno79&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">as</span>:<span class="hljs-value">generator &lt;http://example.org/client1&gt; .
+
+&lt;http://example.org/client1&gt; a as:Application </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">homepage &lt;HomePage1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"Code v2.1"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="foaf-mbox" typeof="bibo:Chapter" resource="#foaf-mbox" property="bibo:hasPart">
+        <h4 id="h-foaf-mbox" resource="#h-foaf-mbox"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.19 </span>foaf:mbox</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/mbox">http://xmlns.com/foaf/0.1/mbox</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 97</span><span style="text-transform: none">: foaf:mbox</span></div><pre class="highlight hljs"></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="foaf-mbox_sha1sum" typeof="bibo:Chapter" resource="#foaf-mbox_sha1sum" property="bibo:hasPart">
+        <h4 id="h-foaf-mbox_sha1sum" resource="#h-foaf-mbox_sha1sum"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.20 </span>foaf:mbox_sha1sum</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/mbox_sha1sum">http://xmlns.com/foaf/0.1/mbox_sha1sum</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 98</span><span style="text-transform: none">: foaf:mbox_sha1sum</span></div><pre class="highlight hljs"></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="foaf-name" typeof="bibo:Chapter" resource="#foaf-name" property="bibo:hasPart">
+        <h4 id="h-foaf-name" resource="#h-foaf-name"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.21 </span>foaf:name</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/name">http://xmlns.com/foaf/0.1/name</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 99</span><span style="text-transform: none">: foaf:name</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno80&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">creator &lt;http://example.org/user1&gt; .
+
+&lt;http://example.org/user1&gt; a foaf:Person </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">nick <span class="hljs-string">"pseudo"</span> </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"My Pseudonym"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="foaf-nick" typeof="bibo:Chapter" resource="#foaf-nick" property="bibo:hasPart">
+        <h4 id="h-foaf-nick" resource="#h-foaf-nick"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.22 </span>foaf:nick</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://xmlns.com/foaf/0.1/nick">http://xmlns.com/foaf/0.1/nick</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 100</span><span style="text-transform: none">: foaf:nick</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno81&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">dcterms</span>:<span class="hljs-value">creator &lt;http://example.org/user1&gt; .
+
+&lt;http://example.org/user1&gt; a foaf:Person </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">nick <span class="hljs-string">"pseudo"</span> </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">foaf</span>:<span class="hljs-value">name <span class="hljs-string">"My Pseudonym"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="rdf-type" typeof="bibo:Chapter" resource="#rdf-type" property="bibo:hasPart">
+        <h4 id="h-rdf-type" resource="#h-rdf-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.23 </span>rdf:type</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">http://www.w3.org/1999/02/22-rdf-syntax-ns#type</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 101</span><span style="text-transform: none">: rdf:type</span></div><pre class="highlight hljs"></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="rdf-value" typeof="bibo:Chapter" resource="#rdf-value" property="bibo:hasPart">
+        <h4 id="h-rdf-value" resource="#h-rdf-value"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.24 </span>rdf:value</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#value">http://www.w3.org/1999/02/22-rdf-syntax-ns#value</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 102</span><span style="text-transform: none">: rdf:value</span></div><pre class="highlight hljs"></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="rdfs-label" typeof="bibo:Chapter" resource="#rdfs-label" property="bibo:hasPart">
+        <h4 id="h-rdfs-label" resource="#h-rdfs-label"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.25 </span>rdfs:label</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://www.w3.org/2000/01/rdf-schema#label">http://www.w3.org/2000/01/rdf-schema#label</a></li>
+            <li><strong>Equivalent Properties:</strong> <a href="http://www.w3.org/ns/activitystreams#name">as:name</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 103</span><span style="text-transform: none">: rdfs:label</span></div><pre class="highlight hljs"></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="schema-accessibilityfeature" typeof="bibo:Chapter" resource="#schema-accessibilityfeature" property="bibo:hasPart">
+        <h4 id="h-schema-accessibilityfeature" resource="#h-schema-accessibilityfeature"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.26 </span>schema:accessibilityFeature</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://schema.org/accessibilityFeature">http://schema.org/accessibilityFeature</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 104</span><span style="text-transform: none">: schema:Audience</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno82&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/video1&gt; .
+
+&lt;http://example.com/video1&gt; a dctypes:MovingImage </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">schema</span>:<span class="hljs-value">accessibilityFeature <span class="hljs-string">"captions"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+      <section class="term" id="schema-audience-1" typeof="bibo:Chapter" resource="#schema-audience-1" property="bibo:hasPart">
+        <h4 id="h-schema-audience-1" resource="#h-schema-audience-1"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2.27 </span>schema:audience</span></h4>
+        <p></p>
+        <div class="tech">
+          <ul>
+            <li><strong>URI:</strong> <a href="http://schema.org/audience">http://schema.org/audience</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="example">
+            <div class="example-title marker"><span>Example 105</span><span style="text-transform: none">: schema:Audience</span></div><pre class="highlight hljs css">&lt;<span class="hljs-rule"><span class="hljs-attribute">http</span>:<span class="hljs-value">//example.org/anno83&gt; a oa:Annotation </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasBody &lt;http://example.net/review1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">oa</span>:<span class="hljs-value">hasTarget &lt;http://example.com/restaurant1&gt; </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">schema</span>:<span class="hljs-value">audience &lt;http://example.net/roles/musician&gt; .
+
+&lt;http://example.net/roles/musician&gt; a schema:Audience </span></span>;
+    <span class="hljs-rule"><span class="hljs-attribute">schema</span>:<span class="hljs-value">audienceType <span class="hljs-string">"musician"</span> .</span></span></pre></div>
+        </div>
+      </section>
+
+    </section>
+    <!-- /Recommended Properties -->
+  </section>
+  <!-- /Recommended Ontologies -->
+
+  <section id="extensions" typeof="bibo:Chapter" resource="#extensions" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-extensions" resource="#h-extensions"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Extensions</span></h2>
+
+    <p>This vocabulary may be extended in the regular way, by creating new or importing existing predicates and classes from other RDF based ontologies. Extensions may be made to any resource, including adding new objects as well as properties. If there is a property in one of the ontologies that are already included in the context, then it is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to use a CURIE, the namespace and property name separated by a <code>:</code> character, as the JSON-LD key rather than creating a new context.</p>
+
+    <p>For example, it is easier to add <code>skos:prefLabel</code> to the Annotation rather than requiring clients to download a new context document to discover the mapping.</p>
+
+    <div class="example">
+      <div class="example-title marker"><span>Example 106</span><span style="text-transform: none">: Extension Example 1</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno84"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">skos:prefLabel</span>": <span class="hljs-value"><span class="hljs-string">"Picture Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I love this picture!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/images/picture1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Image"</span>
+  </span>}
+</span>}</pre></div>
+
+
+    <p>In order to ensure a lack of collision between key names, a JSON-LD context document <em class="rfc2119" title="SHOULD">SHOULD</em> be made available when the term is not from an ontology that is already in the Web Annotation context. Extension contexts <em class="rfc2119" title="MUST NOT">MUST NOT</em> redefine existing JSON-LD keys from the Web Annotation context. Implementations <em class="rfc2119" title="MUST">MUST</em> ignore unfamiliar properties when processing the data, but servers <em class="rfc2119" title="SHOULD">SHOULD</em> preserve them if they are part of a valid and included context.</p>
+
+    <p>The context <em class="rfc2119" title="SHOULD">SHOULD</em> be associated with the resource that most closely encapsulates the extension properties. This is to try to ensure that extensions which define the same key do not collide unexpectedly. If there is more than one context document for a particular resource, then they must be included in an array.</p>
+
+    <p>For example, adding height and width for the target image using the EXIF vocabulary [<cite><a class="bibref" href="#bib-exif">exif</a></cite>] could be done by defining a JSON-LD context, including the <code>height</code> and <code>width</code> properties, and linking to the newly defined context in the target resource.</p>
+
+    <div class="example">
+      <div class="example-title marker"><span>Example 107</span><span style="text-transform: none">: Extension Example 2</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno85"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">skos:prefLabel</span>": <span class="hljs-value"><span class="hljs-string">"Picture Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I love this picture!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/images/ns/extension.jsonld"</span></span>,
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.com/images/picture1"</span></span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Image"</span></span>,
+    "<span class="hljs-attribute">height</span>": <span class="hljs-value"><span class="hljs-number">768</span></span>,
+    "<span class="hljs-attribute">width</span>": <span class="hljs-value"><span class="hljs-number">1024</span>
+  </span>}
+</span>}</pre></div>
+
+    <p>Note that the current JSON-LD [<cite><a class="bibref" href="#bib-JSON-LD">JSON-LD</a></cite>] specification does not allow arrays to contain other arrays directly. As JSON-LD is the <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> serialization format, extensions <em class="rfc2119" title="SHOULD">SHOULD</em> avoid the use of this pattern.</p>
+
+    <p>Finally, new classes can be defined to further extend the model for specific communities and use cases. New Selectors and States are particularly valuable for extension for new ways of defining representations, and for selecting segments of those representations.</p>
+
+    <p>For example, an annotation on a three dimensional model would require the addition of depth and the starting position on the z axis, along with x, y, width, and height. These might be kept together in a new ThreeDSelector resource.</p>
+
+    <div class="example">
+      <div class="example-title marker"><span>Example 108</span><span style="text-transform: none">: Extension Example 3</span></div><pre class="highlight hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/anno86"</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">skos:prefLabel</span>": <span class="hljs-value"><span class="hljs-string">"3d Annotation"</span></span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"TextualBody"</span></span>,
+    "<span class="hljs-attribute">value</span>": <span class="hljs-value"><span class="hljs-string">"I love this part of the model!"</span>
+  </span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">source</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/models/robot.3d"</span></span>,
+    "<span class="hljs-attribute">selector</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://example.org/3d/ns/extension.jsonld"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"ThreeDSelector"</span></span>,
+      "<span class="hljs-attribute">x</span>": <span class="hljs-value"><span class="hljs-number">1035</span></span>,
+      "<span class="hljs-attribute">y</span>": <span class="hljs-value"><span class="hljs-number">245</span></span>,
+      "<span class="hljs-attribute">z</span>": <span class="hljs-value"><span class="hljs-number">782</span></span>,
+      "<span class="hljs-attribute">w</span>": <span class="hljs-value"><span class="hljs-number">120</span></span>,
+      "<span class="hljs-attribute">h</span>": <span class="hljs-value"><span class="hljs-number">180</span></span>,
+      "<span class="hljs-attribute">d</span>": <span class="hljs-value"><span class="hljs-number">90</span>
+    </span>}
+  </span>}
+</span>}</pre></div>
+
+  </section>
+
+
+  <section class="appendix" id="json-ld-context" typeof="bibo:Chapter" resource="#json-ld-context" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-json-ld-context" resource="#h-json-ld-context"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>JSON-LD Context</span></h2>
+
+    <p>
+      The <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> serialization format is [<cite><a class="bibref" href="#bib-JSON-LD">JSON-LD</a></cite>]. The JSON-LD context presented below is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to ensure consistency between implementations, and <em class="rfc2119" title="SHOULD">SHOULD</em> be referenced as <code>http://www.w3.org/ns/anno.jsonld</code>. The same URI <em class="rfc2119" title="SHOULD">SHOULD</em> be used as the profile URI for representations that conform to the model and context.</p>
+
+    <pre class="highlight tech example-padding hljs json">{
+ "<span class="hljs-attribute">@context</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">oa</span>":      <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/oa#"</span></span>,
+    "<span class="hljs-attribute">dc</span>":      <span class="hljs-value"><span class="hljs-string">"http://purl.org/dc/elements/1.1/"</span></span>,
+    "<span class="hljs-attribute">dcterms</span>": <span class="hljs-value"><span class="hljs-string">"http://purl.org/dc/terms/"</span></span>,
+    "<span class="hljs-attribute">dctypes</span>": <span class="hljs-value"><span class="hljs-string">"http://purl.org/dc/dcmitype/"</span></span>,
+    "<span class="hljs-attribute">foaf</span>":    <span class="hljs-value"><span class="hljs-string">"http://xmlns.com/foaf/0.1/"</span></span>,
+    "<span class="hljs-attribute">rdf</span>":     <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span></span>,
+    "<span class="hljs-attribute">rdfs</span>":    <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/2000/01/rdf-schema#"</span></span>,
+    "<span class="hljs-attribute">skos</span>":    <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/2004/02/skos/core#"</span></span>,
+    "<span class="hljs-attribute">xsd</span>":     <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/2001/XMLSchema#"</span></span>,
+    "<span class="hljs-attribute">iana</span>":    <span class="hljs-value"><span class="hljs-string">"http://www.iana.org/assignments/relation/"</span></span>,
+    "<span class="hljs-attribute">owl</span>":     <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/2002/07/owl#"</span></span>,
+    "<span class="hljs-attribute">as</span>":      <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/activitystreams#"</span></span>,
+    "<span class="hljs-attribute">schema</span>":  <span class="hljs-value"><span class="hljs-string">"http://schema.org/"</span></span>,
+
+    "<span class="hljs-attribute">id</span>":      <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>}</span>,
+    "<span class="hljs-attribute">type</span>":    <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"@type"</span></span>}</span>,
+
+    "<span class="hljs-attribute">Annotation</span>":           <span class="hljs-value"><span class="hljs-string">"oa:Annotation"</span></span>,
+    "<span class="hljs-attribute">Dataset</span>":              <span class="hljs-value"><span class="hljs-string">"dctypes:Dataset"</span></span>,
+    "<span class="hljs-attribute">Image</span>":                <span class="hljs-value"><span class="hljs-string">"dctypes:StillImage"</span></span>,
+    "<span class="hljs-attribute">Video</span>":                <span class="hljs-value"><span class="hljs-string">"dctypes:MovingImage"</span></span>,
+    "<span class="hljs-attribute">Audio</span>":                <span class="hljs-value"><span class="hljs-string">"dctypes:Sound"</span></span>,
+    "<span class="hljs-attribute">Text</span>":                 <span class="hljs-value"><span class="hljs-string">"dctypes:Text"</span></span>,
+    "<span class="hljs-attribute">TextualBody</span>":          <span class="hljs-value"><span class="hljs-string">"oa:TextualBody"</span></span>,
+    "<span class="hljs-attribute">ResourceSelection</span>":    <span class="hljs-value"><span class="hljs-string">"oa:ResourceSelection"</span></span>,
+    "<span class="hljs-attribute">SpecificResource</span>":     <span class="hljs-value"><span class="hljs-string">"oa:SpecificResource"</span></span>,
+    "<span class="hljs-attribute">FragmentSelector</span>":     <span class="hljs-value"><span class="hljs-string">"oa:FragmentSelector"</span></span>,
+    "<span class="hljs-attribute">CssSelector</span>":          <span class="hljs-value"><span class="hljs-string">"oa:CssSelector"</span></span>,
+    "<span class="hljs-attribute">XPathSelector</span>":        <span class="hljs-value"><span class="hljs-string">"oa:XPathSelector"</span></span>,
+    "<span class="hljs-attribute">TextQuoteSelector</span>":    <span class="hljs-value"><span class="hljs-string">"oa:TextQuoteSelector"</span></span>,
+    "<span class="hljs-attribute">TextPositionSelector</span>": <span class="hljs-value"><span class="hljs-string">"oa:TextPositionSelector"</span></span>,
+    "<span class="hljs-attribute">DataPositionSelector</span>": <span class="hljs-value"><span class="hljs-string">"oa:DataPositionSelector"</span></span>,
+    "<span class="hljs-attribute">SvgSelector</span>":          <span class="hljs-value"><span class="hljs-string">"oa:SvgSelector"</span></span>,
+    "<span class="hljs-attribute">RangeSelector</span>":        <span class="hljs-value"><span class="hljs-string">"oa:RangeSelector"</span></span>,
+    "<span class="hljs-attribute">TimeState</span>":            <span class="hljs-value"><span class="hljs-string">"oa:TimeState"</span></span>,
+    "<span class="hljs-attribute">HttpState</span>":            <span class="hljs-value"><span class="hljs-string">"oa:HttpRequestState"</span></span>,
+    "<span class="hljs-attribute">CssStylesheet</span>":        <span class="hljs-value"><span class="hljs-string">"oa:CssStyle"</span></span>,
+    "<span class="hljs-attribute">Choice</span>":               <span class="hljs-value"><span class="hljs-string">"oa:Choice"</span></span>,
+    "<span class="hljs-attribute">Composite</span>":            <span class="hljs-value"><span class="hljs-string">"oa:Composite"</span></span>,
+    "<span class="hljs-attribute">List</span>":                 <span class="hljs-value"><span class="hljs-string">"oa:List"</span></span>,
+    "<span class="hljs-attribute">Independents</span>":         <span class="hljs-value"><span class="hljs-string">"oa:Independents"</span></span>,
+    "<span class="hljs-attribute">Person</span>":               <span class="hljs-value"><span class="hljs-string">"foaf:Person"</span></span>,
+    "<span class="hljs-attribute">Software</span>":             <span class="hljs-value"><span class="hljs-string">"as:Application"</span></span>,
+    "<span class="hljs-attribute">Organization</span>":         <span class="hljs-value"><span class="hljs-string">"foaf:Organization"</span></span>,
+    "<span class="hljs-attribute">AnnotationCollection</span>": <span class="hljs-value"><span class="hljs-string">"as:OrderedCollection"</span></span>,
+    "<span class="hljs-attribute">AnnotationPage</span>":       <span class="hljs-value"><span class="hljs-string">"as:OrderedCollectionPage"</span></span>,
+    "<span class="hljs-attribute">Audience</span>":             <span class="hljs-value"><span class="hljs-string">"schema:Audience"</span></span>, 
+
+    "<span class="hljs-attribute">Motivation</span>":    <span class="hljs-value"><span class="hljs-string">"oa:Motivation"</span></span>,
+    "<span class="hljs-attribute">bookmarking</span>":   <span class="hljs-value"><span class="hljs-string">"oa:bookmarking"</span></span>,
+    "<span class="hljs-attribute">classifying</span>":   <span class="hljs-value"><span class="hljs-string">"oa:classifying"</span></span>,
+    "<span class="hljs-attribute">commenting</span>":    <span class="hljs-value"><span class="hljs-string">"oa:commenting"</span></span>,
+    "<span class="hljs-attribute">describing</span>":    <span class="hljs-value"><span class="hljs-string">"oa:describing"</span></span>,
+    "<span class="hljs-attribute">editing</span>":       <span class="hljs-value"><span class="hljs-string">"oa:editing"</span></span>,
+    "<span class="hljs-attribute">highlighting</span>":  <span class="hljs-value"><span class="hljs-string">"oa:highlighting"</span></span>,
+    "<span class="hljs-attribute">identifying</span>":   <span class="hljs-value"><span class="hljs-string">"oa:identifying"</span></span>,
+    "<span class="hljs-attribute">linking</span>":       <span class="hljs-value"><span class="hljs-string">"oa:linking"</span></span>,
+    "<span class="hljs-attribute">moderating</span>":    <span class="hljs-value"><span class="hljs-string">"oa:moderating"</span></span>,
+    "<span class="hljs-attribute">questioning</span>":   <span class="hljs-value"><span class="hljs-string">"oa:questioning"</span></span>,
+    "<span class="hljs-attribute">replying</span>":      <span class="hljs-value"><span class="hljs-string">"oa:replying"</span></span>,
+    "<span class="hljs-attribute">reviewing</span>":     <span class="hljs-value"><span class="hljs-string">"oa:reviewing"</span></span>,
+    "<span class="hljs-attribute">tagging</span>":       <span class="hljs-value"><span class="hljs-string">"oa:tagging"</span></span>,
+
+    "<span class="hljs-attribute">auto</span>":          <span class="hljs-value"><span class="hljs-string">"oa:autoDirection"</span></span>,
+    "<span class="hljs-attribute">ltr</span>":           <span class="hljs-value"><span class="hljs-string">"oa:ltrDirection"</span></span>,
+    "<span class="hljs-attribute">rtl</span>":           <span class="hljs-value"><span class="hljs-string">"oa:rtlDirection"</span></span>,
+
+    "<span class="hljs-attribute">body</span>":          <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasBody"</span></span>}</span>,
+    "<span class="hljs-attribute">target</span>":        <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasTarget"</span></span>}</span>,
+    "<span class="hljs-attribute">source</span>":        <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasSource"</span></span>}</span>,
+    "<span class="hljs-attribute">selector</span>":      <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasSelector"</span></span>}</span>,
+    "<span class="hljs-attribute">state</span>":         <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasState"</span></span>}</span>,
+    "<span class="hljs-attribute">scope</span>":         <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasScope"</span></span>}</span>,
+    "<span class="hljs-attribute">refinedBy</span>":     <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:refinedBy"</span></span>}</span>,
+    "<span class="hljs-attribute">startSelector</span>": <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasStartSelector"</span></span>}</span>,
+    "<span class="hljs-attribute">endSelector</span>":   <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasEndSelector"</span></span>}</span>,
+    "<span class="hljs-attribute">renderedVia</span>":   <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:renderedVia"</span></span>}</span>,
+    "<span class="hljs-attribute">creator</span>":       <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"dcterms:creator"</span></span>}</span>,
+    "<span class="hljs-attribute">generator</span>":     <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:generator"</span></span>}</span>,
+    "<span class="hljs-attribute">rights</span>":        <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"dcterms:rights"</span></span>}</span>,
+    "<span class="hljs-attribute">homepage</span>":      <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"foaf:homepage"</span></span>}</span>,
+    "<span class="hljs-attribute">via</span>":           <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:via"</span></span>}</span>,
+    "<span class="hljs-attribute">canonical</span>":     <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:canonical"</span></span>}</span>,
+    "<span class="hljs-attribute">stylesheet</span>":    <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:styledBy"</span></span>}</span>,
+    "<span class="hljs-attribute">cached</span>":        <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:cachedSource"</span></span>}</span>,
+    "<span class="hljs-attribute">conformsTo</span>":    <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"dcterms:conformsTo"</span></span>}</span>,
+    "<span class="hljs-attribute">items</span>":         <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:items"</span></span>, "<span class="hljs-attribute">@container</span>": <span class="hljs-value"><span class="hljs-string">"@list"</span></span>}</span>,
+    "<span class="hljs-attribute">partOf</span>":        <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:partOf"</span></span>}</span>,
+    "<span class="hljs-attribute">first</span>":         <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:first"</span></span>}</span>,
+    "<span class="hljs-attribute">last</span>":          <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:last"</span></span>}</span>,
+    "<span class="hljs-attribute">next</span>":          <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:next"</span></span>}</span>,
+    "<span class="hljs-attribute">prev</span>":          <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:prev"</span></span>}</span>,
+    "<span class="hljs-attribute">audience</span>":      <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@id"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"schema:audience"</span></span>}</span>,
+    "<span class="hljs-attribute">motivation</span>":    <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@vocab"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:motivatedBy"</span></span>}</span>,
+    "<span class="hljs-attribute">purpose</span>":       <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@vocab"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:hasPurpose"</span></span>}</span>,
+    "<span class="hljs-attribute">textDirection</span>": <span class="hljs-value">{"<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"@vocab"</span></span>, "<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:textDirection"</span></span>}</span>,
+
+    "<span class="hljs-attribute">accessibility</span>": <span class="hljs-value"><span class="hljs-string">"schema:accessibilityFeature"</span></span>,
+    "<span class="hljs-attribute">bodyValue</span>":     <span class="hljs-value"><span class="hljs-string">"oa:bodyValue"</span></span>,
+    "<span class="hljs-attribute">format</span>":        <span class="hljs-value"><span class="hljs-string">"dc:format"</span></span>,
+    "<span class="hljs-attribute">language</span>":      <span class="hljs-value"><span class="hljs-string">"dc:language"</span></span>,
+    "<span class="hljs-attribute">value</span>":         <span class="hljs-value"><span class="hljs-string">"rdf:value"</span></span>,
+    "<span class="hljs-attribute">exact</span>":         <span class="hljs-value"><span class="hljs-string">"oa:exact"</span></span>,
+    "<span class="hljs-attribute">prefix</span>":        <span class="hljs-value"><span class="hljs-string">"oa:prefix"</span></span>,
+    "<span class="hljs-attribute">suffix</span>":        <span class="hljs-value"><span class="hljs-string">"oa:suffix"</span></span>,
+    "<span class="hljs-attribute">styleClass</span>":    <span class="hljs-value"><span class="hljs-string">"oa:styleClass"</span></span>,
+    "<span class="hljs-attribute">name</span>":          <span class="hljs-value"><span class="hljs-string">"foaf:name"</span></span>,
+    "<span class="hljs-attribute">email</span>":         <span class="hljs-value"><span class="hljs-string">"foaf:mbox"</span></span>,
+    "<span class="hljs-attribute">email_sha1</span>":    <span class="hljs-value"><span class="hljs-string">"foaf:mbox_sha1sum"</span></span>,
+    "<span class="hljs-attribute">account</span>":       <span class="hljs-value"><span class="hljs-string">"foaf:nick"</span></span>,
+    "<span class="hljs-attribute">label</span>":         <span class="hljs-value"><span class="hljs-string">"rdfs:label"</span></span>,
+
+    "<span class="hljs-attribute">created</span>":       <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"dcterms:created"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:dateTime"</span></span>}</span>,
+    "<span class="hljs-attribute">modified</span>":      <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"dcterms:modified"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:dateTime"</span></span>}</span>,
+    "<span class="hljs-attribute">generated</span>":     <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"dcterms:issued"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:dateTime"</span></span>}</span>,
+    "<span class="hljs-attribute">sourceDate</span>":    <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:sourceDate"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:dateTime"</span></span>}</span>,
+    "<span class="hljs-attribute">sourceDateStart</span>": <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:sourceDateStart"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:dateTime"</span></span>}</span>,
+    "<span class="hljs-attribute">sourceDateEnd</span>": <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:sourceDateEnd"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:dateTime"</span></span>}</span>,
+
+    "<span class="hljs-attribute">start</span>":         <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:start"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:nonNegativeInteger"</span></span>}</span>,
+    "<span class="hljs-attribute">end</span>":           <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"oa:end"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:nonNegativeInteger"</span></span>}</span>,
+    "<span class="hljs-attribute">total</span>":         <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:totalItems"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:nonNegativeInteger"</span></span>}</span>,
+    "<span class="hljs-attribute">startIndex</span>":    <span class="hljs-value">{"<span class="hljs-attribute">@id</span>": <span class="hljs-value"><span class="hljs-string">"as:startIndex"</span></span>, "<span class="hljs-attribute">@type</span>": <span class="hljs-value"><span class="hljs-string">"xsd:nonNegativeInteger"</span></span>}
+  </span>}
+</span>}
+</pre>
+  </section>
+
+  <section class="appendix" id="json-ld-frames" typeof="bibo:Chapter" resource="#json-ld-frames" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-json-ld-frames" resource="#h-json-ld-frames"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>JSON-LD Frames</span></h2>
+
+    <p>There is an unofficial, yet well implemented, JSON-LD specification [<cite><a class="bibref" href="#bib-json-ld-framing">json-ld-framing</a></cite>] that describes a deterministic layout for serializing an RDF graph into a particular JSON-LD document layout. Applying the following frames to the graph of information will generate JSON as close as possible to the serialization recommended by the Web Annotation Data Model.</p>
+
+    <section id="annotation-frame" typeof="bibo:Chapter" resource="#annotation-frame" property="bibo:hasPart">
+      <h3 id="h-annotation-frame" resource="#h-annotation-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.1 </span>Annotation Frame</span></h3>
+      <p>
+        A Frame for serializing a single Annotation.</p>
+
+      <pre class="highlight tech example-padding hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">@omitDefault</span>": <span class="hljs-value"><span class="hljs-literal">true</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Annotation"</span></span>,
+  "<span class="hljs-attribute">via</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>}</span>,
+  "<span class="hljs-attribute">canonical</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>}</span>,
+  "<span class="hljs-attribute">rights</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>}</span>,
+  "<span class="hljs-attribute">motivation</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>}</span>,
+  "<span class="hljs-attribute">body</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">true</span></span>}</span>,
+  "<span class="hljs-attribute">target</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">true</span></span>}</span>,
+  "<span class="hljs-attribute">creator</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">true</span></span>}</span>,
+  "<span class="hljs-attribute">generator</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">true</span></span>}</span>,
+  "<span class="hljs-attribute">audience</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">true</span></span>}
+</span>}
+
+</pre>
+    </section>
+
+    <section id="annotation-collection-frame" typeof="bibo:Chapter" resource="#annotation-collection-frame" property="bibo:hasPart">
+      <h3 id="h-annotation-collection-frame" resource="#h-annotation-collection-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.2 </span>Annotation Collection Frame</span></h3>
+
+      <p>A Frame for serializing a Collection of Annotations.</p>
+
+      <pre class="highlight tech example-padding hljs json">{
+    "<span class="hljs-attribute">@context</span>" : <span class="hljs-value">[
+    	<span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span>,
+    	<span class="hljs-string">"http://www.w3.org/ns/ldp.jsonld"</span>
+  	]</span>,
+    "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"Collection"</span></span>,
+    "<span class="hljs-attribute">first</span>": <span class="hljs-value">[{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-string">"False"</span></span>}]</span>,
+    "<span class="hljs-attribute">last</span>": <span class="hljs-value">[{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-string">"False"</span></span>}]
+</span>}
+
+</pre>
+
+      <div class="note">
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note5"><span>Note</span></div>
+        <div class="">If it is instead desirable to embed the first page of the Collection, change the <code>false</code> for <code>first</code> to <code>true</code>.</div>
+      </div>
+
+    </section>
+
+    <section id="annotation-page-frame" typeof="bibo:Chapter" resource="#annotation-page-frame" property="bibo:hasPart">
+      <h3 id="h-annotation-page-frame" resource="#h-annotation-page-frame"><span property="xhv:role" resource="xhv:heading"><span class="secno">B.3 </span>Annotation Page Frame</span></h3>
+
+      <p>A Frame for serializing a Page from a Collection of Annotations.</p>
+
+      <pre class="highlight tech example-padding hljs json">{
+  "<span class="hljs-attribute">@context</span>": <span class="hljs-value"><span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span></span>,
+  "<span class="hljs-attribute">@omitDefault</span>": <span class="hljs-value"><span class="hljs-literal">true</span></span>,
+  "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"AnnotationPage"</span></span>,
+  "<span class="hljs-attribute">next</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>}</span>,
+  "<span class="hljs-attribute">prev</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>}</span>,
+  "<span class="hljs-attribute">partOf</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">false</span></span>}</span>,
+  "<span class="hljs-attribute">items</span>": <span class="hljs-value">{"<span class="hljs-attribute">@embed</span>": <span class="hljs-value"><span class="hljs-literal">true</span></span>}
+</span>}
+</pre>
+
+    </section>
+  </section>
+
+  <section class="appendix" id="extending-motivations" typeof="bibo:Chapter" resource="#extending-motivations" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-extending-motivations" resource="#h-extending-motivations"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>Extending Motivations</span></h2>
+
+    <p>Although the list of Motivations in the specification is derived from an extensive survey of the annotation landscape, there are many situations where more precise definitions are required or desirable. In these cases it is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to create a new Motivation resource and relate it to one or more that already exist.</p>
+
+    <p>New Motivations <em class="rfc2119" title="MUST">MUST</em> be instances of <code>oa:Motivation</code>, which is a subClass of <code>skos:Concept</code>. The <code>skos:broader</code> relationship <em class="rfc2119" title="SHOULD">SHOULD</em> be asserted between the new Motivation and at least one existing Motivation, if there are any that are broader in scope. Other relationships, such as <code>skos:relatedMatch</code>, <code>skos:exactMatch</code> and <code>skos:closeMatch</code>, <em class="rfc2119" title="SHOULD">SHOULD</em> also be asserted to concepts created by other communities.
+    </p>
+
+    <h2 id="model">Model</h2>
+    <figure id="fig-extending-motivations">
+      <img src="images/skosmotivations.png" alt="Use of SKOS to extend motivations">
+      <figcaption>Fig. <span class="figno">1</span> <span class="fig-title">Extending Motivations</span></figcaption>
     </figure>
-</section>
+  </section>
 
-<section property="bibo:hasPart" resource="#acknowledgements" typeof="bibo:Chapter" id="acknowledgements" class="appendix">
-<!--OddPage--><h2 resource="#h-acknowledgements" id="h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">D. </span>Acknowledgements</span></h2>
+  <section class="appendix" id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">D. </span>Acknowledgements</span></h2>
 
-<p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>.  The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model.
-</p>
+    <p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>. The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model.
+    </p>
 
-<p>The following people have been instrumental in providing thoughts, feedback, reviews, content, criticism and input in the creation of this specification:
+    <p>The following people have been instrumental in providing thoughts, feedback, reviews, content, criticism and input in the creation of this specification:
 
-</p><div style="margin-left: 3em">
-Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven Capadisli, Paolo Ciccarese, Tim Cole, Ray Denenberg, TB Dinesh, Sergiu Gordea, Benjamin Goering, Amy Guy, Ivan Herman, Frederick Hirsch, Antoine Isaac, Jacob Jett, Takeshi Kanai, Gregg Kellogg, Andreas Kuckartz, Randall Leeds, Hugo Manguinhas, Ben De Meester, Luc Moreau, Addison Phillips, Davis Salisbury, Robert Sanderson, Felix Sasaki, Doug Schepers, Tzviya Siegman, Stian Soiland-Reyes, Manu Sporney, Nick Stenning, Jon Stroop, Lutz Suhrbier, Kyrce Swenson, Raphael Troncy, Simeon Warner, Erik Wilde, Dan Whaley, Benjamin Young
-</div>
-<p></p>
+    </p>
+    <div style="margin-left: 3em">
+      Vladimir Alexiev, Art Barstow, Tim Berners-Lee, Chris Birk, Dan Brickley, Sarven Capadisli, Paolo Ciccarese, Tim Cole, Ray Denenberg, TB Dinesh, Sergiu Gordea, Benjamin Goering, Amy Guy, Ivan Herman, Frederick Hirsch, Antoine Isaac, Jacob Jett, Takeshi Kanai, Gregg Kellogg, Andreas Kuckartz, Randall Leeds, Hugo Manguinhas, Ben De Meester, Luc Moreau, Addison Phillips, Davis Salisbury, Robert Sanderson, Felix Sasaki, Doug Schepers, Tzviya Siegman, Stian Soiland-Reyes, Manu Sporney, Nick Stenning, Jon Stroop, Lutz Suhrbier, Kyrce Swenson, Raphael Troncy, Simeon Warner, Erik Wilde, Dan Whaley, Benjamin Young
+    </div>
+    <p></p>
 
-</section>
+  </section>
 
 
 
-<section property="bibo:hasPart" resource="#references" typeof="bibo:Chapter" id="references" class="appendix"><!--OddPage--><h2 resource="#h-references" id="h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E. </span>References</span></h2><section property="bibo:hasPart" resource="#normative-references" typeof="bibo:Chapter" id="normative-references"><h3 resource="#h-normative-references" id="h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E.1 </span>Normative references</span></h3><dl resource="" class="bibliography"><dt id="bib-DC-TERMS">[DC-TERMS]</dt><dd>Dublin Core Metadata Initiative. <a property="dc:requires" href="http://dublincore.org/documents/2010/10/11/dcmi-terms/"><cite>Dublin Core Metadata Initiative Terms, version 1.1.</cite></a> 11 October 2010. DCMI Recommendation. URL: <a property="dc:requires" href="http://dublincore.org/documents/2010/10/11/dcmi-terms/">http://dublincore.org/documents/2010/10/11/dcmi-terms/</a>.
-</dd><dt id="bib-DC11">[DC11]</dt><dd>Dublin Core metadata initiative. <a property="dc:requires" href="http://dublincore.org/documents/2012/06/14/dces/"><cite>Dublin Core Metadata Element Set, Version 1.1</cite></a>. 14 June 2012. DCMI recommendation. URL: <a property="dc:requires" href="http://dublincore.org/documents/2012/06/14/dces/">http://dublincore.org/documents/2012/06/14/dces/</a>
-</dd><dt id="bib-FOAF">[FOAF]</dt><dd>Dan Brickley; Libby Miller. FOAF project. <a property="dc:requires" href="http://xmlns.com/foaf/spec"><cite>FOAF Vocabulary Specification 0.99 (Paddington Edition)</cite></a>. 14 January 2014. URL: <a property="dc:requires" href="http://xmlns.com/foaf/spec">http://xmlns.com/foaf/spec</a>
-</dd><dt id="bib-JSON-LD">[JSON-LD]</dt><dd>Manu Sporny; Gregg Kellogg; Markus Lanthaler. W3C. <a property="dc:requires" href="http://www.w3.org/TR/json-ld/"><cite>JSON-LD 1.0</cite></a>. 16 January 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/json-ld/">http://www.w3.org/TR/json-ld/</a>
-</dd><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-</dd><dt id="bib-Turtle">[Turtle]</dt><dd>Eric Prud'hommeaux; Gavin Carothers. W3C. <a property="dc:requires" href="http://www.w3.org/TR/turtle/"><cite>RDF 1.1 Turtle</cite></a>. 25 February 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/turtle/">http://www.w3.org/TR/turtle/</a>
-</dd><dt id="bib-activitystreams-vocabulary">[activitystreams-vocabulary]</dt><dd>James Snell; Evan Prodromou. W3C. <a property="dc:requires" href="http://www.w3.org/TR/activitystreams-vocabulary/"><cite>Activity Vocabulary</cite></a>. 15 December 2015. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/activitystreams-vocabulary/">http://www.w3.org/TR/activitystreams-vocabulary/</a>
-</dd><dt id="bib-annotation-model">[annotation-model]</dt><dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/"><cite>Web Annotation Data Model</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
-</dd><dt id="bib-annotation-protocol">[annotation-protocol]</dt><dd>Robert Sanderson. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/"><cite>Web Annotation Protocol</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a>
-</dd><dt id="bib-rdf-schema">[rdf-schema]</dt><dd>Dan Brickley; Ramanathan Guha. W3C. <a property="dc:requires" href="http://www.w3.org/TR/rdf-schema/"><cite>RDF Schema 1.1</cite></a>. 25 February 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/rdf-schema/">http://www.w3.org/TR/rdf-schema/</a>
-</dd><dt id="bib-rfc5988">[rfc5988]</dt><dd>M. Nottingham. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988">https://tools.ietf.org/html/rfc5988</a>
-</dd><dt id="bib-skos-reference">[skos-reference]</dt><dd>Alistair Miles; Sean Bechhofer. W3C. <a property="dc:requires" href="http://www.w3.org/TR/skos-reference"><cite>SKOS Simple Knowledge Organization System Reference</cite></a>. 18 August 2009. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/skos-reference">http://www.w3.org/TR/skos-reference</a>
-</dd><dt id="bib-xmlschema-2">[xmlschema-2]</dt><dd>Paul V. Biron; Ashok Malhotra. W3C. <a property="dc:requires" href="http://www.w3.org/TR/xmlschema-2/"><cite>XML Schema Part 2: Datatypes Second Edition</cite></a>. 28 October 2004. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>
-</dd></dl></section><section property="bibo:hasPart" resource="#informative-references" typeof="bibo:Chapter" id="informative-references"><h3 resource="#h-informative-references" id="h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E.2 </span>Informative references</span></h3><dl resource="" class="bibliography"><dt id="bib-BCP47">[BCP47]</dt><dd>A. Phillips; M. Davis. IETF. <a property="dc:references" href="https://tools.ietf.org/html/bcp47"><cite>Tags for Identifying Languages</cite></a>. September 2009. IETF Best Current Practice. URL: <a property="dc:references" href="https://tools.ietf.org/html/bcp47">https://tools.ietf.org/html/bcp47</a>
-</dd><dt id="bib-exif">[exif]</dt><dd>W3C. <a property="dc:references" href="https://www.w3.org/2003/12/exif/"><cite>Exif Vocabulary Workspace - RDF Schema</cite></a>. URL: <a property="dc:references" href="https://www.w3.org/2003/12/exif/">https://www.w3.org/2003/12/exif/</a>
-</dd><dt id="bib-json-ld-framing">[json-ld-framing]</dt><dd>W3C JSON-LD Community Group. <a property="dc:references" href="http://json-ld.org/spec/latest/json-ld-framing/"><cite>JSON-LD Framing 1.0</cite></a>. URL: <a property="dc:references" href="http://json-ld.org/spec/latest/json-ld-framing/">http://json-ld.org/spec/latest/json-ld-framing/</a>
-</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js" defer="" async=""></script></body></html>
+  <section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E. </span>References</span></h2>
+
+    <section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart">
+      <h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E.1 </span>Normative references</span></h3>
+      <dl class="bibliography" resource=""><dt id="bib-DC-TERMS">[DC-TERMS]</dt>
+        <dd>Dublin Core Metadata Initiative. <a href="http://dublincore.org/documents/2010/10/11/dcmi-terms/" property="dc:requires"><cite>Dublin Core Metadata Initiative Terms, version 1.1.</cite></a> 11 October 2010. DCMI Recommendation. URL: <a href="http://dublincore.org/documents/2010/10/11/dcmi-terms/" property="dc:requires">http://dublincore.org/documents/2010/10/11/dcmi-terms/</a>.
+        </dd><dt id="bib-DC11">[DC11]</dt>
+        <dd>Dublin Core metadata initiative. <a href="http://dublincore.org/documents/2012/06/14/dces/" property="dc:requires"><cite>Dublin Core Metadata Element Set, Version 1.1</cite></a>. 14 June 2012. DCMI recommendation. URL: <a href="http://dublincore.org/documents/2012/06/14/dces/" property="dc:requires">http://dublincore.org/documents/2012/06/14/dces/</a>
+        </dd><dt id="bib-FOAF">[FOAF]</dt>
+        <dd>Dan Brickley; Libby Miller. FOAF project. <a href="http://xmlns.com/foaf/spec" property="dc:requires"><cite>FOAF Vocabulary Specification 0.99 (Paddington Edition)</cite></a>. 14 January 2014. URL: <a href="http://xmlns.com/foaf/spec" property="dc:requires">http://xmlns.com/foaf/spec</a>
+        </dd><dt id="bib-JSON-LD">[JSON-LD]</dt>
+        <dd>Manu Sporny; Gregg Kellogg; Markus Lanthaler. W3C. <a href="http://www.w3.org/TR/json-ld/" property="dc:requires"><cite>JSON-LD 1.0</cite></a>. 16 January 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/json-ld/" property="dc:requires">http://www.w3.org/TR/json-ld/</a>
+        </dd><dt id="bib-RFC2119">[RFC2119]</dt>
+        <dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+        </dd><dt id="bib-Turtle">[Turtle]</dt>
+        <dd>Eric Prud'hommeaux; Gavin Carothers. W3C. <a href="http://www.w3.org/TR/turtle/" property="dc:requires"><cite>RDF 1.1 Turtle</cite></a>. 25 February 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/turtle/" property="dc:requires">http://www.w3.org/TR/turtle/</a>
+        </dd><dt id="bib-activitystreams-vocabulary">[activitystreams-vocabulary]</dt>
+        <dd>James Snell; Evan Prodromou. W3C. <a href="http://www.w3.org/TR/activitystreams-vocabulary/" property="dc:requires"><cite>Activity Vocabulary</cite></a>. 15 December 2015. W3C Working Draft. URL: <a href="http://www.w3.org/TR/activitystreams-vocabulary/" property="dc:requires">http://www.w3.org/TR/activitystreams-vocabulary/</a>
+        </dd><dt id="bib-annotation-model">[annotation-model]</dt>
+        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires"><cite>Web Annotation Data Model</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
+        </dd><dt id="bib-annotation-protocol">[annotation-protocol]</dt>
+        <dd>Robert Sanderson. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/" property="dc:requires"><cite>Web Annotation Protocol</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a>
+        </dd><dt id="bib-rdf-schema">[rdf-schema]</dt>
+        <dd>Dan Brickley; Ramanathan Guha. W3C. <a href="http://www.w3.org/TR/rdf-schema/" property="dc:requires"><cite>RDF Schema 1.1</cite></a>. 25 February 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/rdf-schema/" property="dc:requires">http://www.w3.org/TR/rdf-schema/</a>
+        </dd><dt id="bib-rfc5988">[rfc5988]</dt>
+        <dd>M. Nottingham. IETF. <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires">https://tools.ietf.org/html/rfc5988</a>
+        </dd><dt id="bib-skos-reference">[skos-reference]</dt>
+        <dd>Alistair Miles; Sean Bechhofer. W3C. <a href="http://www.w3.org/TR/skos-reference" property="dc:requires"><cite>SKOS Simple Knowledge Organization System Reference</cite></a>. 18 August 2009. W3C Recommendation. URL: <a href="http://www.w3.org/TR/skos-reference" property="dc:requires">http://www.w3.org/TR/skos-reference</a>
+        </dd><dt id="bib-xmlschema-2">[xmlschema-2]</dt>
+        <dd>Paul V. Biron; Ashok Malhotra. W3C. <a href="http://www.w3.org/TR/xmlschema-2/" property="dc:requires"><cite>XML Schema Part 2: Datatypes Second Edition</cite></a>. 28 October 2004. W3C Recommendation. URL: <a href="http://www.w3.org/TR/xmlschema-2/" property="dc:requires">http://www.w3.org/TR/xmlschema-2/</a>
+        </dd>
+      </dl>
+    </section>
+
+    <section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart">
+      <h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">E.2 </span>Informative references</span></h3>
+      <dl class="bibliography" resource=""><dt id="bib-BCP47">[BCP47]</dt>
+        <dd>A. Phillips; M. Davis. IETF. <a href="https://tools.ietf.org/html/bcp47" property="dc:references"><cite>Tags for Identifying Languages</cite></a>. September 2009. IETF Best Current Practice. URL: <a href="https://tools.ietf.org/html/bcp47" property="dc:references">https://tools.ietf.org/html/bcp47</a>
+        </dd><dt id="bib-exif">[exif]</dt>
+        <dd>W3C. <a href="https://www.w3.org/2003/12/exif/" property="dc:references"><cite>Exif Vocabulary Workspace - RDF Schema</cite></a>. URL: <a href="https://www.w3.org/2003/12/exif/" property="dc:references">https://www.w3.org/2003/12/exif/</a>
+        </dd><dt id="bib-json-ld-framing">[json-ld-framing]</dt>
+        <dd>W3C JSON-LD Community Group. <a href="http://json-ld.org/spec/latest/json-ld-framing/" property="dc:references"><cite>JSON-LD Framing 1.0</cite></a>. URL: <a href="http://json-ld.org/spec/latest/json-ld-framing/" property="dc:references">http://json-ld.org/spec/latest/json-ld-framing/</a>
+        </dd>
+      </dl>
+    </section>
+  </section>
+  <p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p>
+  <script async="" defer="" src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+</body>
+</html>


### PR DESCRIPTION
See https://github.com/w3c/web-annotation/commit/0982e38a81255349e6fe0ed0ae83998ad893340b for the actual changes, the other commits have only automatically extracted/generated files.

In particular this PR addresses:
- #241 -- Protocol to use IRIs
- #240 -- Remove purpose=commenting requirement
- #237 -- Clarify UTF-8 encoding
- #232 -- Recommend HTTPS in Protocol
- #231 -- Add accessibility: schema:accessibilityFeature
- #228 -- Protocol should be clearer regarding status codes
- #224 -- Base direction for text of resources
- #210 -- Note on visual vs logical text ordering 
