### PR TITLE
SOTD changes in the protocol spec

### DIFF
--- a/vocab/wd/index-linktemplate.html
+++ b/vocab/wd/index-linktemplate.html
@@ -186,7 +186,7 @@ The use of the ActivityStreams terms are considered to be at-risk, pending [[!ac
 </p>
 
 <p class="issue">
-The <a href="#composite">Composite</a>, <a href="#list">List</a> and <a href="#independents">Independents</a> classes are marked At Risk, pending implementation experience.</p>
+The <a href="#composite">Composite</a>, <a href="#list">List</a> and <a href="#independents">Independents</a> classes are marked At Risk, pending implementation experience.
 </p>
 
 </section>

--- a/vocab/wd/index-linktemplate.html
+++ b/vocab/wd/index-linktemplate.html
@@ -181,16 +181,12 @@
 
 <section id="sotd">
 
-<div class="note">
-  The content of this document, along with the latest release of the Web Annotation Data Model [[!annotation-model]] specification, is the result of the split of the <a href="https://www.w3.org/TR/2015/WD-annotation-model-20151015/">previous release</a> of the  Web Annotation Data Model Working Draft into two documents.
-</div>
-
 <p class="issue">
-The use of the ActivityStreams terms are considered to be at-risk, pending [[!activitystreams-vocabulary]] reaching Candidate Recommendation.
+The use of the ActivityStreams terms are considered to be at-risk, pending [[!activitystreams-vocabulary]] reaching Candidate Recommendation and, eventually, Recommendation. If this fails, the (few) terms used in the current document will be replaced by terms with a similar names and similar semantics, but in the namespace defined by this document.
 </p>
 
 <p class="issue">
-<p>The <a href="#composite">Composite</a>, <a href="#list">List</a> and <a href="#independents">Independents</a> classes are marked At Risk, pending implementation experience.</p>
+The <a href="#composite">Composite</a>, <a href="#list">List</a> and <a href="#independents">Independents</a> classes are marked At Risk, pending implementation experience.</p>
 </p>
 
 </section>


### PR DESCRIPTION
The ISSUE sectioning was not correct for the at risk feature.

The note on draft splitting has been removed; it is not relevant any more for the upcoming document
