### PR TITLE
Changed the SOTD mark on at risk

### DIFF
--- a/model/wd2/index-nametemplate.html
+++ b/model/wd2/index-nametemplate.html
@@ -143,7 +143,9 @@
 This specification was derived from the Open Annotation Community Group's outcomes, and details of the differences between the two are maintained in the <a href="#acknowledgments">Acknowledgment</a> appendix.
 </p>
 
-<p>The <a href="#sets-of-bodies-and-targets">Composite, List and Independents</a> classes are marked At Risk, pending implementation experience.</p>
+<p class="issue">
+The <a href="#sets-of-bodies-and-targets">Composite, List and Independents</a> classes are marked At Risk, pending implementation experience.
+</p>
 
 </section>
 


### PR DESCRIPTION
This was done to be consistent with the format used in the protocol spec
