### PR TITLE
Protocol tweaky bugs

### DIFF
--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -354,7 +354,7 @@ Response:
 HTTP/1.1 200 OK
 Content-Type: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 ETag: "_87e52ce123123"
-Link: &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"
+Link: &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type",
       &lt;http://www.w3.org/TR/annotation-protocol/&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
 Allow: POST,GET,OPTIONS,HEAD
 Vary: Accept
@@ -405,7 +405,7 @@ HTTP/1.1 200 OK
 Content-Type: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 Content-Location: http://example.org/annotations/?uris=1
 ETag: "_87e52ce123123"
-Link: &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"
+Link: &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type",
       &lt;http://www.w3.org/TR/annotation-protocol/&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
 Allow: POST,GET,OPTIONS,HEAD
 Vary: Accept, Prefer
@@ -558,7 +558,7 @@ Content-Length: 153
 Response:
 <pre class="example highlight">
 HTTP/1.1 201 CREATED
-Link: &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"
+Link: &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type",
       &lt;http://www.w3.org/TR/annotation-protocol/&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
 Allow: PUT,GET,OPTIONS,HEAD,DELETE,PATCH
 Vary: Accept

--- a/protocol/wd/index.html
+++ b/protocol/wd/index.html
@@ -2,8 +2,8 @@
 <html lang="en" dir="ltr" typeof="bibo:Document w3p:WD" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta lang="" property="dc:language" content="en">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <meta property="dc:language" content="en" lang="">
   <style>
     /*
 
@@ -244,11 +244,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     }
     /* --- DL --- */
     
-    .section dd > p:first-child {
+    .section dd> p:first-child {
       margin-top: 0;
     }
     
-    .section dd > p:last-child {
+    .section dd> p:last-child {
       margin-bottom: 0;
     }
     
@@ -346,9 +346,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       color: #999;
     }
   </style>
-  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD">
+  <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet">
   <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
-  <script id="initialUserConfig" type="application/json">
+  <script type="application/json" id="initialUserConfig">
     {
       "specStatus": "WD",
       "shortName": "annotation-protocol",
@@ -412,10 +412,10 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </script>
 </head>
 
-<body class="h-entry" role="document" id="respecDocument">
-  <div class="head" role="contentinfo" id="respecHeader">
+<body id="respecDocument" role="document" class="h-entry toc-inline">
+  <div id="respecHeader" role="contentinfo" class="head">
     <p>
-      <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
+      <a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C" height="48" width="72"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Protocol</h1>
     <h2 id="w3c-working-draft-31-march-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-03-31">31 March 2016</time></h2>
@@ -453,8 +453,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <hr title="Separator for header">
   </div>
 
-  <section id="abstract" class="introductory" property="dc:abstract">
-    <h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+  <section property="dc:abstract" class="introductory" id="abstract">
+    <h2 resource="#h-abstract" id="h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
 
     <p>Annotations are typically used to convey information about a resource or associations between resources. Simple examples include a comment or tag on a single web page or image, or a blog post about a news article. </p>
 
@@ -463,7 +463,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </section>
 
   <section id="sotd" class="introductory">
-    <h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+    <h2 resource="#h-sotd" id="h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
     <p>
       <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
     </p>
@@ -497,49 +497,49 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
   </section>
   <nav id="toc">
-    <h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
-    <ul class="toc" role="directory">
-      <li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a>
+    <h2 resource="#table-of-contents" id="table-of-contents" class="introductory"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
+    <ul role="directory" class="toc">
+      <li class="tocline"><a class="tocxref" href="#introduction"><span class="secno">1. </span>Introduction</a>
         <ul class="toc">
-          <li class="tocline"><a href="#aims-of-the-protocol" class="tocxref"><span class="secno">1.1 </span>Aims of the Protocol</a></li>
-          <li class="tocline"><a href="#summary" class="tocxref"><span class="secno">1.2 </span>Summary</a></li>
-          <li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">1.3 </span>Conformance</a></li>
-          <li class="tocline"><a href="#terminology" class="tocxref"><span class="secno">1.4 </span>Terminology</a></li>
+          <li class="tocline"><a class="tocxref" href="#aims-of-the-protocol"><span class="secno">1.1 </span>Aims of the Protocol</a></li>
+          <li class="tocline"><a class="tocxref" href="#summary"><span class="secno">1.2 </span>Summary</a></li>
+          <li class="tocline"><a class="tocxref" href="#conformance"><span class="secno">1.3 </span>Conformance</a></li>
+          <li class="tocline"><a class="tocxref" href="#terminology"><span class="secno">1.4 </span>Terminology</a></li>
         </ul>
       </li>
-      <li class="tocline"><a href="#web-annotation-protocol-principles" class="tocxref"><span class="secno">2. </span>Web Annotation Protocol Principles</a></li>
-      <li class="tocline"><a href="#annotation-retrieval" class="tocxref"><span class="secno">3. </span>Annotation Retrieval</a></li>
-      <li class="tocline"><a href="#annotation-containers" class="tocxref"><span class="secno">4. </span>Annotation Containers</a>
+      <li class="tocline"><a class="tocxref" href="#web-annotation-protocol-principles"><span class="secno">2. </span>Web Annotation Protocol Principles</a></li>
+      <li class="tocline"><a class="tocxref" href="#annotation-retrieval"><span class="secno">3. </span>Annotation Retrieval</a></li>
+      <li class="tocline"><a class="tocxref" href="#annotation-containers"><span class="secno">4. </span>Annotation Containers</a>
         <ul class="toc">
-          <li class="tocline"><a href="#container-retrieval" class="tocxref"><span class="secno">4.1 </span>Container Retrieval</a>
+          <li class="tocline"><a class="tocxref" href="#container-retrieval"><span class="secno">4.1 </span>Container Retrieval</a>
             <ul class="toc">
-              <li class="tocline"><a href="#client-preferences" class="tocxref"><span class="secno">4.1.1 </span>Client Preferences</a></li>
-              <li class="tocline"><a href="#responses-without-annotations" class="tocxref"><span class="secno">4.1.2 </span>Responses without Annotations</a></li>
-              <li class="tocline"><a href="#responses-with-annotations" class="tocxref"><span class="secno">4.1.3 </span>Responses with Annotations</a></li>
+              <li class="tocline"><a class="tocxref" href="#client-preferences"><span class="secno">4.1.1 </span>Client Preferences</a></li>
+              <li class="tocline"><a class="tocxref" href="#responses-without-annotations"><span class="secno">4.1.2 </span>Responses without Annotations</a></li>
+              <li class="tocline"><a class="tocxref" href="#responses-with-annotations"><span class="secno">4.1.3 </span>Responses with Annotations</a></li>
             </ul>
           </li>
-          <li class="tocline"><a href="#discovery-of-annotation-containers" class="tocxref"><span class="secno">4.2 </span>Discovery of Annotation Containers</a></li>
+          <li class="tocline"><a class="tocxref" href="#discovery-of-annotation-containers"><span class="secno">4.2 </span>Discovery of Annotation Containers</a></li>
         </ul>
       </li>
-      <li class="tocline"><a href="#creation-updating-and-deletion-of-annotations" class="tocxref"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</a>
+      <li class="tocline"><a class="tocxref" href="#creation-updating-and-deletion-of-annotations"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</a>
         <ul class="toc">
-          <li class="tocline"><a href="#create-a-new-annotation" class="tocxref"><span class="secno">5.1 </span>Create a New Annotation</a></li>
-          <li class="tocline"><a href="#suggesting-an-iri-for-an-annotation" class="tocxref"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</a></li>
-          <li class="tocline"><a href="#update-an-existing-annotation" class="tocxref"><span class="secno">5.3 </span>Update an Existing Annotation</a></li>
-          <li class="tocline"><a href="#delete-an-existing-annotation" class="tocxref"><span class="secno">5.4 </span>Delete an Existing Annotation</a></li>
+          <li class="tocline"><a class="tocxref" href="#create-a-new-annotation"><span class="secno">5.1 </span>Create a New Annotation</a></li>
+          <li class="tocline"><a class="tocxref" href="#suggesting-an-iri-for-an-annotation"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</a></li>
+          <li class="tocline"><a class="tocxref" href="#update-an-existing-annotation"><span class="secno">5.3 </span>Update an Existing Annotation</a></li>
+          <li class="tocline"><a class="tocxref" href="#delete-an-existing-annotation"><span class="secno">5.4 </span>Delete an Existing Annotation</a></li>
         </ul>
       </li>
-      <li class="tocline"><a href="#error-conditions" class="tocxref"><span class="secno">6. </span>Error Conditions</a></li>
-      <li class="tocline"><a href="#containers-for-related-resources" class="tocxref"><span class="secno">7. </span>Containers for Related Resources</a></li>
-      <li class="tocline"><a href="#changed-from-previous-versions" class="tocxref"><span class="secno">A. </span>Changed from Previous Versions</a>
+      <li class="tocline"><a class="tocxref" href="#error-conditions"><span class="secno">6. </span>Error Conditions</a></li>
+      <li class="tocline"><a class="tocxref" href="#containers-for-related-resources"><span class="secno">7. </span>Containers for Related Resources</a></li>
+      <li class="tocline"><a class="tocxref" href="#changed-from-previous-versions"><span class="secno">A. </span>Changed from Previous Versions</a>
         <ul class="toc">
-          <li class="tocline"><a href="#changes-from-the-working-draft-of-2016-03-31" class="tocxref"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</a></li>
+          <li class="tocline"><a class="tocxref" href="#changes-from-the-working-draft-of-2016-03-31"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</a></li>
         </ul>
       </li>
-      <li class="tocline"><a href="#acknowledgments" class="tocxref"><span class="secno">B. </span>Acknowledgments</a></li>
-      <li class="tocline"><a href="#references" class="tocxref"><span class="secno">C. </span>References</a>
+      <li class="tocline"><a class="tocxref" href="#acknowledgments"><span class="secno">B. </span>Acknowledgments</a></li>
+      <li class="tocline"><a class="tocxref" href="#references"><span class="secno">C. </span>References</a>
         <ul class="toc">
-          <li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">C.1 </span>Normative references</a></li>
+          <li class="tocline"><a class="tocxref" href="#normative-references"><span class="secno">C.1 </span>Normative references</a></li>
         </ul>
       </li>
     </ul>
@@ -547,18 +547,18 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 
 
-  <section class="informative" id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#introduction" typeof="bibo:Chapter" id="introduction" class="informative">
     <!--OddPage-->
-    <h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
+    <h2 resource="#h-introduction" id="h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
     <p><em>This section is non-normative.</em></p>
 
     <p>Interoperability between systems has two basic aspects: the syntax and semantics of the data that is moved between the systems, and the transport mechanism for that movement. The HTTP protocol and the Web architecture provides us with a great starting point for a standardized transport layer, and can be used to move content between systems easily and effectively. Building upon these foundations allows us to make use of existing technology and patterns to ensure consistency and ease of development.</p>
 
-    <p>The Web Annotation Protocol describes a transport mechanism for creating, managing, and retrieving Annotations. Annotations in this specification are assumed to follow the requirements of the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>] and Web Annotation Vocabulary [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>]. This specification builds upon REST principles and the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] recommendation, and familiarity with it is recommended.</p>
+    <p>The Web Annotation Protocol describes a transport mechanism for creating, managing, and retrieving Annotations. Annotations in this specification are assumed to follow the requirements of the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>] and Web Annotation Vocabulary [<cite><a href="#bib-annotation-vocab" class="bibref">annotation-vocab</a></cite>]. This specification builds upon REST principles and the Linked Data Platform [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] recommendation, and familiarity with it is recommended.</p>
 
 
-    <section id="aims-of-the-protocol" typeof="bibo:Chapter" resource="#aims-of-the-protocol" property="bibo:hasPart">
-      <h3 id="h-aims-of-the-protocol" resource="#h-aims-of-the-protocol"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Aims of the Protocol</span></h3>
+    <section property="bibo:hasPart" resource="#aims-of-the-protocol" typeof="bibo:Chapter" id="aims-of-the-protocol">
+      <h3 resource="#h-aims-of-the-protocol" id="h-aims-of-the-protocol"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Aims of the Protocol</span></h3>
 
       <p>
         The primary aim of the Web Annotation Protocol is to provide a standard set of interactions that allow annotation clients and servers to interoperate seamlessly. By being able to discover annotation protocol end-points and how to interact with them, clients can be configured either automatically or by the user to store annotations in any compatible remote system, rather than being locked in to a single client and server pair.
@@ -566,8 +566,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
     </section>
 
-    <section id="summary" typeof="bibo:Chapter" resource="#summary" property="bibo:hasPart">
-      <h3 id="h-summary" resource="#h-summary"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Summary</span></h3>
+    <section property="bibo:hasPart" resource="#summary" typeof="bibo:Chapter" id="summary">
+      <h3 resource="#h-summary" id="h-summary"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Summary</span></h3>
 
       <p>For those familiar with the Web Annotation model, LDP, and REST, much of the Annotation Protocol will be very obvious. The following aspects are the most important new requirements.
       </p>
@@ -576,43 +576,43 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <li>The media type to use for Annotations is: <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code></li>
         <li>Annotation Containers are constrained by the set of constraints described in this specification, and thus the <code>ldp:constrainedBy</code> URL is <code>http://www.w3.org/TR/annotation-protocol/</code></li>
         <li>The link header can refer from any resource to an Annotation Container using a <code>rel</code> type of: <code>http://www.w3.org/ns/oa#annotationService</code></li>
-        <li>The response from a Container after creating an Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> include a representation of the Annotation, after any changes have been made to it, in the JSON-LD serialization.</li>
-        <li>Annotation Containers <em class="rfc2119" title="SHOULD">SHOULD</em> only contain Annotations, and not other resources.</li>
-        <li>LDP-Paging [<cite><a class="bibref" href="#bib-ldp-paging">ldp-paging</a></cite>] is not used, as in-page ordering is an important requirement. Instead, the Activity Streams Collection model is used [<cite><a class="bibref" href="#bib-activitystreams-core">activitystreams-core</a></cite>].</li>
+        <li>The response from a Container after creating an Annotation <em title="SHOULD" class="rfc2119">SHOULD</em> include a representation of the Annotation, after any changes have been made to it, in the JSON-LD serialization.</li>
+        <li>Annotation Containers <em title="SHOULD" class="rfc2119">SHOULD</em> only contain Annotations, and not other resources.</li>
+        <li>LDP-Paging [<cite><a href="#bib-ldp-paging" class="bibref">ldp-paging</a></cite>] is not used, as in-page ordering is an important requirement. Instead, the Activity Streams Collection model is used [<cite><a href="#bib-activitystreams-core" class="bibref">activitystreams-core</a></cite>].</li>
       </ul>
 
     </section>
 
-    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart">
-      <h3 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
+    <section property="bibo:hasPart" resource="#conformance" typeof="bibo:Chapter" id="conformance">
+      <h3 resource="#h-conformance" id="h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
       <p>
         As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
       </p>
-      <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+      <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a href="#bib-RFC2119" class="bibref">RFC2119</a></cite>].
       </p>
 
     </section>
 
-    <section id="terminology" typeof="bibo:Chapter" resource="#terminology" property="bibo:hasPart">
-      <h3 id="h-terminology" resource="#h-terminology"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.4 </span>Terminology</span></h3>
+    <section property="bibo:hasPart" resource="#terminology" typeof="bibo:Chapter" id="terminology">
+      <h3 resource="#h-terminology" id="h-terminology"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.4 </span>Terminology</span></h3>
 
       <p>
       </p>
       <dl>
-        <dt><dfn data-dfn-type="dfn" id="dfn-iri">IRI</dfn></dt>
-        <dd>An <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>, or Internationalized Resource Identifier, is an extension to the URI specification to allow characters from Unicode, whereas URIs must be made up of a subset of ASCII characters. There is a mapping algorithm for translating between IRIs and the equivalent encoded URI form. IRIs are defined by [<cite><a class="bibref" href="#bib-rfc3987">rfc3987</a></cite>].</dd>
-        <dt><dfn data-dfn-type="dfn" id="dfn-resource">Resource</dfn></dt>
-        <dd>An item of interest that <em class="rfc2119" title="MAY">MAY</em> be identified by an <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>.</dd>
+        <dt><dfn id="dfn-iri" data-dfn-type="dfn">IRI</dfn></dt>
+        <dd>An <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>, or Internationalized Resource Identifier, is an extension to the URI specification to allow characters from Unicode, whereas URIs must be made up of a subset of ASCII characters. There is a mapping algorithm for translating between IRIs and the equivalent encoded URI form. IRIs are defined by [<cite><a href="#bib-rfc3987" class="bibref">rfc3987</a></cite>].</dd>
+        <dt><dfn id="dfn-resource" data-dfn-type="dfn">Resource</dfn></dt>
+        <dd>An item of interest that <em title="MAY" class="rfc2119">MAY</em> be identified by an <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>.</dd>
         <dt>Web Server</dt>
         <dd>A program that accepts connections in order to service HTTP requests by sending HTTP responses.</dd>
         <dt>Annotation</dt>
-        <dd>A web resource that follows the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>].</dd>
+        <dd>A web resource that follows the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].</dd>
         <dt>Annotation Server</dt>
         <dd>A Web Server that also makes available and allows the management of Annotations via the protocol described in this document.</dd>
         <dt>Annotation Client</dt>
         <dd>A program that establishes connections to Annotation Servers for the purpose of retrieving and managing Annotations via the protocol described in this document.</dd>
         <dt>Annotation Container</dt>
-        <dd>An LDP Container [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] used to manage Annotations.</dd>
+        <dd>An LDP Container [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] used to manage Annotations.</dd>
       </dl>
       <p></p>
     </section>
@@ -621,9 +621,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
   <!-- End Introduction -->
 
-  <section id="web-annotation-protocol-principles" typeof="bibo:Chapter" resource="#web-annotation-protocol-principles" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#web-annotation-protocol-principles" typeof="bibo:Chapter" id="web-annotation-protocol-principles">
     <!--OddPage-->
-    <h2 id="h-web-annotation-protocol-principles" resource="#h-web-annotation-protocol-principles"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Protocol Principles</span></h2>
+    <h2 resource="#h-web-annotation-protocol-principles" id="h-web-annotation-protocol-principles"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Protocol Principles</span></h2>
 
     <p>
       The Web Annotation Protocol is defined using the following basic principles:
@@ -642,41 +642,41 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </section>
 
 
-  <section id="annotation-retrieval" typeof="bibo:Chapter" resource="#annotation-retrieval" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#annotation-retrieval" typeof="bibo:Chapter" id="annotation-retrieval">
     <!--OddPage-->
-    <h2 id="h-annotation-retrieval" resource="#h-annotation-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Annotation Retrieval</span></h2>
+    <h2 resource="#h-annotation-retrieval" id="h-annotation-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Annotation Retrieval</span></h2>
 
     <p>
-      The Annotation Server <em class="rfc2119" title="MUST">MUST</em> support the following HTTP methods on the Annotation's IRI:
+      The Annotation Server <em title="MUST" class="rfc2119">MUST</em> support the following HTTP methods on the Annotation's IRI:
 
     </p>
     <ul>
       <li><code>GET</code> (retrieve the description of the Annotation), </li>
       <li><code>HEAD</code> (retrieve the headers of the Annotation without an entity-body),</li>
-      <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a class="bibref" href="#bib-cors">cors</a></cite>]).</li>
+      <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a href="#bib-cors" class="bibref">cors</a></cite>]).</li>
     </ul>
 
-    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use HTTPS rather than HTTP for all interactions, including retrieval of Annotations.</p>
+    <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use HTTPS rather than HTTP for all interactions, including retrieval of Annotations.</p>
 
-    <p>Servers <em class="rfc2119" title="MUST">MUST</em> support the JSON-LD representation using the Web Annotation profile. These responses <em class="rfc2119" title="MUST">MUST</em> have a <code>Content-Type</code> header with the <code>application/ld+json</code> media type, and it <em class="rfc2119" title="SHOULD">SHOULD</em> have the Web Annotation profile IRI of <code>http://www.w3.org/ns/anno.jsonld</code> in the <code>profile</code> parameter.</p>
+    <p>Servers <em title="MUST" class="rfc2119">MUST</em> support the JSON-LD representation using the Web Annotation profile. These responses <em title="MUST" class="rfc2119">MUST</em> have a <code>Content-Type</code> header with the <code>application/ld+json</code> media type, and it <em title="SHOULD" class="rfc2119">SHOULD</em> have the Web Annotation profile IRI of <code>http://www.w3.org/ns/anno.jsonld</code> in the <code>profile</code> parameter.</p>
 
-    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support a Turtle representation, and <em class="rfc2119" title="MAY">MAY</em> support other formats. If more than one representation of the Annotation is available, then the server <em class="rfc2119" title="SHOULD">SHOULD</em> support content negotiation. Content negotiation for different serializations is performed by including the desired media type in the HTTP <code>Accept</code> header of the request, however clients cannot assume that the server will honor their preferences [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>].</p>
+    <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> support a Turtle representation, and <em title="MAY" class="rfc2119">MAY</em> support other formats. If more than one representation of the Annotation is available, then the server <em title="SHOULD" class="rfc2119">SHOULD</em> support content negotiation. Content negotiation for different serializations is performed by including the desired media type in the HTTP <code>Accept</code> header of the request, however clients cannot assume that the server will honor their preferences [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>].</p>
 
     <p>
-      Servers <em class="rfc2119" title="MAY">MAY</em> support different JSON-LD profiles. Content negotiation for different JSON-LD profiles is performed by adding a <code>profile</code> parameter to the JSON-LD media type in a space separated, quoted list as part of the <code>Accept</code> header.</p>
+      Servers <em title="MAY" class="rfc2119">MAY</em> support different JSON-LD profiles. Content negotiation for different JSON-LD profiles is performed by adding a <code>profile</code> parameter to the JSON-LD media type in a space separated, quoted list as part of the <code>Accept</code> header.</p>
 
-    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use the 200 HTTP status code when no errors occurred while processing the request to retrieve an Annotation, and <em class="rfc2119" title="MAY">MAY</em> use 3XX HTTP status codes to redirect to a new location.</p>
+    <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use the 200 HTTP status code when no errors occurred while processing the request to retrieve an Annotation, and <em title="MAY" class="rfc2119">MAY</em> use 3XX HTTP status codes to redirect to a new location.</p>
 
-    <p>The response from the Annotation Server <em class="rfc2119" title="MUST">MUST</em> have a <code>Link</code> header entry
-      <!-- LDP 4.2.1.4 -->where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>. The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> <em class="rfc2119" title="MAY">MAY</em> also be added with the same <code>rel</code> type.</p>
+    <p>The response from the Annotation Server <em title="MUST" class="rfc2119">MUST</em> have a <code>Link</code> header entry
+      <!-- LDP 4.2.1.4 -->where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>. The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> <em title="MAY" class="rfc2119">MAY</em> also be added with the same <code>rel</code> type.</p>
 
-    <p>The response <em class="rfc2119" title="MUST">MUST</em> have an <code>ETag</code> header
-      <!-- LDP 4.2.1.3 -->with an entity reference value that implements the notion of entity tags from HTTP [<cite><a class="bibref" href="#bib-rfc7232">rfc7232</a></cite>].</p>
+    <p>The response <em title="MUST" class="rfc2119">MUST</em> have an <code>ETag</code> header
+      <!-- LDP 4.2.1.3 -->with an entity reference value that implements the notion of entity tags from HTTP [<cite><a href="#bib-rfc7232" class="bibref">rfc7232</a></cite>].</p>
 
-    <p>The response <em class="rfc2119" title="MUST">MUST</em> have an <code>Allow</code> header
-      <!-- LDP 4.2.8.2 from 4.2.2.2 -->that lists the HTTP methods available for the Annotation [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>].</p>
+    <p>The response <em title="MUST" class="rfc2119">MUST</em> have an <code>Allow</code> header
+      <!-- LDP 4.2.8.2 from 4.2.2.2 -->that lists the HTTP methods available for the Annotation [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>].</p>
 
-    <p>If the server supports content negotiation by format or JSON-LD profile, the response <em class="rfc2119" title="MUST">MUST</em> have a <code>Vary</code> header with <code>Accept</code> in the value. [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>]
+    <p>If the server supports content negotiation by format or JSON-LD profile, the response <em title="MUST" class="rfc2119">MUST</em> have a <code>Vary</code> header with <code>Accept</code> in the value. [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>]
       <!-- HTTP + LDP 4.3.2.1 -->
     </p>
 
@@ -711,71 +711,71 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
   </section>
 
-  <section id="annotation-containers" typeof="bibo:Chapter" resource="#annotation-containers" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#annotation-containers" typeof="bibo:Chapter" id="annotation-containers">
     <!--OddPage-->
-    <h2 id="h-annotation-containers" resource="#h-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Annotation Containers</span></h2>
+    <h2 resource="#h-annotation-containers" id="h-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Annotation Containers</span></h2>
 
     <p>
-      If the Annotation Server supports the management of Annotations, including one or more of creating, updating, and deleting them, then the following section's requirements apply. The Annotation Protocol is a use of the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] specification, with some additional constraints derived from the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>].
+      If the Annotation Server supports the management of Annotations, including one or more of creating, updating, and deleting them, then the following section's requirements apply. The Annotation Protocol is a use of the Linked Data Platform [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] specification, with some additional constraints derived from the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].
     </p>
 
-    <p>An Annotation Server <em class="rfc2119" title="MUST">MUST</em> provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] (a service for managing Annotations) and a Collection [<cite><a class="bibref" href="#bib-activitystreams-core">activitystreams-core</a></cite>] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.</p>
+    <p>An Annotation Server <em title="MUST" class="rfc2119">MUST</em> provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] (a service for managing Annotations) and a Collection [<cite><a href="#bib-activitystreams-core" class="bibref">activitystreams-core</a></cite>] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.</p>
     <p>
 
     </p>
     <p>
-      Annotation Containers <em class="rfc2119" title="SHOULD">SHOULD</em> implement the LDP Basic Container specification, but <em class="rfc2119" title="MAY">MAY</em> instead implement another type of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers <em class="rfc2119" title="MAY">MAY</em> have any IRI, but <em class="rfc2119" title="MUST">MUST</em> end in a <code>"/"</code> character. The Annotations <em class="rfc2119" title="MUST">MUST</em> be assigned IRIs with an additional path component below the Container's IRI.
+      Annotation Containers <em title="SHOULD" class="rfc2119">SHOULD</em> implement the LDP Basic Container specification, but <em title="MAY" class="rfc2119">MAY</em> instead implement another type of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers <em title="MAY" class="rfc2119">MAY</em> have any IRI, but <em title="MUST" class="rfc2119">MUST</em> end in a <code>"/"</code> character. The Annotations <em title="MUST" class="rfc2119">MUST</em> be assigned IRIs with an additional path component below the Container's IRI.
     </p>
 
-    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use HTTPS rather than HTTP for all interactions with Annotation Containers.</p>
+    <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use HTTPS rather than HTTP for all interactions with Annotation Containers.</p>
 
     <p>
-      The creation, management, and structure of Annotation Containers are beyond the scope of this specification. Please see the Linked Data Platform specification [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] for additional information.
+      The creation, management, and structure of Annotation Containers are beyond the scope of this specification. Please see the Linked Data Platform specification [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] for additional information.
     </p>
 
-    <section id="container-retrieval" typeof="bibo:Chapter" resource="#container-retrieval" property="bibo:hasPart">
-      <h3 id="h-container-retrieval" resource="#h-container-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Container Retrieval</span></h3>
+    <section property="bibo:hasPart" resource="#container-retrieval" typeof="bibo:Chapter" id="container-retrieval">
+      <h3 resource="#h-container-retrieval" id="h-container-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Container Retrieval</span></h3>
 
       <p>
-        The Annotation Server <em class="rfc2119" title="MUST">MUST</em> support the following HTTP methods on the Annotation Container's IRI:
+        The Annotation Server <em title="MUST" class="rfc2119">MUST</em> support the following HTTP methods on the Annotation Container's IRI:
 
       </p>
       <ul>
         <li><code>GET</code> (retrieve the description of the Container and the list of its contents, described below), </li>
         <li><code>HEAD</code> (retrieve the headers of the Container without an entity-body),</li>
-        <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a class="bibref" href="#bib-cors">cors</a></cite>]).</li>
+        <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a href="#bib-cors" class="bibref">cors</a></cite>]).</li>
       </ul>
       <!-- LDP -->
 
       <p>
-        When an HTTP GET request is issued against the Annotation Container, the server <em class="rfc2119" title="MUST">MUST</em> return a description of the container. That description <em class="rfc2119" title="MUST">MUST</em> be available in JSON-LD, <em class="rfc2119" title="SHOULD">SHOULD</em> be available in Turtle, and <em class="rfc2119" title="MAY">MAY</em> be available in other formats. The JSON-LD serialization of the Container's description <em class="rfc2119" title="SHOULD">SHOULD</em> use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>], unless the request would determine otherwise.
+        When an HTTP GET request is issued against the Annotation Container, the server <em title="MUST" class="rfc2119">MUST</em> return a description of the container. That description <em title="MUST" class="rfc2119">MUST</em> be available in JSON-LD, <em title="SHOULD" class="rfc2119">SHOULD</em> be available in Turtle, and <em title="MAY" class="rfc2119">MAY</em> be available in other formats. The JSON-LD serialization of the Container's description <em title="SHOULD" class="rfc2119">SHOULD</em> use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>], unless the request would determine otherwise.
       </p>
 
-      <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences. If redirection is required, then the server <em class="rfc2119" title="SHOULD">SHOULD</em> use a 3XX HTTP status code instead.</p>
+      <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences. If redirection is required, then the server <em title="SHOULD" class="rfc2119">SHOULD</em> use a 3XX HTTP status code instead.</p>
 
       <p>
-        Clients that have a preference for JSON-LD <em class="rfc2119" title="SHOULD">SHOULD</em> explicitly request it using an <code>Accept</code> header on the request. If the <code>Accept</code> header is absent from the request, then Annotation Servers <em class="rfc2119" title="MUST">MUST</em> respond with the JSON-LD representation of the Annotation Container.
+        Clients that have a preference for JSON-LD <em title="SHOULD" class="rfc2119">SHOULD</em> explicitly request it using an <code>Accept</code> header on the request. If the <code>Accept</code> header is absent from the request, then Annotation Servers <em title="MUST" class="rfc2119">MUST</em> respond with the JSON-LD representation of the Annotation Container.
       </p>
 
       <p>
-        All supported methods for interacting with the Annotation Container <em class="rfc2119" title="MUST">MUST</em> be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's IRI
-        <!-- LDP -->. The <code>Allow</code> header <em class="rfc2119" title="MAY">MAY</em> also be included on any other responses.</p>
+        All supported methods for interacting with the Annotation Container <em title="MUST" class="rfc2119">MUST</em> be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's IRI
+        <!-- LDP -->. The <code>Allow</code> header <em title="MAY" class="rfc2119">MAY</em> also be included on any other responses.</p>
 
-      <p>Annotation Containers <em class="rfc2119" title="MUST">MUST</em> return a <code>Link</code> header [<cite><a class="bibref" href="#bib-rfc5988">rfc5988</a></cite>] on all responses with the following components:
+      <p>Annotation Containers <em title="MUST" class="rfc2119">MUST</em> return a <code>Link</code> header [<cite><a href="#bib-rfc5988" class="bibref">rfc5988</a></cite>] on all responses with the following components:
       </p>
       <ul>
-        <li>It <em class="rfc2119" title="MUST">MUST</em> advertise its type by including a link where the <code>rel</code> parameter value is <code>type</code> and the target IRI is the appropriate Container Type, such as <code>http://www.w3.org/ns/ldp#BasicContainer</code> for Basic Containers.</li>
-        <li>It <em class="rfc2119" title="MUST">MUST</em> advertise that it imposes Annotation protocol specific constraints by including a link where the target IRI is <code>http://www.w3.org/TR/annotation-protocol/</code>, and the <code>rel</code> parameter value is the IRI <code>http://www.w3.org/ns/ldp#constrainedBy</code>.</li>
+        <li>It <em title="MUST" class="rfc2119">MUST</em> advertise its type by including a link where the <code>rel</code> parameter value is <code>type</code> and the target IRI is the appropriate Container Type, such as <code>http://www.w3.org/ns/ldp#BasicContainer</code> for Basic Containers.</li>
+        <li>It <em title="MUST" class="rfc2119">MUST</em> advertise that it imposes Annotation protocol specific constraints by including a link where the target IRI is <code>http://www.w3.org/TR/annotation-protocol/</code>, and the <code>rel</code> parameter value is the IRI <code>http://www.w3.org/ns/ldp#constrainedBy</code>.</li>
       </ul>
       <p></p>
 
       <p>
-        All HTTP responses from Annotation Containers <em class="rfc2119" title="MUST">MUST</em> include an <code>ETag</code> header that implements the notion of entity tags from HTTP [<cite><a class="bibref" href="#bib-rfc7230">rfc7230</a></cite>].</p>
+        All HTTP responses from Annotation Containers <em title="MUST" class="rfc2119">MUST</em> include an <code>ETag</code> header that implements the notion of entity tags from HTTP [<cite><a href="#bib-rfc7230" class="bibref">rfc7230</a></cite>].</p>
 
       <p>
-        If the server supports content negotiation by format or JSON-LD profile, the response from the Annotation Container <em class="rfc2119" title="MUST">MUST</em> have a <code>Vary</code> header that includes <code>Accept</code> in the value.</p>
+        If the server supports content negotiation by format or JSON-LD profile, the response from the Annotation Container <em title="MUST" class="rfc2119">MUST</em> have a <code>Vary</code> header that includes <code>Accept</code> in the value.</p>
 
-      <p>Responses from Annotation Containers that support the use of the POST method to create Annotations <em class="rfc2119" title="SHOULD">SHOULD</em> include an <code>Accept-Post</code> header on responses to GET, HEAD and OPTIONS requests. The value is a comma separated list of media-types that are acceptable for the client to send via POST [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>].</p>
+      <p>Responses from Annotation Containers that support the use of the POST method to create Annotations <em title="SHOULD" class="rfc2119">SHOULD</em> include an <code>Accept-Post</code> header on responses to GET, HEAD and OPTIONS requests. The value is a comma separated list of media-types that are acceptable for the client to send via POST [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>].</p>
 
       <div>
         <div class="example">
@@ -787,24 +787,24 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 Accept-<span class="hljs-string">Post:</span> application<span class="hljs-regexp">/ld+json; profile="http:/</span><span class="hljs-regexp">/www.w3.org/</span>ns<span class="hljs-regexp">/anno.jsonld", text/</span>turtle</pre></div>
       </div>
 
-      <section id="client-preferences" typeof="bibo:Chapter" resource="#client-preferences" property="bibo:hasPart">
-        <h4 id="h-client-preferences" resource="#h-client-preferences"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.1 </span>Client Preferences</span></h4> There are three possibilities for the request that will govern the server's response:
+      <section property="bibo:hasPart" resource="#client-preferences" typeof="bibo:Chapter" id="client-preferences">
+        <h4 resource="#h-client-preferences" id="h-client-preferences"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.1 </span>Client Preferences</span></h4> There are three possibilities for the request that will govern the server's response:
 
         <ol>
-          <li>If the client prefers to only receive the Container description and no annotations, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
-          <li>If the client prefers to receive the list of annotations only as IRIs, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
-          <li>If the client prefers to receive the complete annotation description, then it <em class="rfc2119" title="MUST">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
+          <li>If the client prefers to only receive the Container description and no annotations, then it <em title="MUST" class="rfc2119">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
+          <li>If the client prefers to receive the list of annotations only as IRIs, then it <em title="MUST" class="rfc2119">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
+          <li>If the client prefers to receive the complete annotation description, then it <em title="MUST" class="rfc2119">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
         </ol>
 
-        If no preference is given by the client, the server <em class="rfc2119" title="SHOULD">SHOULD</em> return the full annotation descriptions. The server <em class="rfc2119" title="MAY">MAY</em> ignore the client's preference.
+        If no preference is given by the client, the server <em title="SHOULD" class="rfc2119">SHOULD</em> return the full annotation descriptions. The server <em title="MAY" class="rfc2119">MAY</em> ignore the client's preference.
 
       </section>
 
-      <section id="responses-without-annotations" typeof="bibo:Chapter" resource="#responses-without-annotations" property="bibo:hasPart">
-        <h4 id="h-responses-without-annotations" resource="#h-responses-without-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.2 </span>Responses without Annotations</span></h4>
+      <section property="bibo:hasPart" resource="#responses-without-annotations" typeof="bibo:Chapter" id="responses-without-annotations">
+        <h4 resource="#h-responses-without-annotations" id="h-responses-without-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.2 </span>Responses without Annotations</span></h4>
 
         <p>The Client may request the description of the Annotation Container without any included Annotations.</p>
-        <p>The response <em class="rfc2119" title="SHOULD">SHOULD</em> include links to the first and last AnnotationPages in the Collection, and without either the <code>ldp:contains</code> predicate or the first page of annotations embedded.</p>
+        <p>The response <em title="SHOULD" class="rfc2119">SHOULD</em> include links to the first and last AnnotationPages in the Collection, and without either the <code>ldp:contains</code> predicate or the first page of annotations embedded.</p>
 
         <div>
 
@@ -841,18 +841,18 @@ Content-Length: <span class="hljs-number">221</span>
         </div>
       </section>
 
-      <section id="responses-with-annotations" typeof="bibo:Chapter" resource="#responses-with-annotations" property="bibo:hasPart">
+      <section property="bibo:hasPart" resource="#responses-with-annotations" typeof="bibo:Chapter" id="responses-with-annotations">
 
-        <h4 id="h-responses-with-annotations" resource="#h-responses-with-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.3 </span>Responses with Annotations</span></h4>
+        <h4 resource="#h-responses-with-annotations" id="h-responses-with-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.3 </span>Responses with Annotations</span></h4>
 
-        <p>If the client requests a response that would include the Annotations, either by IRI or embedded in the response, then the server <em class="rfc2119" title="MUST">MUST</em> use the paged collection model. Each page, described below, will contain an ordered list with a subset of the managed annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container. The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages. The feature or features by which the annotations are sorted are not explicit in the response.
+        <p>If the client requests a response that would include the Annotations, either by IRI or embedded in the response, then the server <em title="MUST" class="rfc2119">MUST</em> use the paged collection model. Each page, described below, will contain an ordered list with a subset of the managed annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container. The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages. The feature or features by which the annotations are sorted are not explicit in the response.
         </p>
 
         <p>
-          The Collection <em class="rfc2119" title="SHOULD">SHOULD</em> include the <code>total</code> property with the total number of annotations in the container. It <em class="rfc2119" title="MUST">MUST</em> also have a link to the first page of its contents using <code>first</code>, and <em class="rfc2119" title="SHOULD">SHOULD</em> have a link to the last page of its contents using <code>last</code>.
+          The Collection <em title="SHOULD" class="rfc2119">SHOULD</em> include the <code>total</code> property with the total number of annotations in the container. It <em title="MUST" class="rfc2119">MUST</em> also have a link to the first page of its contents using <code>first</code>, and <em title="SHOULD" class="rfc2119">SHOULD</em> have a link to the last page of its contents using <code>last</code>.
         </p>
 
-        <p>The IRI of the Collection in the response should differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations. It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that this be done with a query parameter. The server <em class="rfc2119" title="MAY">MAY</em> redirect the client to this IRI and deliver the response there, otherwise it <em class="rfc2119" title="MUST">MUST</em> include a <code>Content-Location</code> header with the IRI as its value. The server <em class="rfc2119" title="SHOULD">SHOULD</em> include <code>Prefer</code> in the <code>Vary</code> response header to assist with caching.</p>
+        <p>The IRI of the Collection in the response should differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations. It is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> that this be done with a query parameter. The server <em title="MAY" class="rfc2119">MAY</em> redirect the client to this IRI and deliver the response there, otherwise it <em title="MUST" class="rfc2119">MUST</em> include a <code>Content-Location</code> header with the IRI as its value. The server <em title="SHOULD" class="rfc2119">SHOULD</em> include <code>Prefer</code> in the <code>Vary</code> response header to assist with caching.</p>
 
         <div>
 
@@ -893,11 +893,11 @@ Content-Length: <span class="hljs-number">221</span>
         <p>
           Individual pages are instances of <code>CollectionPage</code>. The page contains the Annotations, either via their IRIs or full descriptions, in the <code>items</code> property.</p>
 
-        <p>Each page <em class="rfc2119" title="MUST">MUST</em> have a link to the container that it is part of, using the <code>partOf</code> property. If it is not the first page, it <em class="rfc2119" title="MUST">MUST</em> have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it <em class="rfc2119" title="MUST">MUST</em> have a link to the next page in the sequence, using the <code>next</code> property. The response <em class="rfc2119" title="MAY">MAY</em> include properties of the Collection in the response, including the total number of items or first and last page links.
+        <p>Each page <em title="MUST" class="rfc2119">MUST</em> have a link to the container that it is part of, using the <code>partOf</code> property. If it is not the first page, it <em title="MUST" class="rfc2119">MUST</em> have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it <em title="MUST" class="rfc2119">MUST</em> have a link to the next page in the sequence, using the <code>next</code> property. The response <em title="MAY" class="rfc2119">MAY</em> include properties of the Collection in the response, including the total number of items or first and last page links.
         </p>
 
         <p>
-          The client <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> send the <code>Prefer</code> header when requesting the page, as it has already been taken into account when requesting the Container.
+          The client <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> send the <code>Prefer</code> header when requesting the page, as it has already been taken into account when requesting the Container.
         </p>
 
         <p>This specification does not require any particular functionality when a client makes requests other than GET, HEAD or OPTIONS to a page.</p>
@@ -944,14 +944,14 @@ Content-Length: <span class="hljs-number">221</span>
       </section>
     </section>
 
-    <section id="discovery-of-annotation-containers" typeof="bibo:Chapter" resource="#discovery-of-annotation-containers" property="bibo:hasPart">
-      <h3 id="h-discovery-of-annotation-containers" resource="#h-discovery-of-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Discovery of Annotation Containers</span></h3>
+    <section property="bibo:hasPart" resource="#discovery-of-annotation-containers" typeof="bibo:Chapter" id="discovery-of-annotation-containers">
+      <h3 resource="#h-discovery-of-annotation-containers" id="h-discovery-of-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Discovery of Annotation Containers</span></h3>
 
-      <p>As the IRI for Annotation Containers <em class="rfc2119" title="MAY">MAY</em> be any IRI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
+      <p>As the IRI for Annotation Containers <em title="MAY" class="rfc2119">MAY</em> be any IRI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
 
-      <p>Any resource <em class="rfc2119" title="MAY">MAY</em> link to an Annotation Container when Annotations on the resource <em class="rfc2119" title="SHOULD">SHOULD</em> be created within the referenced Container. This link is carried in an HTTP <code>Link</code> header and the value of the <code>rel</code> parameter <em class="rfc2119" title="MUST">MUST</em> be <code>http://www.w3.org/ns/oa#annotationService</code>.</p>
+      <p>Any resource <em title="MAY" class="rfc2119">MAY</em> link to an Annotation Container when Annotations on the resource <em title="SHOULD" class="rfc2119">SHOULD</em> be created within the referenced Container. This link is carried in an HTTP <code>Link</code> header and the value of the <code>rel</code> parameter <em title="MUST" class="rfc2119">MUST</em> be <code>http://www.w3.org/ns/oa#annotationService</code>.</p>
 
-      <p>For HTML representations of resources, the equivalent <code>link</code> tag in the header of the document <em class="rfc2119" title="MAY">MAY</em> also be used.</p>
+      <p>For HTML representations of resources, the equivalent <code>link</code> tag in the header of the document <em title="MAY" class="rfc2119">MAY</em> also be used.</p>
 
       <div>
         <p>For an example image resource, a GET request and response with a link to the above Annotation Container might look like:</p>
@@ -975,25 +975,25 @@ Content-Length: <span class="hljs-number">221</span>
   </section>
   <!-- End of Containers -->
 
-  <section id="creation-updating-and-deletion-of-annotations" typeof="bibo:Chapter" resource="#creation-updating-and-deletion-of-annotations" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#creation-updating-and-deletion-of-annotations" typeof="bibo:Chapter" id="creation-updating-and-deletion-of-annotations">
     <!--OddPage-->
-    <h2 id="h-creation-updating-and-deletion-of-annotations" resource="#h-creation-updating-and-deletion-of-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</span></h2>
+    <h2 resource="#h-creation-updating-and-deletion-of-annotations" id="h-creation-updating-and-deletion-of-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</span></h2>
 
-    <section id="create-a-new-annotation" typeof="bibo:Chapter" resource="#create-a-new-annotation" property="bibo:hasPart">
-      <h3 id="h-create-a-new-annotation" resource="#h-create-a-new-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Create a New Annotation</span></h3>
+    <section property="bibo:hasPart" resource="#create-a-new-annotation" typeof="bibo:Chapter" id="create-a-new-annotation">
+      <h3 resource="#h-create-a-new-annotation" id="h-create-a-new-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Create a New Annotation</span></h3>
 
-      <p>New Annotations are created via a POST request to an Annotation Container. The Annotation, serialized as JSON-LD, is sent in the body of the request. All of the known information about the Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> be sent, and if there are already IRIs associated with the resources, they <em class="rfc2119" title="SHOULD">SHOULD</em> be included. The serialization <em class="rfc2119" title="SHOULD">SHOULD</em> use the Web Annotation JSON-LD profile, and servers <em class="rfc2119" title="MAY">MAY</em> reject other contexts even if they would otherwise produce the same model. The server <em class="rfc2119" title="MAY">MAY</em> reject content that is not considered an Annotation according to the Web Annotation specification [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>].</p>
+      <p>New Annotations are created via a POST request to an Annotation Container. The Annotation, serialized as JSON-LD, is sent in the body of the request. All of the known information about the Annotation <em title="SHOULD" class="rfc2119">SHOULD</em> be sent, and if there are already IRIs associated with the resources, they <em title="SHOULD" class="rfc2119">SHOULD</em> be included. The serialization <em title="SHOULD" class="rfc2119">SHOULD</em> use the Web Annotation JSON-LD profile, and servers <em title="MAY" class="rfc2119">MAY</em> reject other contexts even if they would otherwise produce the same model. The server <em title="MAY" class="rfc2119">MAY</em> reject content that is not considered an Annotation according to the Web Annotation specification [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].</p>
 
-      <p>Upon receipt of an Annotation, the server <em class="rfc2119" title="MAY">MAY</em> assign HTTPS IRIs to all resources and blank nodes in the Annotation, and <em class="rfc2119" title="MUST">MUST</em> assign a IRI to the Annotation resource, even if it already has one provided in the entity body description. The server <em class="rfc2119" title="MAY">MAY</em> also add additional information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, additional types and formats.</p>
+      <p>Upon receipt of an Annotation, the server <em title="MAY" class="rfc2119">MAY</em> assign HTTPS IRIs to all resources and blank nodes in the Annotation, and <em title="MUST" class="rfc2119">MUST</em> assign a IRI to the Annotation resource, even if it already has one provided in the entity body description. The server <em title="MAY" class="rfc2119">MAY</em> also add additional information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, additional types and formats.</p>
 
-      <p>If the Annotation contains a <code>canonical</code> link, then it <em class="rfc2119" title="MUST">MUST</em> be maintained without change. If the Annotation has a IRI in the <code>id</code> property, then it <em class="rfc2119" title="SHOULD">SHOULD</em> be copied to the <code>via</code> property, and the IRI assigned by the server, at which the Annotation will be available, <em class="rfc2119" title="MUST">MUST</em> be put in the <code>id</code> field to replace it.</p>
+      <p>If the Annotation contains a <code>canonical</code> link, then it <em title="MUST" class="rfc2119">MUST</em> be maintained without change. If the Annotation has a IRI in the <code>id</code> property, then it <em title="SHOULD" class="rfc2119">SHOULD</em> be copied to the <code>via</code> property, and the IRI assigned by the server, at which the Annotation will be available, <em title="MUST" class="rfc2119">MUST</em> be put in the <code>id</code> field to replace it.</p>
 
-      <p>The server <em class="rfc2119" title="MUST">MUST</em> respond with a <code>201</code> Created response if the creation is successful, and an appropriate error code otherwise. The response <em class="rfc2119" title="MUST">MUST</em> have a <code>Location</code> header with the Annotation's new IRI.</p>
+      <p>The server <em title="MUST" class="rfc2119">MUST</em> respond with a <code>201</code> Created response if the creation is successful, and an appropriate error code otherwise. The response <em title="MUST" class="rfc2119">MUST</em> have a <code>Location</code> header with the Annotation's new IRI.</p>
 
-      <p>The body of the response <em class="rfc2119" title="MUST">MUST</em> be the Annotation as now managed by the server, including any additional IRIs or data created in the process or without any information that was sent but not stored. Unless content negotiation would dictate otherwise, the response <em class="rfc2119" title="SHOULD">SHOULD</em> be serialized in JSON-LD following the Annotation Data Model specification.</p>
-      <p>The response <em class="rfc2119" title="MUST">MUST</em> include a <code>Link</code> header with the target IRI of <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value of <code>type</code> to advertise that this is an RDF Source, according to the LDP specification [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>]. It <em class="rfc2119" title="MAY">MAY</em> also include the IRI <code>http://www.w3.org/ns/oa#Annotation</code> with the same <code>rel</code> parameter of <code>type</code> to also assert that it is an Annotation following the Web Annotation specifications.</p>
+      <p>The body of the response <em title="MUST" class="rfc2119">MUST</em> be the Annotation as now managed by the server, including any additional IRIs or data created in the process or without any information that was sent but not stored. Unless content negotiation would dictate otherwise, the response <em title="SHOULD" class="rfc2119">SHOULD</em> be serialized in JSON-LD following the Annotation Data Model specification.</p>
+      <p>The response <em title="MUST" class="rfc2119">MUST</em> include a <code>Link</code> header with the target IRI of <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value of <code>type</code> to advertise that this is an RDF Source, according to the LDP specification [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>]. It <em title="MAY" class="rfc2119">MAY</em> also include the IRI <code>http://www.w3.org/ns/oa#Annotation</code> with the same <code>rel</code> parameter of <code>type</code> to also assert that it is an Annotation following the Web Annotation specifications.</p>
 
-      <p>The response <em class="rfc2119" title="MUST">MUST</em> include a <code>Vary</code> header with the value that includes <code>Accept</code>, if the server supports content negotiation by format. If the container preferences described above are supported, this <em class="rfc2119" title="MUST">MUST</em> also include <code>Prefer</code>
+      <p>The response <em title="MUST" class="rfc2119">MUST</em> include a <code>Vary</code> header with the value that includes <code>Accept</code>, if the server supports content negotiation by format. If the container preferences described above are supported, this <em title="MUST" class="rfc2119">MUST</em> also include <code>Prefer</code>
         <!-- HTTP -->.
 
       </p>
@@ -1041,9 +1041,9 @@ Content-Length: <span class="hljs-number">243</span>
       </div>
     </section>
 
-    <section id="suggesting-an-iri-for-an-annotation" typeof="bibo:Chapter" resource="#suggesting-an-iri-for-an-annotation" property="bibo:hasPart">
-      <h3 id="h-suggesting-an-iri-for-an-annotation" resource="#h-suggesting-an-iri-for-an-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</span></h3>
-      <p>The IRI path segment that is appended to the Container IRI for a resource <em class="rfc2119" title="MAY">MAY</em> be suggested by the Annotation Client by using the <code>Slug</code> HTTP header on the request when the resource is created. The server <em class="rfc2119" title="SHOULD">SHOULD</em> use this name, so long as it does not already identify an existing resource, but <em class="rfc2119" title="MAY">MAY</em> ignore it and use an automatically assigned name. </p>
+    <section property="bibo:hasPart" resource="#suggesting-an-iri-for-an-annotation" typeof="bibo:Chapter" id="suggesting-an-iri-for-an-annotation">
+      <h3 resource="#h-suggesting-an-iri-for-an-annotation" id="h-suggesting-an-iri-for-an-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</span></h3>
+      <p>The IRI path segment that is appended to the Container IRI for a resource <em title="MAY" class="rfc2119">MAY</em> be suggested by the Annotation Client by using the <code>Slug</code> HTTP header on the request when the resource is created. The server <em title="SHOULD" class="rfc2119">SHOULD</em> use this name, so long as it does not already identify an existing resource, but <em title="MAY" class="rfc2119">MAY</em> ignore it and use an automatically assigned name. </p>
 
       <div>
         Request:
@@ -1090,17 +1090,17 @@ Content-Length: <span class="hljs-number">243</span>
     </section>
 
 
-    <section id="update-an-existing-annotation" typeof="bibo:Chapter" resource="#update-an-existing-annotation" property="bibo:hasPart">
-      <h3 id="h-update-an-existing-annotation" resource="#h-update-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.3 </span>Update an Existing Annotation</span></h3>
+    <section property="bibo:hasPart" resource="#update-an-existing-annotation" typeof="bibo:Chapter" id="update-an-existing-annotation">
+      <h3 resource="#h-update-an-existing-annotation" id="h-update-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.3 </span>Update an Existing Annotation</span></h3>
 
-      <p>Annotations can be updated by using a PUT request to replace the entire state of the Annotation. Annotation Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support this method. Servers <em class="rfc2119" title="MAY">MAY</em> also support using a PATCH request to update only the aspects of the Annotation that have changed, but that functionality is not specified in this document.
+      <p>Annotations can be updated by using a PUT request to replace the entire state of the Annotation. Annotation Servers <em title="SHOULD" class="rfc2119">SHOULD</em> support this method. Servers <em title="MAY" class="rfc2119">MAY</em> also support using a PATCH request to update only the aspects of the Annotation that have changed, but that functionality is not specified in this document.
       </p>
 
-      <p>Replacing the Annotation with a new state <em class="rfc2119" title="MUST">MUST</em> be done with the PUT method, where the body of the request is the intended new state of the Annotation. The client <em class="rfc2119" title="SHOULD">SHOULD</em> use the <code>If-Match</code> header with a value of the ETag it received from the server before the editing process began, to avoid collisions of multiple users modifying the same Annotation at the same time.</p>
+      <p>Replacing the Annotation with a new state <em title="MUST" class="rfc2119">MUST</em> be done with the PUT method, where the body of the request is the intended new state of the Annotation. The client <em title="SHOULD" class="rfc2119">SHOULD</em> use the <code>If-Match</code> header with a value of the ETag it received from the server before the editing process began, to avoid collisions of multiple users modifying the same Annotation at the same time.</p>
 
-      <p>If successful, the server <em class="rfc2119" title="MUST">MUST</em> return a 200 OK status with the Annotation as the body according to the content-type requested. As with creation, the server <em class="rfc2119" title="MUST">MUST</em> return the new state of the Annotation in the response.</p>
+      <p>If successful, the server <em title="MUST" class="rfc2119">MUST</em> return a 200 OK status with the Annotation as the body according to the content-type requested. As with creation, the server <em title="MUST" class="rfc2119">MUST</em> return the new state of the Annotation in the response.</p>
 
-      <p>Servers <em class="rfc2119" title="MUST">MUST</em> advertise the availability of updating via PUT on requests to the Annotation's IRI using the <code>Allow</code> response header.</p>
+      <p>Servers <em title="MUST" class="rfc2119">MUST</em> advertise the availability of updating via PUT on requests to the Annotation's IRI using the <code>Allow</code> response header.</p>
 
       <div>
         Request:
@@ -1151,14 +1151,14 @@ Content-Length: <span class="hljs-number">243</span>
     </section>
 
 
-    <section id="delete-an-existing-annotation" typeof="bibo:Chapter" resource="#delete-an-existing-annotation" property="bibo:hasPart">
-      <h3 id="h-delete-an-existing-annotation" resource="#h-delete-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.4 </span>Delete an Existing Annotation</span></h3>
+    <section property="bibo:hasPart" resource="#delete-an-existing-annotation" typeof="bibo:Chapter" id="delete-an-existing-annotation">
+      <h3 resource="#h-delete-an-existing-annotation" id="h-delete-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.4 </span>Delete an Existing Annotation</span></h3>
 
-      <p>Clients <em class="rfc2119" title="MUST">MUST</em> use the DELETE HTTP method to request that an Annotation be deleted by the server. Annotation Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support this method. Clients <em class="rfc2119" title="SHOULD">SHOULD</em> send the ETag of the Annotation in the <code>If-Match</code> header to ensure that it is operating against the most recent version of the Annotation.</p>
+      <p>Clients <em title="MUST" class="rfc2119">MUST</em> use the DELETE HTTP method to request that an Annotation be deleted by the server. Annotation Servers <em title="SHOULD" class="rfc2119">SHOULD</em> support this method. Clients <em title="SHOULD" class="rfc2119">SHOULD</em> send the ETag of the Annotation in the <code>If-Match</code> header to ensure that it is operating against the most recent version of the Annotation.</p>
 
-      <p>If the DELETE request is successfully processed, then the server <em class="rfc2119" title="MUST">MUST</em> return a 204 status response. The IRIs of deleted Annotations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be re-used for subsequent Annotations.
-        <!-- LDP -->The IRI of the deleted Annotation <em class="rfc2119" title="MUST">MUST</em> be removed from the Annotation Container it was created in.
-        <!-- LDP -->There are no requirements made on the body of the response, and it <em class="rfc2119" title="MAY">MAY</em> be empty.</p>
+      <p>If the DELETE request is successfully processed, then the server <em title="MUST" class="rfc2119">MUST</em> return a 204 status response. The IRIs of deleted Annotations <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> be re-used for subsequent Annotations.
+        <!-- LDP -->The IRI of the deleted Annotation <em title="MUST" class="rfc2119">MUST</em> be removed from the Annotation Container it was created in.
+        <!-- LDP -->There are no requirements made on the body of the response, and it <em title="MAY" class="rfc2119">MAY</em> be empty.</p>
 
       <div>
         Request:
@@ -1175,11 +1175,11 @@ Content-Length: <span class="hljs-number">243</span>
   </section>
 
 
-  <section id="error-conditions" typeof="bibo:Chapter" resource="#error-conditions" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#error-conditions" typeof="bibo:Chapter" id="error-conditions">
     <!--OddPage-->
-    <h2 id="h-error-conditions" resource="#h-error-conditions"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Error Conditions</span></h2>
+    <h2 resource="#h-error-conditions" id="h-error-conditions"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Error Conditions</span></h2>
 
-    <p>There are inevitably situations where errors occur when retrieving or managing Annotations. The use of the HTTP status codes below provides a method for clients to understand the reason why a request has failed. No requirements are made regarding the body of the response from the Annotation Server, however all HTTP header requirements from section 4 <em class="rfc2119" title="MUST">MUST</em> be adhered to.</p>
+    <p>There are inevitably situations where errors occur when retrieving or managing Annotations. The use of the HTTP status codes below provides a method for clients to understand the reason why a request has failed. No requirements are made regarding the body of the response from the Annotation Server, however all HTTP header requirements from section 4 <em title="MUST" class="rfc2119">MUST</em> be adhered to.</p>
 
     <dl>
       <dt>400</dt>
@@ -1206,28 +1206,28 @@ Content-Length: <span class="hljs-number">243</span>
 
   </section>
 
-  <section id="containers-for-related-resources" typeof="bibo:Chapter" resource="#containers-for-related-resources" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#containers-for-related-resources" typeof="bibo:Chapter" id="containers-for-related-resources">
     <!--OddPage-->
-    <h2 id="h-containers-for-related-resources" resource="#h-containers-for-related-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Containers for Related Resources</span></h2>
+    <h2 resource="#h-containers-for-related-resources" id="h-containers-for-related-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Containers for Related Resources</span></h2>
 
     <p>Annotations may have related resources that are required for their correct interpretation and rendering, such as content resources used in or as the Body, CSS stylesheets that determine the rendering of the annotation, SVG documents describing a non-rectangular region of a resource, and so forth. If these resources do not already have IRIs, then they need to be made available somewhere so that they can be referred to.</p>
 
-    <p>Annotation Servers <em class="rfc2119" title="MAY">MAY</em> support the management of related resources independently from the Annotations. If a server supports the management of these resources, it <em class="rfc2119" title="SHOULD">SHOULD</em> do this with one or more separate Containers. Resources that are not Annotations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be included in an Annotation Container, as Annotation Clients would not expect to find arbitrary content when dereferencing the IRIs.
-      <!-- Additional but insanity reducing constraint -->Containers for related resources <em class="rfc2119" title="MAY">MAY</em> contain both RDF Sources and Non-RDF Sources. No restrictions are placed on the type or configuration of the Container beyond those of the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>].</p>
+    <p>Annotation Servers <em title="MAY" class="rfc2119">MAY</em> support the management of related resources independently from the Annotations. If a server supports the management of these resources, it <em title="SHOULD" class="rfc2119">SHOULD</em> do this with one or more separate Containers. Resources that are not Annotations <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> be included in an Annotation Container, as Annotation Clients would not expect to find arbitrary content when dereferencing the IRIs.
+      <!-- Additional but insanity reducing constraint -->Containers for related resources <em title="MAY" class="rfc2119">MAY</em> contain both RDF Sources and Non-RDF Sources. No restrictions are placed on the type or configuration of the Container beyond those of the Linked Data Platform [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>].</p>
 
-    <p>Containers for related resources <em class="rfc2119" title="MUST">MUST</em> support the same HTTP methods as described above for the Annotation Container, and <em class="rfc2119" title="MUST">MUST</em> support identifying their type with a <code>Link</code> header. The <code>constrainedBy</code> link header on the response when dereferencing the Container <em class="rfc2119" title="SHOULD">SHOULD</em> refer to a server specific set of constraints listing the types of content that are acceptable.
+    <p>Containers for related resources <em title="MUST" class="rfc2119">MUST</em> support the same HTTP methods as described above for the Annotation Container, and <em title="MUST" class="rfc2119">MUST</em> support identifying their type with a <code>Link</code> header. The <code>constrainedBy</code> link header on the response when dereferencing the Container <em title="SHOULD" class="rfc2119">SHOULD</em> refer to a server specific set of constraints listing the types of content that are acceptable.
       <!-- LDP -->
     </p>
 
   </section>
 
-  <section class="appendix informative changelog" id="changed-from-previous-versions" typeof="bibo:Chapter" resource="#changed-from-previous-versions" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#changed-from-previous-versions" typeof="bibo:Chapter" id="changed-from-previous-versions" class="appendix informative changelog">
     <!--OddPage-->
-    <h2 id="h-changed-from-previous-versions" resource="#h-changed-from-previous-versions"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Changed from Previous Versions</span></h2>
+    <h2 resource="#h-changed-from-previous-versions" id="h-changed-from-previous-versions"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Changed from Previous Versions</span></h2>
     <p><em>This section is non-normative.</em></p>
 
-    <section id="changes-from-the-working-draft-of-2016-03-31" typeof="bibo:Chapter" resource="#changes-from-the-working-draft-of-2016-03-31" property="bibo:hasPart">
-      <h3 id="h-changes-from-the-working-draft-of-2016-03-31" resource="#h-changes-from-the-working-draft-of-2016-03-31"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</span></h3>
+    <section property="bibo:hasPart" resource="#changes-from-the-working-draft-of-2016-03-31" typeof="bibo:Chapter" id="changes-from-the-working-draft-of-2016-03-31">
+      <h3 resource="#h-changes-from-the-working-draft-of-2016-03-31" id="h-changes-from-the-working-draft-of-2016-03-31"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</span></h3>
 
       <p>Significant technical changes in this specification from the <a href="https://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">Working Draft Published of 2016-03-31</a> are:</p>
 
@@ -1242,9 +1242,9 @@ Content-Length: <span class="hljs-number">243</span>
   </section>
 
 
-  <section class="appendix" id="acknowledgments" typeof="bibo:Chapter" resource="#acknowledgments" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#acknowledgments" typeof="bibo:Chapter" id="acknowledgments" class="appendix">
     <!--OddPage-->
-    <h2 id="h-acknowledgments" resource="#h-acknowledgments"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>Acknowledgments</span></h2>
+    <h2 resource="#h-acknowledgments" id="h-acknowledgments"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>Acknowledgments</span></h2>
 
     <p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>. The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model and protocol.
     </p>
@@ -1260,41 +1260,41 @@ Content-Length: <span class="hljs-number">243</span>
 
 
 
-  <section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart">
+  <section property="bibo:hasPart" resource="#references" typeof="bibo:Chapter" id="references" class="appendix">
     <!--OddPage-->
-    <h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>References</span></h2>
+    <h2 resource="#h-references" id="h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>References</span></h2>
 
-    <section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart">
-      <h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">C.1 </span>Normative references</span></h3>
-      <dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt>
-        <dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+    <section property="bibo:hasPart" resource="#normative-references" typeof="bibo:Chapter" id="normative-references">
+      <h3 resource="#h-normative-references" id="h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">C.1 </span>Normative references</span></h3>
+      <dl resource="" class="bibliography"><dt id="bib-RFC2119">[RFC2119]</dt>
+        <dd>S. Bradner. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
         </dd><dt id="bib-activitystreams-core">[activitystreams-core]</dt>
-        <dd>James Snell; Evan Prodromou. W3C. <a href="http://www.w3.org/TR/activitystreams-core/" property="dc:requires"><cite>Activity Streams 2.0</cite></a>. 31 May 2016. W3C Working Draft. URL: <a href="http://www.w3.org/TR/activitystreams-core/" property="dc:requires">http://www.w3.org/TR/activitystreams-core/</a>
+        <dd>James Snell; Evan Prodromou. W3C. <a property="dc:requires" href="http://www.w3.org/TR/activitystreams-core/"><cite>Activity Streams 2.0</cite></a>. 31 May 2016. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/activitystreams-core/">http://www.w3.org/TR/activitystreams-core/</a>
         </dd><dt id="bib-annotation-model">[annotation-model]</dt>
-        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires"><cite>Web Annotation Data Model</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
+        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/"><cite>Web Annotation Data Model</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-model-20160331/">http://www.w3.org/TR/2016/WD-annotation-model-20160331/</a>
         </dd><dt id="bib-annotation-vocab">[annotation-vocab]</dt>
-        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/" property="dc:requires"><cite>Web Annotation Vocabulary</cite></a>. W3C Working Draft. URL: <a href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/" property="dc:requires">http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/</a>
+        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/"><cite>Web Annotation Vocabulary</cite></a>. W3C Working Draft. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/">http://www.w3.org/TR/2016/WD-annotation-vocab-20160331/</a>
         </dd><dt id="bib-cors">[cors]</dt>
-        <dd>Anne van Kesteren. W3C. <a href="http://www.w3.org/TR/cors/" property="dc:requires"><cite>Cross-Origin Resource Sharing</cite></a>. 16 January 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/cors/" property="dc:requires">http://www.w3.org/TR/cors/</a>
+        <dd>Anne van Kesteren. W3C. <a property="dc:requires" href="http://www.w3.org/TR/cors/"><cite>Cross-Origin Resource Sharing</cite></a>. 16 January 2014. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/cors/">http://www.w3.org/TR/cors/</a>
         </dd><dt id="bib-ldp">[ldp]</dt>
-        <dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a href="http://www.w3.org/TR/ldp/" property="dc:requires"><cite>Linked Data Platform 1.0</cite></a>. 26 February 2015. W3C Recommendation. URL: <a href="http://www.w3.org/TR/ldp/" property="dc:requires">http://www.w3.org/TR/ldp/</a>
+        <dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a property="dc:requires" href="http://www.w3.org/TR/ldp/"><cite>Linked Data Platform 1.0</cite></a>. 26 February 2015. W3C Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/ldp/">http://www.w3.org/TR/ldp/</a>
         </dd><dt id="bib-ldp-paging">[ldp-paging]</dt>
-        <dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a href="http://www.w3.org/TR/ldp-paging/" property="dc:requires"><cite>Linked Data Platform Paging 1.0</cite></a>. 30 June 2015. W3C Note. URL: <a href="http://www.w3.org/TR/ldp-paging/" property="dc:requires">http://www.w3.org/TR/ldp-paging/</a>
+        <dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a property="dc:requires" href="http://www.w3.org/TR/ldp-paging/"><cite>Linked Data Platform Paging 1.0</cite></a>. 30 June 2015. W3C Note. URL: <a property="dc:requires" href="http://www.w3.org/TR/ldp-paging/">http://www.w3.org/TR/ldp-paging/</a>
         </dd><dt id="bib-rfc3987">[rfc3987]</dt>
-        <dd>M. Duerst; M. Suignard. IETF. <a href="https://tools.ietf.org/html/rfc3987" property="dc:requires"><cite>Internationalized Resource Identifiers (IRIs)</cite></a>. January 2005. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc3987" property="dc:requires">https://tools.ietf.org/html/rfc3987</a>
+        <dd>M. Duerst; M. Suignard. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc3987"><cite>Internationalized Resource Identifiers (IRIs)</cite></a>. January 2005. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc3987">https://tools.ietf.org/html/rfc3987</a>
         </dd><dt id="bib-rfc5988">[rfc5988]</dt>
-        <dd>M. Nottingham. IETF. <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires">https://tools.ietf.org/html/rfc5988</a>
+        <dd>M. Nottingham. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988">https://tools.ietf.org/html/rfc5988</a>
         </dd><dt id="bib-rfc7230">[rfc7230]</dt>
-        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7230" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7230" property="dc:requires">https://tools.ietf.org/html/rfc7230</a>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc7230"><cite>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</cite></a>. June 2014. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc7230">https://tools.ietf.org/html/rfc7230</a>
         </dd><dt id="bib-rfc7231">[rfc7231]</dt>
-        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7231" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231" property="dc:requires">https://tools.ietf.org/html/rfc7231</a>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc7231"><cite>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</cite></a>. June 2014. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>
         </dd><dt id="bib-rfc7232">[rfc7232]</dt>
-        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7232" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7232" property="dc:requires">https://tools.ietf.org/html/rfc7232</a>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc7232"><cite>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</cite></a>. June 2014. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc7232">https://tools.ietf.org/html/rfc7232</a>
         </dd>
       </dl>
     </section>
   </section>
   <p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p>
-  <script async="" defer="" src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+  <script src="https://www.w3.org/scripts/TR/2016/fixup.js" defer="" async=""></script>
 </body>
 </html>


### PR DESCRIPTION
Found some `Link` header commas missing.

Example 3 (and the examples after that) have some odd formatting/styling issues...but I've not sorted that one out yet.

I'll send another PR if/when I do, otherwise, at least the headers are fixed! :smile: 
