### PR TITLE
Fix editor info

### DIFF
--- a/vocab/wd/index-linktemplate.html
+++ b/vocab/wd/index-linktemplate.html
@@ -106,8 +106,8 @@
                 },
                 {   name:       "Benjamin Young",
                     url:        "http://bigbluehat.com/",
-                    company:    "Invited Expert",
-                    companyURL: "",
+                    company:    "John Wiley & Sons, Inc.",
+                    companyURL: "http://www.wiley.com/",
                     mailto:     "byoung@bigbluehat.com"
                 }
           ],

--- a/vocab/wd/requirements.txt
+++ b/vocab/wd/requirements.txt
@@ -1,0 +1,1 @@
+TurtleLexer


### PR DESCRIPTION
@azaroth42 I missed the Vocab earlier...

Additionally, I tried to run `python make_links.py` but got an error about missing [TurtleLexer](https://github.com/kierdavis/TurtleLexer)--which you can see I added to a `requirements.txt` file.

However...my python install still can't find it. :stuck_out_tongue_closed_eyes: 

Rather than block on my local python dev mess, maybe you can finish this off? :smile_cat: 

Thanks!
