### PR TITLE
Fix 333 multiple http headers

### DIFF
--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -345,7 +345,7 @@ There are three preferences for Container requests that will govern the represen
   <li>If the client prefers to receive complete Annotation descriptions, either in the current Container response or future paged responses, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
 </ol>
 
-<p>The client MAY send multiple preferences. The client MUST NOT include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server MAY respond with the first page of Annotations embedded within the Container response or it MAY provide links to the first and last pages. If no preference is given by the client, the server SHOULD default to the <code>PreferContainedDescriptions</code> behavior. The server MAY ignore the client's preferences.</p>
+<p>The client MAY send multiple preferences as the value of the <code>include</code> parameter as defined by the Linked Data Platform [[ldp]]. However, the client MUST NOT include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server MAY respond with the first page of Annotations embedded within the Container response or it MAY provide links to the first and last pages. If no preference is given by the client, the server SHOULD default to the <code>PreferContainedDescriptions</code> behavior. The server MAY ignore the client's preferences.</p>
 
 </section>
 
@@ -366,8 +366,7 @@ Request:
 GET /annotations/ HTTP/1.1
 Host: example.org
 Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
-Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"
-Prefer: return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"
+Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer http://www.w3.org/ns/oa#PreferContainedIRIs"
 </pre>
 
 Response:

--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -207,13 +207,13 @@ Servers MAY support different JSON-LD profiles. Content negotiation for differen
 
 <p>Servers SHOULD use the 200 HTTP status code when no errors occurred while processing the request to retrieve an Annotation, and MAY use 3XX HTTP status codes to redirect to a new location.</p>
 
-<p>The response from the Annotation Server MUST have a <code>Link</code> header entry <!-- LDP 4.2.1.4 --> where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>.  The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> MAY also be added with the same <code>rel</code> type.</p>
+<p>The response from the Annotation Server MUST have a <code>Link</code> header entry <!-- LDP 4.2.1.4 --> where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>.  The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> MAY also be added with the same <code>rel</code> type. This is to let client systems know that the retrieved representation is a Resource and an Annotation, even if the client cannot process the representation's format.</p>
 
-<p>The response MUST have an <code>ETag</code> header <!-- LDP 4.2.1.3 --> with an entity reference value that implements the notion of entity tags from HTTP [[!rfc7232]].</p>
+<p>The response MUST have an <code>ETag</code> header <!-- LDP 4.2.1.3 --> with an entity reference value that implements the notion of entity tags from HTTP [[!rfc7232]]. This value will be used by the client when sending <a href="#update-an-existing-annotation">update</a> or <a href="#delete-an-existing-annotation">delete</a> requests.</p>
 
-<p>The response MUST have an <code>Allow</code> header <!-- LDP 4.2.8.2 from 4.2.2.2 --> that lists the HTTP methods available for the Annotation [[!rfc7231]].</p>
+<p>The response MUST have an <code>Allow</code> header <!-- LDP 4.2.8.2 from 4.2.2.2 --> that lists the HTTP methods available for interacting with the Annotation [[!rfc7231]].</p>
 
-<p>If the server supports content negotiation by format or JSON-LD profile, the response MUST have a <code>Vary</code> header with <code>Accept</code> in the value. [[!rfc7231]]<!-- HTTP + LDP 4.3.2.1 --> </p>
+<p>If the server supports content negotiation by format or JSON-LD profile, the response MUST have a <code>Vary</code> header with <code>Accept</code> in the value [[!rfc7231]].  This is to ensure that caches understand that the representation changes based on the value of that request header. <!-- HTTP + LDP 4.3.2.1 --> </p>
 
 <div>
 Request:
@@ -256,10 +256,10 @@ Content-Length: 287
 If the Annotation Server supports the management of Annotations, including one or more of creating, updating, and deleting them, then the following section's requirements apply. The Annotation Protocol is a use of the Linked Data Platform [[!ldp]] specification, with some additional constraints derived from the Web Annotation Data Model [[!annotation-model]].
 </p>
 
-<p>An Annotation Server MUST provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [[!ldp]] (a service for managing Annotations) and a Collection [[!activitystreams-core]] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.<p>
+<p>An Annotation Server MUST provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [[!ldp]] (a service for managing Annotations) and an OrderedCollection [[!activitystreams-core]] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.<p>
 
 <p>
-Annotation Containers SHOULD implement the LDP Basic Container specification, but MAY instead implement another type of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers MAY have any IRI, but MUST end in a <code>"/"</code> character. The Annotations MUST be assigned IRIs with an additional path component below the Container's IRI.
+Annotation Containers SHOULD implement the LDP Basic Container specification, but MAY instead implement another type of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers MAY have any IRI, but it MUST end in a <code>"/"</code> character. 
 </p>
 
 <p>Implementations SHOULD use HTTPS rather than HTTP for all interactions with Annotation Containers.</p>
@@ -273,6 +273,7 @@ Annotation Containers SHOULD implement the LDP Basic Container specification, bu
 
 <p>
   The Annotation Server MUST support the following HTTP methods on the Annotation Container's IRI:
+</p>
 
 <ul>
   <li><code>GET</code> (retrieve the description of the Container and the list of its contents, described below), </li>
@@ -284,11 +285,7 @@ Annotation Containers SHOULD implement the LDP Basic Container specification, bu
   When an HTTP GET request is issued against the Annotation Container, the server MUST return a description of the container.  That description MUST be available in JSON-LD, SHOULD be available in Turtle, and MAY be available in other formats. The JSON-LD serialization of the Container's description SHOULD use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [[!annotation-model]], unless the request would determine otherwise.
 </p>
 
-<p>Servers SHOULD use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences.  If redirection is required, then the server SHOULD use a 3XX HTTP status code instead.</p>
-
-<p>
-  Clients that have a preference for JSON-LD SHOULD explicitly request it using an <code>Accept</code> header on the request. If the <code>Accept</code> header is absent from the request, then Annotation Servers MUST respond with the JSON-LD representation of the Annotation Container.
-</p>
+<p>Servers SHOULD use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences.</p>
 
 <p>
   All supported methods for interacting with the Annotation Container SHOULD be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's IRI <!-- LDP --> . The <code>Allow</code> header MAY also be included on any other responses.</p>
@@ -301,10 +298,14 @@ Annotation Containers SHOULD implement the LDP Basic Container specification, bu
 </p>
 
 <p>
-  All HTTP responses from Annotation Containers MUST include an <code>ETag</code> header that implements the notion of entity tags from HTTP [[!rfc7230]].</p>
+  All HTTP responses from Annotation Containers MUST include an <code>ETag</code> header that implements the notion of entity tags from HTTP [[!rfc7230]].  This value will be used by administrative clients when updating the container by including it in an <code>If-Match</code> request header in the same way as clients wanting to update an Annotation.</p>
 
 <p>
-If the server supports content negotiation by format or JSON-LD profile, the response from the Annotation Container MUST have a <code>Vary</code> header that includes <code>Accept</code> in the value.</p>
+  If the <code>Accept</code> header is absent from the request, then Annotation Servers MUST respond with a JSON-LD representation of the Annotation Container, however clients with a preference for JSON-LD SHOULD explicitly request it using an <code>Accept</code> request header. 
+</p>
+
+<p>
+If the server supports content negotiation by format or JSON-LD profile, the response from the Annotation Container MUST have a <code>Vary</code> header that includes <code>Accept</code> in the value to ensure that caches can determine that the representation will change based on the value of this header in requests.</p>
 
 <p>Responses from Annotation Containers that support the use of the POST method to create Annotations SHOULD include an <code>Accept-Post</code> header on responses to GET, HEAD and OPTIONS requests.  The value is a comma separated list of media-types that are acceptable for the client to send via POST [[!ldp]].</p>
 
@@ -319,26 +320,43 @@ Accept-Post: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld", te
 </pre>
 </div>
 
-<section>
-  <h3>Client Preferences</h3>
-
-There are three possibilities for the request that will govern the server's response:
-
-<ol>
-  <li>If the client prefers to only receive the Container description and no annotations, then it MUST include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
-  <li>If the client prefers to receive the list of annotations only as IRIs, then it MUST include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
-  <li>If the client prefers to receive the complete annotation description, then it MUST include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
-</ol>
-
-If no preference is given by the client, the server SHOULD return the full annotation descriptions. The server MAY ignore the client's preference.
-
 </section>
 
 <section>
-  <h3>Responses without Annotations</h3>
+<h3>Container Representations</h3>
 
-<p>The Client may request the description of the Annotation Container without any included Annotations.</p>
-<p>The response SHOULD include links to the first and last AnnotationPages in the Collection, and without either the <code>ldp:contains</code> predicate or the first page of annotations embedded.</p>
+<p>As there are likely to be many Annotations in a single Container, the Annotation Protocol adopts the ActivityStreams <a href="https://www.w3.org/TR/activitystreams-core/#collections">paging mechanism</a> for returning the contents of the Container.  Each page contains an ordered list with a subset of the managed Annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container.  The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages.  The feature or features by which the Annotations are sorted are not explicit in the response.</p>
+
+<p>If there are greater than zero Annotations in the Container, he representation MUST either include a link to the first page of Annotations as the value of the <code>first</code> property, or include the representation of the first page embedded within the response.  If there is more than one page of Annotations, then the representation SHOULD have a link to the last page using the <code>last</code> property.</p>
+
+<p>The representation of the Container SHOULD include the <code>total</code> property with the total number of annotations in the Container.</p>
+
+<p>The IRI of the Container provided in the response SHOULD differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations.  It is RECOMMENDED that this be done with a query parameter.  The server MAY redirect the client to this IRI and deliver the response there, otherwise it MUST include a <code>Content-Location</code> header with the IRI as its value.</p> 
+
+<section>
+  <h3>Client Representation Preferences</h3>
+
+<p>
+There are three preferences for the request that will govern the representation in the server's responses:</p>
+
+<ol>
+  <li>If the client prefers to only receive the Container description and no Annotations in the current response, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
+  <li>If the client prefers to receive the list of Annotations only as IRIs, either in the current or future paged responses, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
+  <li>If the client prefers to receive complete Annotation descriptions, either in the current or future paged responses, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
+</ol>
+
+<p>The client MUST NOT include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server MAY respond with the first page of Annotations embedded within the Container response or it MAY provide links to the first and last pages. If no preference is given by the client, the server SHOULD default to the <code>PreferContainedDescriptions</code> behavior. The server MAY ignore the client's preferences.</p>
+
+</section>
+
+
+<section>
+  <h3>Representations without Annotations</h3>
+
+<p>If the client requested the minimal representation of the Annotation Container, the response MUST NOT include either the <code>ldp:contains</code> predicate or the first page of Annotations embedded within the response.  The linked pages SHOULD follow any preference provided for whether they include only the IRIs or the full descriptions of the Annotations.
+</p>
+
+<p>The server MAY return a representation without embedded Annotations, even if the <code>PreferMinimalContainer</code> preference is not supplied.</p>
 
 <div>
 
@@ -348,6 +366,7 @@ GET /annotations/ HTTP/1.1
 Host: example.org
 Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"
+Prefer: return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"
 </pre>
 
 Response:
@@ -366,12 +385,12 @@ Content-Length: 368
     "http://www.w3.org/ns/anno.jsonld",
     "http://www.w3.org/ns/ldp.jsonld"
   ],
-  "id": "http://example.org/annotations/",
+  "id": "http://example.org/annotations/?iris=1",
   "type": ["BasicContainer", "AnnotationCollection"],
   "total": 42023,
   "label": "A Container for Web Annotations",
-  "first": "http://example.org/annotations/?page=0",
-  "last": "http://example.org/annotations/?page=42"
+  "first": "http://example.org/annotations/?iris=1&amp;page=0",
+  "last": "http://example.org/annotations/?iris=1&amp;page=42"
 }
 </pre>
 </div>
@@ -379,20 +398,13 @@ Content-Length: 368
 
 <section>
 
-  <h3>Responses with Annotations</h3>
+  <h3>Representations with Annotation IRIs</h3>
 
-<p>If the client requests a response that would include the Annotations, either by IRI or embedded in the response, then the server MUST use the paged collection model. Each page, described below, will contain an ordered list with a subset of the managed annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container.  The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages.  The feature or features by which the annotations are sorted are not explicit in the response.
-</p>
-
-<p>
-The Collection SHOULD include the <code>total</code> property with the total number of annotations in the container. It MUST also have a link to the first page of its contents using <code>first</code>, and SHOULD have a link to the last page of its contents using <code>last</code>.
-</p>
-
-<p>The IRI of the Collection in the response should differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations.  It is RECOMMENDED that this be done with a query parameter.  The server MAY redirect the client to this IRI and deliver the response there, otherwise it MUST include a <code>Content-Location</code> header with the IRI as its value. The server SHOULD include <code>Prefer</code> in the <code>Vary</code> response header to assist with caching.</p>
+<p></p>
 
 <div>
 Request for embedded IRIs:
-<pre class="example highlight" title="Collection Request">
+<pre class="example highlight" title="Container Request (Embedded IRIs)">
 GET /annotations/ HTTP/1.1
 Host: example.org
 Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
@@ -400,7 +412,7 @@ Prefer: return=representation;include="http://www.w3.org/ns/oa#PreferContainedIR
 </pre>
 
 Response:
-<pre class="example highlight" title="Collection Response">
+<pre class="example highlight" title="Container Response (Embedded IRIs)">
 HTTP/1.1 200 OK
 Content-Type: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 Content-Location: http://example.org/annotations/?iris=1
@@ -420,24 +432,95 @@ Content-Length: 397
   "type": ["BasicContainer", "AnnotationCollection"],
   "total": 42023,
   "label": "A Container for Web Annotations",
-  "first": "http://example.org/annotations/?iris=1&amp;page=0",
+  "first": {
+    "id": "http://example.org/annotations/?iris=1&amp;page=0",
+    "type": "AnnotationPage",
+    "next": "http://example.org/annotations/?iris=1&amp;page=1",
+    "items": [
+      "http://example.org/annotations/anno1",
+      "http://example.org/annotations/anno2",
+      "http://example.org/annotations/anno3",
+      "http://example.org/annotations/anno4",
+      "http://example.org/annotations/anno5",
+      "http://example.org/annotations/anno6",
+      ...
+      "http://example.org/annotations/anno999",
+    ]
+  },
   "last": "http://example.org/annotations/?iris=1&amp;page=42"
 }
 </pre>
+</div>
+</section>
+
+<section>
+<h3>Representations with Annotation Descriptions</h3>
+<p></p>
+
 
 Request for embedded descriptions:
-<pre class="example highlight" title="Collection Request">
+
+<pre class="example highlight" title="Container Request (Embedded Descriptions)">
 GET /annotations/ HTTP/1.1
 Host: example.org
 Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 Prefer: return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"
 </pre>
 
-This request would generate a very similar response to the one above, just with some way to distinguish that the pages should embed the Annotations rather than just their IRIs.
+<pre class="example highlight" title="Container Response (Embedded Descriptions)">
+HTTP/1.1 200 OK
+Content-Type: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
+Allow: GET,OPTIONS,HEAD
+Vary: Accept, Prefer
+Content-Length: 924
 
+{
+  "@context": [
+    "http://www.w3.org/ns/anno.jsonld",
+    "http://www.w3.org/ns/ldp.jsonld"
+  ],
+  "id": "http://example.org/annotations/?iris=0",
+  "type": ["BasicContainer", "AnnotationCollection"],
+  "total": 42023,
+  "label": "A Container for Web Annotations",
+  "first": {
+    "id": "http://example.org/annotations/?iris=0&amp;page=0",
+    "type": "AnnotationPage",
+    "next": "http://example.org/annotations/?iris=0&amp;page=1",
+    "items": [
+      {
+        "id": "http://example.org/annotations/anno1",
+        "type": "Annotation",
+        "body": "http://example.net/body1",
+        "target": "http://example.com/page1"
+      },
+      {
+        "id": "http://example.org/annotations/anno2",
+        "type": "Annotation",
+        "body": {
+          "type": "TextualBody",
+          "value": "I like this!"
+        },
+        "target": "http://example.com/book1"
+      }
+      // ...
+      {
+        "id": "http://example.org/annotations/anno50",
+        "type": "Annotation",
+        "body" : "http://example.org/texts/description1",
+        "target": "http://example.com/images/image1"
+      }
+    ]
+  },
+  "last": "http://example.org/annotations/?iris=0&amp;page=840"
+}
+</pre>
 </div>
+</section>
+</section>
 
-<h4>Page Response</h4>
+<section>
+<h3>Annotation Pages</h3>
 <p>
 Individual pages are instances of <code>CollectionPage</code>.  The page contains the Annotations, either via their IRIs or full descriptions, in the <code>items</code> property.</p>
 
@@ -462,7 +545,7 @@ Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 </pre>
 
 Response:
-<pre class="example highlight" title="Page Response">
+<pre class="example highlight" title="Page Response (Embedded IRIs)">
 HTTP/1.1 200 OK
 Content-Type: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 Allow: GET,OPTIONS,HEAD
@@ -491,10 +574,15 @@ Content-Length: 630
 }
 </pre>
 
-A request for the same set of Annotations, with the descriptions embedded might return fewer Annotations.
 
-Response:
-<pre class="example highlight" title="Page Response">
+Request:
+<pre class="example highlight" title="Page Request (Embedded Descriptions)">
+GET /annotations/?iris=0&amp;page=0 HTTP/1.1
+Host: example.org
+Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
+</pre>
+
+<pre class="example highlight" title="Page Response (Embedded Descriptions)">
 HTTP/1.1 200 OK
 Content-Type: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 Allow: GET,OPTIONS,HEAD
@@ -539,7 +627,6 @@ Content-Length: 924
 
 </div>
 </section>
-</section>
 
 <section>
   <h3>Discovery of Annotation Containers</h3>
@@ -582,7 +669,10 @@ Content-Length: 76983
 
 <p>New Annotations are created via a POST request to an Annotation Container.  The Annotation, serialized as JSON-LD, is sent in the body of the request. All of the known information about the Annotation SHOULD be sent, and if there are already IRIs associated with the resources, they SHOULD be included. The serialization SHOULD use the Web Annotation JSON-LD profile, and servers MAY reject other contexts even if they would otherwise produce the same model. The server MAY reject content that is not considered an Annotation according to the Web Annotation specification [[!annotation-model]].</p>
 
-<p>Upon receipt of an Annotation, the server MAY assign IRIs to any resource or blank node in the Annotation, and MUST assign an IRI to the Annotation resource in the <code>id</code> property, even if it already has one provided. The server SHOULD use HTTPS IRIs when those resources are able to be retrieved individually. The server MAY also add additional information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, additional types and formats.</p>
+<p>Upon receipt of an Annotation, the server MAY assign IRIs to any resource or blank node in the Annotation, and MUST assign an IRI to the Annotation resource in the <code>id</code> property, even if it already has one provided. The server SHOULD use HTTPS IRIs when those resources are able to be retrieved individually. The IRI for the Annotation MUST be the IRI of the Container with an additional component added to the end.
+</p>
+
+<p>The server MAY add information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, or additional types and formats of the constituent resources.</p>
 
 <p>If the Annotation contains a <code>canonical</code> link, then it MUST be maintained without change.  If the Annotation has an IRI in the <code>id</code> property, then it SHOULD be copied to the <code>via</code> property, and the IRI assigned by the server, at which the Annotation will be available, MUST be put in the <code>id</code> field to replace it.</p>
 

--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -907,6 +907,18 @@ Content-Length: 0
 <h3>Changed from Previous Versions</h3>
 
 <section>
+    <h3>Changes from the Candidate Recommendation of 2016-06-12</h3>
+
+<p>Significant technical changes in this specification from the <a href="http://www.w3.org/TR/2016/CR-annotation-protocol-20160712/">Candidate Recommendation of 2016-06-12</a> are:</p>
+
+<ul>
+<li>Editorial restructuring of the Pagination content.</li>
+<li>Clarified requirements for Annotation Server's representation preference handling.</li>
+<li>Explained the proper use of the <code>Prefer</code> header when the client has multiple preferences.</li>
+</ul>
+</section>
+
+<section>
     <h3>Changes from the Working Draft of 2016-03-31</h3>
 
 <p>Significant technical changes in this specification from the <a href="https://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">Working Draft Published of 2016-03-31</a> are:</p>

--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -327,25 +327,25 @@ Accept-Post: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld", te
 
 <p>As there are likely to be many Annotations in a single Container, the Annotation Protocol adopts the ActivityStreams <a href="https://www.w3.org/TR/activitystreams-core/#collections">paging mechanism</a> for returning the contents of the Container.  Each page contains an ordered list with a subset of the managed Annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container.  The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages.  The feature or features by which the Annotations are sorted are not explicit in the response.</p>
 
-<p>If there are greater than zero Annotations in the Container, he representation MUST either include a link to the first page of Annotations as the value of the <code>first</code> property, or include the representation of the first page embedded within the response.  If there is more than one page of Annotations, then the representation SHOULD have a link to the last page using the <code>last</code> property.</p>
+<p>If there are greater than zero Annotations in the Container, the representation MUST either include a link to the first page of Annotations as the value of the <code>first</code> property, or include the representation of the first page embedded within the response.  If there is more than one page of Annotations, then the representation SHOULD have a link to the last page using the <code>last</code> property.</p>
 
 <p>The representation of the Container SHOULD include the <code>total</code> property with the total number of annotations in the Container.</p>
 
 <p>The IRI of the Container provided in the response SHOULD differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations.  It is RECOMMENDED that this be done with a query parameter.  The server MAY redirect the client to this IRI and deliver the response there, otherwise it MUST include a <code>Content-Location</code> header with the IRI as its value.</p> 
 
 <section>
-  <h3>Client Representation Preferences</h3>
+  <h3>Container Representation Preferences</h3>
 
 <p>
-There are three preferences for the request that will govern the representation in the server's responses:</p>
+There are three preferences for Container requests that will govern the representation of the server's responses:</p>
 
 <ol>
-  <li>If the client prefers to only receive the Container description and no Annotations in the current response, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
-  <li>If the client prefers to receive the list of Annotations only as IRIs, either in the current or future paged responses, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
-  <li>If the client prefers to receive complete Annotation descriptions, either in the current or future paged responses, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
+  <li>If the client prefers to only receive the Container description and no Annotations in the Container response, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
+  <li>If the client prefers to receive the list of Annotations only as IRIs, either in the current Container response or future paged responses, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
+  <li>If the client prefers to receive complete Annotation descriptions, either in the current Container response or future paged responses, then it MUST include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
 </ol>
 
-<p>The client MUST NOT include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server MAY respond with the first page of Annotations embedded within the Container response or it MAY provide links to the first and last pages. If no preference is given by the client, the server SHOULD default to the <code>PreferContainedDescriptions</code> behavior. The server MAY ignore the client's preferences.</p>
+<p>The client MAY send multiple preferences. The client MUST NOT include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server MAY respond with the first page of Annotations embedded within the Container response or it MAY provide links to the first and last pages. If no preference is given by the client, the server SHOULD default to the <code>PreferContainedDescriptions</code> behavior. The server MAY ignore the client's preferences.</p>
 
 </section>
 
@@ -353,8 +353,9 @@ There are three preferences for the request that will govern the representation 
 <section>
   <h3>Representations without Annotations</h3>
 
-<p>If the client requested the minimal representation of the Annotation Container, the response MUST NOT include either the <code>ldp:contains</code> predicate or the first page of Annotations embedded within the response.  The linked pages SHOULD follow any preference provided for whether they include only the IRIs or the full descriptions of the Annotations.
-</p>
+  <p>If the client requests the minimal representation of an Annotation Container, the response MUST NOT include either the <code>ldp:contains</code> predicate nor embed the first page of Annotations within the response.</p>
+
+  <p>The linked pages SHOULD follow any <code>PreferContainedDescriptions</code> or <code>PreferContainedIRIs</code> preferences.</p>
 
 <p>The server MAY return a representation without embedded Annotations, even if the <code>PreferMinimalContainer</code> preference is not supplied.</p>
 

--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -401,7 +401,11 @@ Content-Length: 368
 
   <h3>Representations with Annotation IRIs</h3>
 
-<p></p>
+  <p>If the Server supports Container preferences, it MUST respond to <code>PreferContainedIRIs</code> with a response containing an <cocde>AnnotationPage</code> as the value of <code>first</code> with its <code>items</code> containing only the IRIs of the contained Annotations.</p>
+
+  <p>The linked pages SHOULD follow the <code>PreferContainedIRIs</code> preference.</p>
+
+  <p>The <code>PreferContainedIRIs</code> and the <code>PreferContainedDescriptions</code> preferences are mutually exclusive.</p>
 
 <div>
 Request for embedded IRIs:
@@ -456,8 +460,12 @@ Content-Length: 397
 
 <section>
 <h3>Representations with Annotation Descriptions</h3>
-<p></p>
 
+<p>If the Server supports Container preferences, it MUST respond to <code>PreferContainedDescriptions</code> with a response containing an <code>AnnotationPage</code> as the value of <code>first</code> with its <code>items</code> containing complete, inline Annotations.</p>
+
+  <p>The linked pages SHOULD follow the <code>PreferContainedDescriptions</code> preference.</p>
+
+  <p>The <code>PreferContainedIRIs</code> and the <code>PreferContainedDescriptions</code> preferences are mutually exclusive.</p>
 
 Request for embedded descriptions:
 

--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -909,6 +909,7 @@ Content-Length: 0
 <li>Rename PreferContainedURIs to PreferContainedIRIs.</li>
 <li>Add recommendation for Accept-Post, with example.</li>
 <li>Clarify expected status codes for successful interactions.</li>
+<li>Restructure Container Retrieval section and promote Container Representations and Annotation Pages sections.</li>
 </ul>
 </section>
 </section>

--- a/protocol/wd/index.html
+++ b/protocol/wd/index.html
@@ -2,8 +2,8 @@
 <html lang="en" dir="ltr" typeof="bibo:Document w3p:CR" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
 <head>
   <meta charset="utf-8">
-  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <meta property="dc:language" content="en" lang="">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta lang="" property="dc:language" content="en">
   <style>
     /*
 
@@ -216,6 +216,10 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     code {
       color: #C83500;
     }
+    
+    th code {
+      color: inherit;
+    }
     /* --- TOC --- */
     
     .toc a,
@@ -322,9 +326,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </style>
 
 
-  <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-CR" rel="stylesheet">
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-CR">
   <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
-  <script type="application/json" id="initialUserConfig">
+  <script id="initialUserConfig" type="application/json">
     {
       "specStatus": "CR",
       "shortName": "annotation-protocol",
@@ -389,10 +393,10 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </script>
 </head>
 
-<body id="respecDocument" role="document" class="h-entry">
-  <div id="respecHeader" role="contentinfo" class="head">
+<body class="h-entry toc-inline" role="document" id="respecDocument">
+  <div class="head" role="contentinfo" id="respecHeader">
     <p>
-      <a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C" width="72" height="48"></a>
+      <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Protocol</h1>
     <h2 id="w3c-candidate-recommendation-12-july-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Candidate Recommendation <time property="dcterms:issued" class="dt-published" datetime="2016-07-12">12 July 2016</time></h2>
@@ -432,8 +436,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <hr title="Separator for header">
   </div>
 
-  <section property="dc:abstract" class="introductory" id="abstract">
-    <h2 resource="#h-abstract" id="h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+  <section id="abstract" class="introductory" property="dc:abstract">
+    <h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
 
     <p>Annotations are typically used to convey information about a resource or associations between resources. Simple examples include a comment or tag on a single web page or image, or a blog post about a news article. </p>
 
@@ -442,7 +446,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </section>
 
   <section id="sotd" class="introductory">
-    <h2 resource="#h-sotd" id="h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+    <h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
     <p>
       <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
     </p>
@@ -482,52 +486,52 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
   </section>
   <nav id="toc">
-    <h2 resource="#table-of-contents" id="table-of-contents" class="introductory"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
-    <ul role="directory" class="toc">
-      <li class="tocline"><a class="tocxref" href="#introduction"><span class="secno">1. </span>Introduction</a>
+    <h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
+    <ul class="toc" role="directory">
+      <li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a>
         <ul class="toc">
-          <li class="tocline"><a class="tocxref" href="#aims-of-the-protocol"><span class="secno">1.1 </span>Aims of the Protocol</a></li>
-          <li class="tocline"><a class="tocxref" href="#summary"><span class="secno">1.2 </span>Summary</a></li>
-          <li class="tocline"><a class="tocxref" href="#conformance"><span class="secno">1.3 </span>Conformance</a></li>
-          <li class="tocline"><a class="tocxref" href="#terminology"><span class="secno">1.4 </span>Terminology</a></li>
+          <li class="tocline"><a href="#aims-of-the-protocol" class="tocxref"><span class="secno">1.1 </span>Aims of the Protocol</a></li>
+          <li class="tocline"><a href="#summary" class="tocxref"><span class="secno">1.2 </span>Summary</a></li>
+          <li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">1.3 </span>Conformance</a></li>
+          <li class="tocline"><a href="#terminology" class="tocxref"><span class="secno">1.4 </span>Terminology</a></li>
         </ul>
       </li>
-      <li class="tocline"><a class="tocxref" href="#web-annotation-protocol-principles"><span class="secno">2. </span>Web Annotation Protocol Principles</a></li>
-      <li class="tocline"><a class="tocxref" href="#annotation-retrieval"><span class="secno">3. </span>Annotation Retrieval</a></li>
-      <li class="tocline"><a class="tocxref" href="#annotation-containers"><span class="secno">4. </span>Annotation Containers</a>
+      <li class="tocline"><a href="#web-annotation-protocol-principles" class="tocxref"><span class="secno">2. </span>Web Annotation Protocol Principles</a></li>
+      <li class="tocline"><a href="#annotation-retrieval" class="tocxref"><span class="secno">3. </span>Annotation Retrieval</a></li>
+      <li class="tocline"><a href="#annotation-containers" class="tocxref"><span class="secno">4. </span>Annotation Containers</a>
         <ul class="toc">
-          <li class="tocline"><a class="tocxref" href="#container-retrieval"><span class="secno">4.1 </span>Container Retrieval</a></li>
-          <li class="tocline"><a class="tocxref" href="#container-representations"><span class="secno">4.2 </span>Container Representations</a>
+          <li class="tocline"><a href="#container-retrieval" class="tocxref"><span class="secno">4.1 </span>Container Retrieval</a></li>
+          <li class="tocline"><a href="#container-representations" class="tocxref"><span class="secno">4.2 </span>Container Representations</a>
             <ul class="toc">
-              <li class="tocline"><a class="tocxref" href="#client-representation-preferences"><span class="secno">4.2.1 </span>Client Representation Preferences</a></li>
-              <li class="tocline"><a class="tocxref" href="#representations-without-annotations"><span class="secno">4.2.2 </span>Representations without Annotations</a></li>
-              <li class="tocline"><a class="tocxref" href="#representations-with-annotation-iris"><span class="secno">4.2.3 </span>Representations with Annotation IRIs</a></li>
-              <li class="tocline"><a class="tocxref" href="#representations-with-annotation-descriptions"><span class="secno">4.2.4 </span>Representations with Annotation Descriptions</a></li>
+              <li class="tocline"><a href="#container-representation-preferences" class="tocxref"><span class="secno">4.2.1 </span>Container Representation Preferences</a></li>
+              <li class="tocline"><a href="#representations-without-annotations" class="tocxref"><span class="secno">4.2.2 </span>Representations without Annotations</a></li>
+              <li class="tocline"><a href="#representations-with-annotation-iris" class="tocxref"><span class="secno">4.2.3 </span>Representations with Annotation IRIs</a></li>
+              <li class="tocline"><a href="#representations-with-annotation-descriptions" class="tocxref"><span class="secno">4.2.4 </span>Representations with Annotation Descriptions</a></li>
             </ul>
           </li>
-          <li class="tocline"><a class="tocxref" href="#annotation-pages"><span class="secno">4.3 </span>Annotation Pages</a></li>
-          <li class="tocline"><a class="tocxref" href="#discovery-of-annotation-containers"><span class="secno">4.4 </span>Discovery of Annotation Containers</a></li>
+          <li class="tocline"><a href="#annotation-pages" class="tocxref"><span class="secno">4.3 </span>Annotation Pages</a></li>
+          <li class="tocline"><a href="#discovery-of-annotation-containers" class="tocxref"><span class="secno">4.4 </span>Discovery of Annotation Containers</a></li>
         </ul>
       </li>
-      <li class="tocline"><a class="tocxref" href="#creation-updating-and-deletion-of-annotations"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</a>
+      <li class="tocline"><a href="#creation-updating-and-deletion-of-annotations" class="tocxref"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</a>
         <ul class="toc">
-          <li class="tocline"><a class="tocxref" href="#create-a-new-annotation"><span class="secno">5.1 </span>Create a New Annotation</a></li>
-          <li class="tocline"><a class="tocxref" href="#suggesting-an-iri-for-an-annotation"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</a></li>
-          <li class="tocline"><a class="tocxref" href="#update-an-existing-annotation"><span class="secno">5.3 </span>Update an Existing Annotation</a></li>
-          <li class="tocline"><a class="tocxref" href="#delete-an-existing-annotation"><span class="secno">5.4 </span>Delete an Existing Annotation</a></li>
+          <li class="tocline"><a href="#create-a-new-annotation" class="tocxref"><span class="secno">5.1 </span>Create a New Annotation</a></li>
+          <li class="tocline"><a href="#suggesting-an-iri-for-an-annotation" class="tocxref"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</a></li>
+          <li class="tocline"><a href="#update-an-existing-annotation" class="tocxref"><span class="secno">5.3 </span>Update an Existing Annotation</a></li>
+          <li class="tocline"><a href="#delete-an-existing-annotation" class="tocxref"><span class="secno">5.4 </span>Delete an Existing Annotation</a></li>
         </ul>
       </li>
-      <li class="tocline"><a class="tocxref" href="#error-conditions"><span class="secno">6. </span>Error Conditions</a></li>
-      <li class="tocline"><a class="tocxref" href="#containers-for-related-resources"><span class="secno">7. </span>Containers for Related Resources</a></li>
-      <li class="tocline"><a class="tocxref" href="#changed-from-previous-versions"><span class="secno">A. </span>Changed from Previous Versions</a>
+      <li class="tocline"><a href="#error-conditions" class="tocxref"><span class="secno">6. </span>Error Conditions</a></li>
+      <li class="tocline"><a href="#containers-for-related-resources" class="tocxref"><span class="secno">7. </span>Containers for Related Resources</a></li>
+      <li class="tocline"><a href="#changed-from-previous-versions" class="tocxref"><span class="secno">A. </span>Changed from Previous Versions</a>
         <ul class="toc">
-          <li class="tocline"><a class="tocxref" href="#changes-from-the-working-draft-of-2016-03-31"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</a></li>
+          <li class="tocline"><a href="#changes-from-the-working-draft-of-2016-03-31" class="tocxref"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</a></li>
         </ul>
       </li>
-      <li class="tocline"><a class="tocxref" href="#acknowledgments"><span class="secno">B. </span>Acknowledgments</a></li>
-      <li class="tocline"><a class="tocxref" href="#references"><span class="secno">C. </span>References</a>
+      <li class="tocline"><a href="#acknowledgments" class="tocxref"><span class="secno">B. </span>Acknowledgments</a></li>
+      <li class="tocline"><a href="#references" class="tocxref"><span class="secno">C. </span>References</a>
         <ul class="toc">
-          <li class="tocline"><a class="tocxref" href="#normative-references"><span class="secno">C.1 </span>Normative references</a></li>
+          <li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">C.1 </span>Normative references</a></li>
         </ul>
       </li>
     </ul>
@@ -535,18 +539,18 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 
 
-  <section property="bibo:hasPart" resource="#introduction" typeof="bibo:Chapter" id="introduction" class="informative">
+  <section class="informative" id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-introduction" id="h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
+    <h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
     <p><em>This section is non-normative.</em></p>
 
     <p>Interoperability between systems has two basic aspects: the syntax and semantics of the data that is moved between the systems, and the transport mechanism for that movement. The HTTP protocol and the Web architecture provides us with a great starting point for a standardized transport layer, and can be used to move content between systems easily and effectively. Building upon these foundations allows us to make use of existing technology and patterns to ensure consistency and ease of development.</p>
 
-    <p>The Web Annotation Protocol describes a transport mechanism for creating, managing, and retrieving Annotations. Annotations in this specification are assumed to follow the requirements of the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>] and Web Annotation Vocabulary [<cite><a href="#bib-annotation-vocab" class="bibref">annotation-vocab</a></cite>]. This specification builds upon REST principles and the Linked Data Platform [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] recommendation, and familiarity with it is recommended.</p>
+    <p>The Web Annotation Protocol describes a transport mechanism for creating, managing, and retrieving Annotations. Annotations in this specification are assumed to follow the requirements of the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>] and Web Annotation Vocabulary [<cite><a class="bibref" href="#bib-annotation-vocab">annotation-vocab</a></cite>]. This specification builds upon REST principles and the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] recommendation, and familiarity with it is recommended.</p>
 
 
-    <section property="bibo:hasPart" resource="#aims-of-the-protocol" typeof="bibo:Chapter" id="aims-of-the-protocol">
-      <h3 resource="#h-aims-of-the-protocol" id="h-aims-of-the-protocol"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Aims of the Protocol</span></h3>
+    <section id="aims-of-the-protocol" typeof="bibo:Chapter" resource="#aims-of-the-protocol" property="bibo:hasPart">
+      <h3 id="h-aims-of-the-protocol" resource="#h-aims-of-the-protocol"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.1 </span>Aims of the Protocol</span></h3>
 
       <p>
         The primary aim of the Web Annotation Protocol is to provide a standard set of interactions that allow annotation clients and servers to interoperate seamlessly. By being able to discover annotation protocol end-points and how to interact with them, clients can be configured either automatically or by the user to store annotations in any compatible remote system, rather than being locked in to a single client and server pair.
@@ -554,8 +558,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
     </section>
 
-    <section property="bibo:hasPart" resource="#summary" typeof="bibo:Chapter" id="summary">
-      <h3 resource="#h-summary" id="h-summary"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Summary</span></h3>
+    <section id="summary" typeof="bibo:Chapter" resource="#summary" property="bibo:hasPart">
+      <h3 id="h-summary" resource="#h-summary"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.2 </span>Summary</span></h3>
 
       <p>For those familiar with the Web Annotation model, LDP, and REST, much of the Annotation Protocol will be very obvious. The following aspects are the most important new requirements.
       </p>
@@ -564,43 +568,43 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <li>The media type to use for Annotations is: <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code></li>
         <li>Annotation Containers are constrained by the set of constraints described in this specification, and thus the <code>ldp:constrainedBy</code> URL is <code>http://www.w3.org/TR/annotation-protocol/</code></li>
         <li>The link header can refer from any resource to an Annotation Container using a <code>rel</code> type of: <code>http://www.w3.org/ns/oa#annotationService</code></li>
-        <li>The response from a Container after creating an Annotation <em title="SHOULD" class="rfc2119">SHOULD</em> include a representation of the Annotation, after any changes have been made to it, in the JSON-LD serialization.</li>
-        <li>Annotation Containers <em title="SHOULD" class="rfc2119">SHOULD</em> only contain Annotations, and not other resources.</li>
-        <li>Activity Streams Collection [<cite><a href="#bib-activitystreams-core" class="bibref">activitystreams-core</a></cite>] model is used for paging, as in-page ordering is an important requirement.</li>
+        <li>The response from a Container after creating an Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> include a representation of the Annotation, after any changes have been made to it, in the JSON-LD serialization.</li>
+        <li>Annotation Containers <em class="rfc2119" title="SHOULD">SHOULD</em> only contain Annotations, and not other resources.</li>
+        <li>Activity Streams Collection [<cite><a class="bibref" href="#bib-activitystreams-core">activitystreams-core</a></cite>] model is used for paging, as in-page ordering is an important requirement.</li>
       </ul>
 
     </section>
 
-    <section property="bibo:hasPart" resource="#conformance" typeof="bibo:Chapter" id="conformance">
-      <h3 resource="#h-conformance" id="h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart">
+      <h3 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.3 </span>Conformance</span></h3>
       <p>
         As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
       </p>
-      <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a href="#bib-RFC2119" class="bibref">RFC2119</a></cite>].
+      <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
       </p>
 
     </section>
 
-    <section property="bibo:hasPart" resource="#terminology" typeof="bibo:Chapter" id="terminology">
-      <h3 resource="#h-terminology" id="h-terminology"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.4 </span>Terminology</span></h3>
+    <section id="terminology" typeof="bibo:Chapter" resource="#terminology" property="bibo:hasPart">
+      <h3 id="h-terminology" resource="#h-terminology"><span property="xhv:role" resource="xhv:heading"><span class="secno">1.4 </span>Terminology</span></h3>
 
       <p>
       </p>
       <dl>
-        <dt><dfn id="dfn-iri" data-dfn-type="dfn">IRI</dfn></dt>
-        <dd>An <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>, or Internationalized Resource Identifier, is an extension to the URI specification to allow characters from Unicode, whereas URIs must be made up of a subset of ASCII characters. There is a mapping algorithm for translating between IRIs and the equivalent encoded URI form. IRIs are defined by [<cite><a href="#bib-rfc3987" class="bibref">rfc3987</a></cite>].</dd>
-        <dt><dfn id="dfn-resource" data-dfn-type="dfn">Resource</dfn></dt>
-        <dd>An item of interest that <em title="MAY" class="rfc2119">MAY</em> be identified by an <a data-link-type="dfn" class="internalDFN" href="#dfn-iri">IRI</a>.</dd>
+        <dt><dfn data-dfn-type="dfn" id="dfn-iri">IRI</dfn></dt>
+        <dd>An <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>, or Internationalized Resource Identifier, is an extension to the URI specification to allow characters from Unicode, whereas URIs must be made up of a subset of ASCII characters. There is a mapping algorithm for translating between IRIs and the equivalent encoded URI form. IRIs are defined by [<cite><a class="bibref" href="#bib-rfc3987">rfc3987</a></cite>].</dd>
+        <dt><dfn data-dfn-type="dfn" id="dfn-resource">Resource</dfn></dt>
+        <dd>An item of interest that <em class="rfc2119" title="MAY">MAY</em> be identified by an <a href="#dfn-iri" class="internalDFN" data-link-type="dfn">IRI</a>.</dd>
         <dt>Web Server</dt>
         <dd>A program that accepts connections in order to service HTTP requests by sending HTTP responses.</dd>
         <dt>Annotation</dt>
-        <dd>A web resource that follows the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].</dd>
+        <dd>A web resource that follows the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>].</dd>
         <dt>Annotation Server</dt>
         <dd>A Web Server that also makes available and allows the management of Annotations via the protocol described in this document.</dd>
         <dt>Annotation Client</dt>
         <dd>A program that establishes connections to Annotation Servers for the purpose of retrieving and managing Annotations via the protocol described in this document.</dd>
         <dt>Annotation Container</dt>
-        <dd>An LDP Container [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] used to manage Annotations.</dd>
+        <dd>An LDP Container [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] used to manage Annotations.</dd>
       </dl>
       <p></p>
     </section>
@@ -609,9 +613,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
   <!-- End Introduction -->
 
-  <section property="bibo:hasPart" resource="#web-annotation-protocol-principles" typeof="bibo:Chapter" id="web-annotation-protocol-principles">
+  <section id="web-annotation-protocol-principles" typeof="bibo:Chapter" resource="#web-annotation-protocol-principles" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-web-annotation-protocol-principles" id="h-web-annotation-protocol-principles"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Protocol Principles</span></h2>
+    <h2 id="h-web-annotation-protocol-principles" resource="#h-web-annotation-protocol-principles"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Web Annotation Protocol Principles</span></h2>
 
     <p>
       The Web Annotation Protocol is defined using the following basic principles:
@@ -630,41 +634,41 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </section>
 
 
-  <section property="bibo:hasPart" resource="#annotation-retrieval" typeof="bibo:Chapter" id="annotation-retrieval">
+  <section id="annotation-retrieval" typeof="bibo:Chapter" resource="#annotation-retrieval" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-annotation-retrieval" id="h-annotation-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Annotation Retrieval</span></h2>
+    <h2 id="h-annotation-retrieval" resource="#h-annotation-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Annotation Retrieval</span></h2>
 
     <p>
-      The Annotation Server <em title="MUST" class="rfc2119">MUST</em> support the following HTTP methods on the Annotation's IRI:
+      The Annotation Server <em class="rfc2119" title="MUST">MUST</em> support the following HTTP methods on the Annotation's IRI:
 
     </p>
     <ul>
       <li><code>GET</code> (retrieve the description of the Annotation), </li>
       <li><code>HEAD</code> (retrieve the headers of the Annotation without an entity-body),</li>
-      <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a href="#bib-cors" class="bibref">cors</a></cite>]).</li>
+      <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a class="bibref" href="#bib-cors">cors</a></cite>]).</li>
     </ul>
 
-    <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use HTTPS rather than HTTP for all interactions, including retrieval of Annotations.</p>
+    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use HTTPS rather than HTTP for all interactions, including retrieval of Annotations.</p>
 
-    <p>Servers <em title="MUST" class="rfc2119">MUST</em> support the JSON-LD representation using the Web Annotation profile. These responses <em title="MUST" class="rfc2119">MUST</em> have a <code>Content-Type</code> header with the <code>application/ld+json</code> media type, and it <em title="SHOULD" class="rfc2119">SHOULD</em> have the Web Annotation profile IRI of <code>http://www.w3.org/ns/anno.jsonld</code> in the <code>profile</code> parameter.</p>
+    <p>Servers <em class="rfc2119" title="MUST">MUST</em> support the JSON-LD representation using the Web Annotation profile. These responses <em class="rfc2119" title="MUST">MUST</em> have a <code>Content-Type</code> header with the <code>application/ld+json</code> media type, and it <em class="rfc2119" title="SHOULD">SHOULD</em> have the Web Annotation profile IRI of <code>http://www.w3.org/ns/anno.jsonld</code> in the <code>profile</code> parameter.</p>
 
-    <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> support a Turtle representation, and <em title="MAY" class="rfc2119">MAY</em> support other formats. If more than one representation of the Annotation is available, then the server <em title="SHOULD" class="rfc2119">SHOULD</em> support content negotiation. Content negotiation for different serializations is performed by including the desired media type in the HTTP <code>Accept</code> header of the request, however clients cannot assume that the server will honor their preferences [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>].</p>
+    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support a Turtle representation, and <em class="rfc2119" title="MAY">MAY</em> support other formats. If more than one representation of the Annotation is available, then the server <em class="rfc2119" title="SHOULD">SHOULD</em> support content negotiation. Content negotiation for different serializations is performed by including the desired media type in the HTTP <code>Accept</code> header of the request, however clients cannot assume that the server will honor their preferences [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>].</p>
 
     <p>
-      Servers <em title="MAY" class="rfc2119">MAY</em> support different JSON-LD profiles. Content negotiation for different JSON-LD profiles is performed by adding a <code>profile</code> parameter to the JSON-LD media type in a space separated, quoted list as part of the <code>Accept</code> header.</p>
+      Servers <em class="rfc2119" title="MAY">MAY</em> support different JSON-LD profiles. Content negotiation for different JSON-LD profiles is performed by adding a <code>profile</code> parameter to the JSON-LD media type in a space separated, quoted list as part of the <code>Accept</code> header.</p>
 
-    <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use the 200 HTTP status code when no errors occurred while processing the request to retrieve an Annotation, and <em title="MAY" class="rfc2119">MAY</em> use 3XX HTTP status codes to redirect to a new location.</p>
+    <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use the 200 HTTP status code when no errors occurred while processing the request to retrieve an Annotation, and <em class="rfc2119" title="MAY">MAY</em> use 3XX HTTP status codes to redirect to a new location.</p>
 
-    <p>The response from the Annotation Server <em title="MUST" class="rfc2119">MUST</em> have a <code>Link</code> header entry
-      <!-- LDP 4.2.1.4 -->where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>. The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> <em title="MAY" class="rfc2119">MAY</em> also be added with the same <code>rel</code> type. This is to let client systems know that the retrieved representation is a Resource and an Annotation, even if the client cannot process the representation's format.</p>
+    <p>The response from the Annotation Server <em class="rfc2119" title="MUST">MUST</em> have a <code>Link</code> header entry
+      <!-- LDP 4.2.1.4 -->where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>. The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> <em class="rfc2119" title="MAY">MAY</em> also be added with the same <code>rel</code> type. This is to let client systems know that the retrieved representation is a Resource and an Annotation, even if the client cannot process the representation's format.</p>
 
-    <p>The response <em title="MUST" class="rfc2119">MUST</em> have an <code>ETag</code> header
-      <!-- LDP 4.2.1.3 -->with an entity reference value that implements the notion of entity tags from HTTP [<cite><a href="#bib-rfc7232" class="bibref">rfc7232</a></cite>]. This value will be used by the client when sending <a href="#update-an-existing-annotation">update</a> or <a href="#delete-an-existing-annotation">delete</a> requests.</p>
+    <p>The response <em class="rfc2119" title="MUST">MUST</em> have an <code>ETag</code> header
+      <!-- LDP 4.2.1.3 -->with an entity reference value that implements the notion of entity tags from HTTP [<cite><a class="bibref" href="#bib-rfc7232">rfc7232</a></cite>]. This value will be used by the client when sending <a href="#update-an-existing-annotation">update</a> or <a href="#delete-an-existing-annotation">delete</a> requests.</p>
 
-    <p>The response <em title="MUST" class="rfc2119">MUST</em> have an <code>Allow</code> header
-      <!-- LDP 4.2.8.2 from 4.2.2.2 -->that lists the HTTP methods available for interacting with the Annotation [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>].</p>
+    <p>The response <em class="rfc2119" title="MUST">MUST</em> have an <code>Allow</code> header
+      <!-- LDP 4.2.8.2 from 4.2.2.2 -->that lists the HTTP methods available for interacting with the Annotation [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>].</p>
 
-    <p>If the server supports content negotiation by format or JSON-LD profile, the response <em title="MUST" class="rfc2119">MUST</em> have a <code>Vary</code> header with <code>Accept</code> in the value [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>]. This is to ensure that caches understand that the representation changes based on the value of that request header.
+    <p>If the server supports content negotiation by format or JSON-LD profile, the response <em class="rfc2119" title="MUST">MUST</em> have a <code>Vary</code> header with <code>Accept</code> in the value [<cite><a class="bibref" href="#bib-rfc7231">rfc7231</a></cite>]. This is to ensure that caches understand that the representation changes based on the value of that request header.
       <!-- HTTP + LDP 4.3.2.1 -->
     </p>
 
@@ -699,71 +703,71 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
   </section>
 
-  <section property="bibo:hasPart" resource="#annotation-containers" typeof="bibo:Chapter" id="annotation-containers">
+  <section id="annotation-containers" typeof="bibo:Chapter" resource="#annotation-containers" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-annotation-containers" id="h-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Annotation Containers</span></h2>
+    <h2 id="h-annotation-containers" resource="#h-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Annotation Containers</span></h2>
 
     <p>
-      If the Annotation Server supports the management of Annotations, including one or more of creating, updating, and deleting them, then the following section's requirements apply. The Annotation Protocol is a use of the Linked Data Platform [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] specification, with some additional constraints derived from the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].
+      If the Annotation Server supports the management of Annotations, including one or more of creating, updating, and deleting them, then the following section's requirements apply. The Annotation Protocol is a use of the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] specification, with some additional constraints derived from the Web Annotation Data Model [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>].
     </p>
 
-    <p>An Annotation Server <em title="MUST" class="rfc2119">MUST</em> provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] (a service for managing Annotations) and an OrderedCollection [<cite><a href="#bib-activitystreams-core" class="bibref">activitystreams-core</a></cite>] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.</p>
+    <p>An Annotation Server <em class="rfc2119" title="MUST">MUST</em> provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] (a service for managing Annotations) and an OrderedCollection [<cite><a class="bibref" href="#bib-activitystreams-core">activitystreams-core</a></cite>] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.</p>
     <p>
 
     </p>
     <p>
-      Annotation Containers <em title="SHOULD" class="rfc2119">SHOULD</em> implement the LDP Basic Container specification, but <em title="MAY" class="rfc2119">MAY</em> instead implement another type of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers <em title="MAY" class="rfc2119">MAY</em> have any IRI, but it <em title="MUST" class="rfc2119">MUST</em> end in a <code>"/"</code> character.
+      Annotation Containers <em class="rfc2119" title="SHOULD">SHOULD</em> implement the LDP Basic Container specification, but <em class="rfc2119" title="MAY">MAY</em> instead implement another type of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers <em class="rfc2119" title="MAY">MAY</em> have any IRI, but it <em class="rfc2119" title="MUST">MUST</em> end in a <code>"/"</code> character.
     </p>
 
-    <p>Implementations <em title="SHOULD" class="rfc2119">SHOULD</em> use HTTPS rather than HTTP for all interactions with Annotation Containers.</p>
+    <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> use HTTPS rather than HTTP for all interactions with Annotation Containers.</p>
 
     <p>
-      The creation, management, and structure of Annotation Containers are beyond the scope of this specification. Please see the Linked Data Platform specification [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] for additional information.
+      The creation, management, and structure of Annotation Containers are beyond the scope of this specification. Please see the Linked Data Platform specification [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>] for additional information.
     </p>
 
-    <section property="bibo:hasPart" resource="#container-retrieval" typeof="bibo:Chapter" id="container-retrieval">
-      <h3 resource="#h-container-retrieval" id="h-container-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Container Retrieval</span></h3>
+    <section id="container-retrieval" typeof="bibo:Chapter" resource="#container-retrieval" property="bibo:hasPart">
+      <h3 id="h-container-retrieval" resource="#h-container-retrieval"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Container Retrieval</span></h3>
 
       <p>
-        The Annotation Server <em title="MUST" class="rfc2119">MUST</em> support the following HTTP methods on the Annotation Container's IRI:
+        The Annotation Server <em class="rfc2119" title="MUST">MUST</em> support the following HTTP methods on the Annotation Container's IRI:
       </p>
 
       <ul>
         <li><code>GET</code> (retrieve the description of the Container and the list of its contents, described below), </li>
         <li><code>HEAD</code> (retrieve the headers of the Container without an entity-body),</li>
-        <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a href="#bib-cors" class="bibref">cors</a></cite>]).</li>
+        <li><code>OPTIONS</code> (enable CORS pre-flight requests [<cite><a class="bibref" href="#bib-cors">cors</a></cite>]).</li>
       </ul>
       <!-- LDP -->
 
       <p>
-        When an HTTP GET request is issued against the Annotation Container, the server <em title="MUST" class="rfc2119">MUST</em> return a description of the container. That description <em title="MUST" class="rfc2119">MUST</em> be available in JSON-LD, <em title="SHOULD" class="rfc2119">SHOULD</em> be available in Turtle, and <em title="MAY" class="rfc2119">MAY</em> be available in other formats. The JSON-LD serialization of the Container's description <em title="SHOULD" class="rfc2119">SHOULD</em> use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>], unless the request would determine otherwise.
+        When an HTTP GET request is issued against the Annotation Container, the server <em class="rfc2119" title="MUST">MUST</em> return a description of the container. That description <em class="rfc2119" title="MUST">MUST</em> be available in JSON-LD, <em class="rfc2119" title="SHOULD">SHOULD</em> be available in Turtle, and <em class="rfc2119" title="MAY">MAY</em> be available in other formats. The JSON-LD serialization of the Container's description <em class="rfc2119" title="SHOULD">SHOULD</em> use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>], unless the request would determine otherwise.
       </p>
 
-      <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences.</p>
+      <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences.</p>
 
       <p>
-        All supported methods for interacting with the Annotation Container <em title="SHOULD" class="rfc2119">SHOULD</em> be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's IRI
-        <!-- LDP -->. The <code>Allow</code> header <em title="MAY" class="rfc2119">MAY</em> also be included on any other responses.</p>
+        All supported methods for interacting with the Annotation Container <em class="rfc2119" title="SHOULD">SHOULD</em> be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's IRI
+        <!-- LDP -->. The <code>Allow</code> header <em class="rfc2119" title="MAY">MAY</em> also be included on any other responses.</p>
 
-      <p>Annotation Containers <em title="MUST" class="rfc2119">MUST</em> return a <code>Link</code> header [<cite><a href="#bib-rfc5988" class="bibref">rfc5988</a></cite>] on all responses with the following components:
+      <p>Annotation Containers <em class="rfc2119" title="MUST">MUST</em> return a <code>Link</code> header [<cite><a class="bibref" href="#bib-rfc5988">rfc5988</a></cite>] on all responses with the following components:
       </p>
       <ul>
-        <li>It <em title="MUST" class="rfc2119">MUST</em> advertise its type by including a link where the <code>rel</code> parameter value is <code>type</code> and the target IRI is the appropriate Container Type, such as <code>http://www.w3.org/ns/ldp#BasicContainer</code> for Basic Containers.</li>
-        <li>It <em title="MUST" class="rfc2119">MUST</em> advertise that it imposes Annotation protocol specific constraints by including a link where the target IRI is <code>http://www.w3.org/TR/annotation-protocol/</code>, and the <code>rel</code> parameter value is the IRI <code>http://www.w3.org/ns/ldp#constrainedBy</code>.</li>
+        <li>It <em class="rfc2119" title="MUST">MUST</em> advertise its type by including a link where the <code>rel</code> parameter value is <code>type</code> and the target IRI is the appropriate Container Type, such as <code>http://www.w3.org/ns/ldp#BasicContainer</code> for Basic Containers.</li>
+        <li>It <em class="rfc2119" title="MUST">MUST</em> advertise that it imposes Annotation protocol specific constraints by including a link where the target IRI is <code>http://www.w3.org/TR/annotation-protocol/</code>, and the <code>rel</code> parameter value is the IRI <code>http://www.w3.org/ns/ldp#constrainedBy</code>.</li>
       </ul>
       <p></p>
 
       <p>
-        All HTTP responses from Annotation Containers <em title="MUST" class="rfc2119">MUST</em> include an <code>ETag</code> header that implements the notion of entity tags from HTTP [<cite><a href="#bib-rfc7230" class="bibref">rfc7230</a></cite>]. This value will be used by administrative clients when updating the container by including it in an <code>If-Match</code> request header in the same way as clients wanting to update an Annotation.</p>
+        All HTTP responses from Annotation Containers <em class="rfc2119" title="MUST">MUST</em> include an <code>ETag</code> header that implements the notion of entity tags from HTTP [<cite><a class="bibref" href="#bib-rfc7230">rfc7230</a></cite>]. This value will be used by administrative clients when updating the container by including it in an <code>If-Match</code> request header in the same way as clients wanting to update an Annotation.</p>
 
       <p>
-        If the <code>Accept</code> header is absent from the request, then Annotation Servers <em title="MUST" class="rfc2119">MUST</em> respond with a JSON-LD representation of the Annotation Container, however clients with a preference for JSON-LD <em title="SHOULD" class="rfc2119">SHOULD</em> explicitly request it using an <code>Accept</code> request header.
+        If the <code>Accept</code> header is absent from the request, then Annotation Servers <em class="rfc2119" title="MUST">MUST</em> respond with a JSON-LD representation of the Annotation Container, however clients with a preference for JSON-LD <em class="rfc2119" title="SHOULD">SHOULD</em> explicitly request it using an <code>Accept</code> request header.
       </p>
 
       <p>
-        If the server supports content negotiation by format or JSON-LD profile, the response from the Annotation Container <em title="MUST" class="rfc2119">MUST</em> have a <code>Vary</code> header that includes <code>Accept</code> in the value to ensure that caches can determine that the representation will change based on the value of this header in requests.</p>
+        If the server supports content negotiation by format or JSON-LD profile, the response from the Annotation Container <em class="rfc2119" title="MUST">MUST</em> have a <code>Vary</code> header that includes <code>Accept</code> in the value to ensure that caches can determine that the representation will change based on the value of this header in requests.</p>
 
-      <p>Responses from Annotation Containers that support the use of the POST method to create Annotations <em title="SHOULD" class="rfc2119">SHOULD</em> include an <code>Accept-Post</code> header on responses to GET, HEAD and OPTIONS requests. The value is a comma separated list of media-types that are acceptable for the client to send via POST [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>].</p>
+      <p>Responses from Annotation Containers that support the use of the POST method to create Annotations <em class="rfc2119" title="SHOULD">SHOULD</em> include an <code>Accept-Post</code> header on responses to GET, HEAD and OPTIONS requests. The value is a comma separated list of media-types that are acceptable for the client to send via POST [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>].</p>
 
       <div>
         <div class="example">
@@ -777,41 +781,42 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
     </section>
 
-    <section property="bibo:hasPart" resource="#container-representations" typeof="bibo:Chapter" id="container-representations">
-      <h3 resource="#h-container-representations" id="h-container-representations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Container Representations</span></h3>
+    <section id="container-representations" typeof="bibo:Chapter" resource="#container-representations" property="bibo:hasPart">
+      <h3 id="h-container-representations" resource="#h-container-representations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Container Representations</span></h3>
 
       <p>As there are likely to be many Annotations in a single Container, the Annotation Protocol adopts the ActivityStreams <a href="https://www.w3.org/TR/activitystreams-core/#collections">paging mechanism</a> for returning the contents of the Container. Each page contains an ordered list with a subset of the managed Annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container. The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages. The feature or features by which the Annotations are sorted are not explicit in the response.</p>
 
-      <p>If there are greater than zero Annotations in the Container, he representation <em title="MUST" class="rfc2119">MUST</em> either include a link to the first page of Annotations as the value of the <code>first</code> property, or include the representation of the first page embedded within the response. If there is more than one page of Annotations, then the representation <em title="SHOULD" class="rfc2119">SHOULD</em> have a link to the last page using the <code>last</code> property.</p>
+      <p>If there are greater than zero Annotations in the Container, the representation <em class="rfc2119" title="MUST">MUST</em> either include a link to the first page of Annotations as the value of the <code>first</code> property, or include the representation of the first page embedded within the response. If there is more than one page of Annotations, then the representation <em class="rfc2119" title="SHOULD">SHOULD</em> have a link to the last page using the <code>last</code> property.</p>
 
-      <p>The representation of the Container <em title="SHOULD" class="rfc2119">SHOULD</em> include the <code>total</code> property with the total number of annotations in the Container.</p>
+      <p>The representation of the Container <em class="rfc2119" title="SHOULD">SHOULD</em> include the <code>total</code> property with the total number of annotations in the Container.</p>
 
-      <p>The IRI of the Container provided in the response <em title="SHOULD" class="rfc2119">SHOULD</em> differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations. It is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> that this be done with a query parameter. The server <em title="MAY" class="rfc2119">MAY</em> redirect the client to this IRI and deliver the response there, otherwise it <em title="MUST" class="rfc2119">MUST</em> include a <code>Content-Location</code> header with the IRI as its value.</p>
+      <p>The IRI of the Container provided in the response <em class="rfc2119" title="SHOULD">SHOULD</em> differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations. It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that this be done with a query parameter. The server <em class="rfc2119" title="MAY">MAY</em> redirect the client to this IRI and deliver the response there, otherwise it <em class="rfc2119" title="MUST">MUST</em> include a <code>Content-Location</code> header with the IRI as its value.</p>
 
-      <section property="bibo:hasPart" resource="#client-representation-preferences" typeof="bibo:Chapter" id="client-representation-preferences">
-        <h4 resource="#h-client-representation-preferences" id="h-client-representation-preferences"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.1 </span>Client Representation Preferences</span></h4>
+      <section id="container-representation-preferences" typeof="bibo:Chapter" resource="#container-representation-preferences" property="bibo:hasPart">
+        <h4 id="h-container-representation-preferences" resource="#h-container-representation-preferences"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.1 </span>Container Representation Preferences</span></h4>
 
         <p>
-          There are three preferences for the request that will govern the representation in the server's responses:</p>
+          There are three preferences for Container requests that will govern the representation of the server's responses:</p>
 
         <ol>
-          <li>If the client prefers to only receive the Container description and no Annotations in the current response, then it <em title="MUST" class="rfc2119">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
-          <li>If the client prefers to receive the list of Annotations only as IRIs, either in the current or future paged responses, then it <em title="MUST" class="rfc2119">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
-          <li>If the client prefers to receive complete Annotation descriptions, either in the current or future paged responses, then it <em title="MUST" class="rfc2119">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
+          <li>If the client prefers to only receive the Container description and no Annotations in the Container response, then it <em class="rfc2119" title="MUST">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
+          <li>If the client prefers to receive the list of Annotations only as IRIs, either in the current Container response or future paged responses, then it <em class="rfc2119" title="MUST">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
+          <li>If the client prefers to receive complete Annotation descriptions, either in the current Container response or future paged responses, then it <em class="rfc2119" title="MUST">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
         </ol>
 
-        <p>The client <em title="MUST NOT" class="rfc2119">MUST NOT</em> include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server <em title="MAY" class="rfc2119">MAY</em> respond with the first page of Annotations embedded within the Container response or it <em title="MAY" class="rfc2119">MAY</em> provide links to the first and last pages. If no preference is given by the client, the server <em title="SHOULD" class="rfc2119">SHOULD</em> default to the <code>PreferContainedDescriptions</code> behavior. The server <em title="MAY" class="rfc2119">MAY</em> ignore the client's preferences.</p>
+        <p>The client <em class="rfc2119" title="MAY">MAY</em> send multiple preferences. The client <em class="rfc2119" title="MUST NOT">MUST NOT</em> include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server <em class="rfc2119" title="MAY">MAY</em> respond with the first page of Annotations embedded within the Container response or it <em class="rfc2119" title="MAY">MAY</em> provide links to the first and last pages. If no preference is given by the client, the server <em class="rfc2119" title="SHOULD">SHOULD</em> default to the <code>PreferContainedDescriptions</code> behavior. The server <em class="rfc2119" title="MAY">MAY</em> ignore the client's preferences.</p>
 
       </section>
 
 
-      <section property="bibo:hasPart" resource="#representations-without-annotations" typeof="bibo:Chapter" id="representations-without-annotations">
-        <h4 resource="#h-representations-without-annotations" id="h-representations-without-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.2 </span>Representations without Annotations</span></h4>
+      <section id="representations-without-annotations" typeof="bibo:Chapter" resource="#representations-without-annotations" property="bibo:hasPart">
+        <h4 id="h-representations-without-annotations" resource="#h-representations-without-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.2 </span>Representations without Annotations</span></h4>
 
-        <p>If the client requested the minimal representation of the Annotation Container, the response <em title="MUST NOT" class="rfc2119">MUST NOT</em> include either the <code>ldp:contains</code> predicate or the first page of Annotations embedded within the response. The linked pages <em title="SHOULD" class="rfc2119">SHOULD</em> follow any preference provided for whether they include only the IRIs or the full descriptions of the Annotations.
-        </p>
+        <p>If the client requests the minimal representation of an Annotation Container, the response <em class="rfc2119" title="MUST NOT">MUST NOT</em> include either the <code>ldp:contains</code> predicate nor embed the first page of Annotations within the response.</p>
 
-        <p>The server <em title="MAY" class="rfc2119">MAY</em> return a representation without embedded Annotations, even if the <code>PreferMinimalContainer</code> preference is not supplied.</p>
+        <p>The linked pages <em class="rfc2119" title="SHOULD">SHOULD</em> follow any <code>PreferContainedDescriptions</code> or <code>PreferContainedIRIs</code> preferences.</p>
+
+        <p>The server <em class="rfc2119" title="MAY">MAY</em> return a representation without embedded Annotations, even if the <code>PreferMinimalContainer</code> preference is not supplied.</p>
 
         <div>
 
@@ -849,11 +854,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </div>
       </section>
 
-      <section property="bibo:hasPart" resource="#representations-with-annotation-iris" typeof="bibo:Chapter" id="representations-with-annotation-iris">
+      <section id="representations-with-annotation-iris" typeof="bibo:Chapter" resource="#representations-with-annotation-iris" property="bibo:hasPart">
 
-        <h4 resource="#h-representations-with-annotation-iris" id="h-representations-with-annotation-iris"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.3 </span>Representations with Annotation IRIs</span></h4>
+        <h4 id="h-representations-with-annotation-iris" resource="#h-representations-with-annotation-iris"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.3 </span>Representations with Annotation IRIs</span></h4>
 
-        <p></p>
+        <p>If the Server supports Container preferences, it <em class="rfc2119" title="MUST">MUST</em> respond to <code>PreferContainedIRIs</code> with a response containing an
+          <cocde>AnnotationPage as the value of <code>first</code> with its <code>items</code> containing only the IRIs of the contained Annotations.</cocde>
+        </p>
+
+        <p>The linked pages <em class="rfc2119" title="SHOULD">SHOULD</em> follow the <code>PreferContainedIRIs</code> preference.</p>
+
+        <p>The <code>PreferContainedIRIs</code> and the <code>PreferContainedDescriptions</code> preferences are mutually exclusive.</p>
 
         <div>
           Request for embedded IRIs:
@@ -904,10 +915,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </div>
       </section>
 
-      <section property="bibo:hasPart" resource="#representations-with-annotation-descriptions" typeof="bibo:Chapter" id="representations-with-annotation-descriptions">
-        <h4 resource="#h-representations-with-annotation-descriptions" id="h-representations-with-annotation-descriptions"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.4 </span>Representations with Annotation Descriptions</span></h4>
-        <p></p>
+      <section id="representations-with-annotation-descriptions" typeof="bibo:Chapter" resource="#representations-with-annotation-descriptions" property="bibo:hasPart">
+        <h4 id="h-representations-with-annotation-descriptions" resource="#h-representations-with-annotation-descriptions"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.4 </span>Representations with Annotation Descriptions</span></h4>
 
+        <p>If the Server supports Container preferences, it <em class="rfc2119" title="MUST">MUST</em> respond to <code>PreferContainedDescriptions</code> with a response containing an <code>AnnotationPage</code> as the value of <code>first</code> with its <code>items</code> containing complete, inline Annotations.</p>
+
+        <p>The linked pages <em class="rfc2119" title="SHOULD">SHOULD</em> follow the <code>PreferContainedDescriptions</code> preference.</p>
+
+        <p>The <code>PreferContainedIRIs</code> and the <code>PreferContainedDescriptions</code> preferences are mutually exclusive.</p>
 
         Request for embedded descriptions:
 
@@ -968,16 +983,16 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </section>
     </section>
 
-    <section property="bibo:hasPart" resource="#annotation-pages" typeof="bibo:Chapter" id="annotation-pages">
-      <h3 resource="#h-annotation-pages" id="h-annotation-pages"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3 </span>Annotation Pages</span></h3>
+    <section id="annotation-pages" typeof="bibo:Chapter" resource="#annotation-pages" property="bibo:hasPart">
+      <h3 id="h-annotation-pages" resource="#h-annotation-pages"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3 </span>Annotation Pages</span></h3>
       <p>
         Individual pages are instances of <code>CollectionPage</code>. The page contains the Annotations, either via their IRIs or full descriptions, in the <code>items</code> property.</p>
 
-      <p>Each page <em title="MUST" class="rfc2119">MUST</em> have a link to the container that it is part of, using the <code>partOf</code> property. If it is not the first page, it <em title="MUST" class="rfc2119">MUST</em> have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it <em title="MUST" class="rfc2119">MUST</em> have a link to the next page in the sequence, using the <code>next</code> property. The response <em title="MAY" class="rfc2119">MAY</em> include properties of the Collection in the response, including the total number of items or first and last page links.
+      <p>Each page <em class="rfc2119" title="MUST">MUST</em> have a link to the container that it is part of, using the <code>partOf</code> property. If it is not the first page, it <em class="rfc2119" title="MUST">MUST</em> have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it <em class="rfc2119" title="MUST">MUST</em> have a link to the next page in the sequence, using the <code>next</code> property. The response <em class="rfc2119" title="MAY">MAY</em> include properties of the Collection in the response, including the total number of items or first and last page links.
       </p>
 
       <p>
-        The client <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> send the <code>Prefer</code> header when requesting the page, as it has already been taken into account when requesting the Container.
+        The client <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> send the <code>Prefer</code> header when requesting the page, as it has already been taken into account when requesting the Container.
       </p>
 
       <p>This specification does not require any particular functionality when a client makes requests other than GET, HEAD or OPTIONS to a page.</p>
@@ -1073,14 +1088,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </div>
     </section>
 
-    <section property="bibo:hasPart" resource="#discovery-of-annotation-containers" typeof="bibo:Chapter" id="discovery-of-annotation-containers">
-      <h3 resource="#h-discovery-of-annotation-containers" id="h-discovery-of-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.4 </span>Discovery of Annotation Containers</span></h3>
+    <section id="discovery-of-annotation-containers" typeof="bibo:Chapter" resource="#discovery-of-annotation-containers" property="bibo:hasPart">
+      <h3 id="h-discovery-of-annotation-containers" resource="#h-discovery-of-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.4 </span>Discovery of Annotation Containers</span></h3>
 
-      <p>As the IRI for Annotation Containers <em title="MAY" class="rfc2119">MAY</em> be any IRI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
+      <p>As the IRI for Annotation Containers <em class="rfc2119" title="MAY">MAY</em> be any IRI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
 
-      <p>Any resource <em title="MAY" class="rfc2119">MAY</em> link to an Annotation Container when Annotations on the resource <em title="SHOULD" class="rfc2119">SHOULD</em> be created within the referenced Container. This link is carried in an HTTP <code>Link</code> header and the value of the <code>rel</code> parameter <em title="MUST" class="rfc2119">MUST</em> be <code>http://www.w3.org/ns/oa#annotationService</code>.</p>
+      <p>Any resource <em class="rfc2119" title="MAY">MAY</em> link to an Annotation Container when Annotations on the resource <em class="rfc2119" title="SHOULD">SHOULD</em> be created within the referenced Container. This link is carried in an HTTP <code>Link</code> header and the value of the <code>rel</code> parameter <em class="rfc2119" title="MUST">MUST</em> be <code>http://www.w3.org/ns/oa#annotationService</code>.</p>
 
-      <p>For HTML representations of resources, the equivalent <code>link</code> tag in the header of the document <em title="MAY" class="rfc2119">MAY</em> also be used.</p>
+      <p>For HTML representations of resources, the equivalent <code>link</code> tag in the header of the document <em class="rfc2119" title="MAY">MAY</em> also be used.</p>
 
       <div>
         <p>For an example image resource, a GET request and response with a link to the above Annotation Container might look like:</p>
@@ -1104,23 +1119,23 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </section>
   <!-- End of Containers -->
 
-  <section property="bibo:hasPart" resource="#creation-updating-and-deletion-of-annotations" typeof="bibo:Chapter" id="creation-updating-and-deletion-of-annotations">
+  <section id="creation-updating-and-deletion-of-annotations" typeof="bibo:Chapter" resource="#creation-updating-and-deletion-of-annotations" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-creation-updating-and-deletion-of-annotations" id="h-creation-updating-and-deletion-of-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</span></h2>
+    <h2 id="h-creation-updating-and-deletion-of-annotations" resource="#h-creation-updating-and-deletion-of-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</span></h2>
 
-    <section property="bibo:hasPart" resource="#create-a-new-annotation" typeof="bibo:Chapter" id="create-a-new-annotation">
-      <h3 resource="#h-create-a-new-annotation" id="h-create-a-new-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Create a New Annotation</span></h3>
+    <section id="create-a-new-annotation" typeof="bibo:Chapter" resource="#create-a-new-annotation" property="bibo:hasPart">
+      <h3 id="h-create-a-new-annotation" resource="#h-create-a-new-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.1 </span>Create a New Annotation</span></h3>
 
-      <p>New Annotations are created via a POST request to an Annotation Container. The Annotation, serialized as JSON-LD, is sent in the body of the request. All of the known information about the Annotation <em title="SHOULD" class="rfc2119">SHOULD</em> be sent, and if there are already IRIs associated with the resources, they <em title="SHOULD" class="rfc2119">SHOULD</em> be included. The serialization <em title="SHOULD" class="rfc2119">SHOULD</em> use the Web Annotation JSON-LD profile, and servers <em title="MAY" class="rfc2119">MAY</em> reject other contexts even if they would otherwise produce the same model. The server <em title="MAY" class="rfc2119">MAY</em> reject content that is not considered an Annotation according to the Web Annotation specification [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].</p>
+      <p>New Annotations are created via a POST request to an Annotation Container. The Annotation, serialized as JSON-LD, is sent in the body of the request. All of the known information about the Annotation <em class="rfc2119" title="SHOULD">SHOULD</em> be sent, and if there are already IRIs associated with the resources, they <em class="rfc2119" title="SHOULD">SHOULD</em> be included. The serialization <em class="rfc2119" title="SHOULD">SHOULD</em> use the Web Annotation JSON-LD profile, and servers <em class="rfc2119" title="MAY">MAY</em> reject other contexts even if they would otherwise produce the same model. The server <em class="rfc2119" title="MAY">MAY</em> reject content that is not considered an Annotation according to the Web Annotation specification [<cite><a class="bibref" href="#bib-annotation-model">annotation-model</a></cite>].</p>
 
-      <p>Upon receipt of an Annotation, the server <em title="MAY" class="rfc2119">MAY</em> assign IRIs to any resource or blank node in the Annotation, and <em title="MUST" class="rfc2119">MUST</em> assign an IRI to the Annotation resource in the <code>id</code> property, even if it already has one provided. The server <em title="SHOULD" class="rfc2119">SHOULD</em> use HTTPS IRIs when those resources are able to be retrieved individually. The IRI for the Annotation <em title="MUST" class="rfc2119">MUST</em> be the IRI of the Container with an additional component added to the end.
+      <p>Upon receipt of an Annotation, the server <em class="rfc2119" title="MAY">MAY</em> assign IRIs to any resource or blank node in the Annotation, and <em class="rfc2119" title="MUST">MUST</em> assign an IRI to the Annotation resource in the <code>id</code> property, even if it already has one provided. The server <em class="rfc2119" title="SHOULD">SHOULD</em> use HTTPS IRIs when those resources are able to be retrieved individually. The IRI for the Annotation <em class="rfc2119" title="MUST">MUST</em> be the IRI of the Container with an additional component added to the end.
       </p>
 
-      <p>The server <em title="MAY" class="rfc2119">MAY</em> add information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, or additional types and formats of the constituent resources.</p>
+      <p>The server <em class="rfc2119" title="MAY">MAY</em> add information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, or additional types and formats of the constituent resources.</p>
 
-      <p>If the Annotation contains a <code>canonical</code> link, then it <em title="MUST" class="rfc2119">MUST</em> be maintained without change. If the Annotation has an IRI in the <code>id</code> property, then it <em title="SHOULD" class="rfc2119">SHOULD</em> be copied to the <code>via</code> property, and the IRI assigned by the server, at which the Annotation will be available, <em title="MUST" class="rfc2119">MUST</em> be put in the <code>id</code> field to replace it.</p>
+      <p>If the Annotation contains a <code>canonical</code> link, then it <em class="rfc2119" title="MUST">MUST</em> be maintained without change. If the Annotation has an IRI in the <code>id</code> property, then it <em class="rfc2119" title="SHOULD">SHOULD</em> be copied to the <code>via</code> property, and the IRI assigned by the server, at which the Annotation will be available, <em class="rfc2119" title="MUST">MUST</em> be put in the <code>id</code> field to replace it.</p>
 
-      <p>The server <em title="MUST" class="rfc2119">MUST</em> respond with a <code>201</code> Created response if the creation is successful, and an appropriate error code otherwise. The response <em title="MUST" class="rfc2119">MUST</em> have a <code>Location</code> header with the Annotation's new IRI.</p>
+      <p>The server <em class="rfc2119" title="MUST">MUST</em> respond with a <code>201</code> Created response if the creation is successful, and an appropriate error code otherwise. The response <em class="rfc2119" title="MUST">MUST</em> have a <code>Location</code> header with the Annotation's new IRI.</p>
 
       <div>
         Request:
@@ -1164,9 +1179,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </div>
     </section>
 
-    <section property="bibo:hasPart" resource="#suggesting-an-iri-for-an-annotation" typeof="bibo:Chapter" id="suggesting-an-iri-for-an-annotation">
-      <h3 resource="#h-suggesting-an-iri-for-an-annotation" id="h-suggesting-an-iri-for-an-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</span></h3>
-      <p>The IRI path segment that is appended to the Container IRI for a resource <em title="MAY" class="rfc2119">MAY</em> be suggested by the Annotation Client by using the <code>Slug</code> HTTP header on the request when the resource is created. The server <em title="SHOULD" class="rfc2119">SHOULD</em> use this name, so long as it does not already identify an existing resource, but <em title="MAY" class="rfc2119">MAY</em> ignore it and use an automatically assigned name. </p>
+    <section id="suggesting-an-iri-for-an-annotation" typeof="bibo:Chapter" resource="#suggesting-an-iri-for-an-annotation" property="bibo:hasPart">
+      <h3 id="h-suggesting-an-iri-for-an-annotation" resource="#h-suggesting-an-iri-for-an-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</span></h3>
+      <p>The IRI path segment that is appended to the Container IRI for a resource <em class="rfc2119" title="MAY">MAY</em> be suggested by the Annotation Client by using the <code>Slug</code> HTTP header on the request when the resource is created. The server <em class="rfc2119" title="SHOULD">SHOULD</em> use this name, so long as it does not already identify an existing resource, but <em class="rfc2119" title="MAY">MAY</em> ignore it and use an automatically assigned name. </p>
 
       <div>
         Request:
@@ -1214,17 +1229,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     </section>
 
 
-    <section property="bibo:hasPart" resource="#update-an-existing-annotation" typeof="bibo:Chapter" id="update-an-existing-annotation">
-      <h3 resource="#h-update-an-existing-annotation" id="h-update-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.3 </span>Update an Existing Annotation</span></h3>
+    <section id="update-an-existing-annotation" typeof="bibo:Chapter" resource="#update-an-existing-annotation" property="bibo:hasPart">
+      <h3 id="h-update-an-existing-annotation" resource="#h-update-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.3 </span>Update an Existing Annotation</span></h3>
 
-      <p>Annotations can be updated by using a PUT request to replace the entire state of the Annotation. Annotation Servers <em title="SHOULD" class="rfc2119">SHOULD</em> support this method. Servers <em title="MAY" class="rfc2119">MAY</em> also support using a PATCH request to update only the aspects of the Annotation that have changed, but that functionality is not specified in this document.
+      <p>Annotations can be updated by using a PUT request to replace the entire state of the Annotation. Annotation Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support this method. Servers <em class="rfc2119" title="MAY">MAY</em> also support using a PATCH request to update only the aspects of the Annotation that have changed, but that functionality is not specified in this document.
       </p>
 
-      <p>Replacing the Annotation with a new state <em title="MUST" class="rfc2119">MUST</em> be done with the PUT method, where the body of the request is the intended new state of the Annotation. The client <em title="SHOULD" class="rfc2119">SHOULD</em> use the <code>If-Match</code> header with a value of the ETag it received from the server before the editing process began, to avoid collisions of multiple users modifying the same Annotation at the same time.</p>
+      <p>Replacing the Annotation with a new state <em class="rfc2119" title="MUST">MUST</em> be done with the PUT method, where the body of the request is the intended new state of the Annotation. The client <em class="rfc2119" title="SHOULD">SHOULD</em> use the <code>If-Match</code> header with a value of the ETag it received from the server before the editing process began, to avoid collisions of multiple users modifying the same Annotation at the same time.</p>
 
-      <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> reject update requests that modify the values of the <code>canonical</code> or <code>via</code> properties, if they have been already set.</p>
+      <p>Servers <em class="rfc2119" title="SHOULD">SHOULD</em> reject update requests that modify the values of the <code>canonical</code> or <code>via</code> properties, if they have been already set.</p>
 
-      <p>If successful, the server <em title="MUST" class="rfc2119">MUST</em> return a 200 OK status with the Annotation as the body according to the content-type requested. As with creation, the server <em title="MUST" class="rfc2119">MUST</em> return the new state of the Annotation in the response.</p>
+      <p>If successful, the server <em class="rfc2119" title="MUST">MUST</em> return a 200 OK status with the Annotation as the body according to the content-type requested. As with creation, the server <em class="rfc2119" title="MUST">MUST</em> return the new state of the Annotation in the response.</p>
 
 
       <div>
@@ -1276,14 +1291,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     </section>
 
 
-    <section property="bibo:hasPart" resource="#delete-an-existing-annotation" typeof="bibo:Chapter" id="delete-an-existing-annotation">
-      <h3 resource="#h-delete-an-existing-annotation" id="h-delete-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.4 </span>Delete an Existing Annotation</span></h3>
+    <section id="delete-an-existing-annotation" typeof="bibo:Chapter" resource="#delete-an-existing-annotation" property="bibo:hasPart">
+      <h3 id="h-delete-an-existing-annotation" resource="#h-delete-an-existing-annotation"><span property="xhv:role" resource="xhv:heading"><span class="secno">5.4 </span>Delete an Existing Annotation</span></h3>
 
-      <p>Clients <em title="MUST" class="rfc2119">MUST</em> use the DELETE HTTP method to request that an Annotation be deleted by the server. Annotation Servers <em title="SHOULD" class="rfc2119">SHOULD</em> support this method. Clients <em title="SHOULD" class="rfc2119">SHOULD</em> send the ETag of the Annotation in the <code>If-Match</code> header to ensure that it is operating against the most recent version of the Annotation.</p>
+      <p>Clients <em class="rfc2119" title="MUST">MUST</em> use the DELETE HTTP method to request that an Annotation be deleted by the server. Annotation Servers <em class="rfc2119" title="SHOULD">SHOULD</em> support this method. Clients <em class="rfc2119" title="SHOULD">SHOULD</em> send the ETag of the Annotation in the <code>If-Match</code> header to ensure that it is operating against the most recent version of the Annotation.</p>
 
-      <p>If the DELETE request is successfully processed, then the server <em title="MUST" class="rfc2119">MUST</em> return a 204 status response. The IRIs of deleted Annotations <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> be re-used for subsequent Annotations.
-        <!-- LDP -->The IRI of the deleted Annotation <em title="MUST" class="rfc2119">MUST</em> be removed from the Annotation Container it was created in.
-        <!-- LDP -->There are no requirements made on the body of the response, and it <em title="MAY" class="rfc2119">MAY</em> be empty.</p>
+      <p>If the DELETE request is successfully processed, then the server <em class="rfc2119" title="MUST">MUST</em> return a 204 status response. The IRIs of deleted Annotations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be re-used for subsequent Annotations.
+        <!-- LDP -->The IRI of the deleted Annotation <em class="rfc2119" title="MUST">MUST</em> be removed from the Annotation Container it was created in.
+        <!-- LDP -->There are no requirements made on the body of the response, and it <em class="rfc2119" title="MAY">MAY</em> be empty.</p>
 
       <div>
         Request:
@@ -1300,9 +1315,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </section>
 
 
-  <section property="bibo:hasPart" resource="#error-conditions" typeof="bibo:Chapter" id="error-conditions" class="informative">
+  <section class="informative" id="error-conditions" typeof="bibo:Chapter" resource="#error-conditions" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-error-conditions" id="h-error-conditions"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Error Conditions</span></h2>
+    <h2 id="h-error-conditions" resource="#h-error-conditions"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Error Conditions</span></h2>
     <p><em>This section is non-normative.</em></p>
 
     <p>There are inevitably situations where errors occur when retrieving or managing Annotations. The use of the HTTP status codes below provides a method for clients to understand the reason why a request has failed. Some of the situations that might occur, and the preferred HTTP status code are given below. This list is intended to be informative and explanatory, rather than imposing additional requirements beyond those already established by HTTP.</p>
@@ -1358,28 +1373,28 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
   </section>
 
-  <section property="bibo:hasPart" resource="#containers-for-related-resources" typeof="bibo:Chapter" id="containers-for-related-resources">
+  <section id="containers-for-related-resources" typeof="bibo:Chapter" resource="#containers-for-related-resources" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-containers-for-related-resources" id="h-containers-for-related-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Containers for Related Resources</span></h2>
+    <h2 id="h-containers-for-related-resources" resource="#h-containers-for-related-resources"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Containers for Related Resources</span></h2>
 
     <p>Annotations may have related resources that are required for their correct interpretation and rendering, such as content resources used in or as the Body, CSS stylesheets that determine the rendering of the annotation, SVG documents describing a non-rectangular region of a resource, and so forth. If these resources do not already have IRIs, then they need to be made available somewhere so that they can be referred to.</p>
 
-    <p>Annotation Servers <em title="MAY" class="rfc2119">MAY</em> support the management of related resources independently from the Annotations. If a server supports the management of these resources, it <em title="SHOULD" class="rfc2119">SHOULD</em> do this with one or more separate Containers. Resources that are not Annotations <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> be included in an Annotation Container, as Annotation Clients would not expect to find arbitrary content when dereferencing the IRIs.
-      <!-- Additional but insanity reducing constraint -->Containers for related resources <em title="MAY" class="rfc2119">MAY</em> contain both RDF Sources and Non-RDF Sources. No restrictions are placed on the type or configuration of the Container beyond those of the Linked Data Platform [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>].</p>
+    <p>Annotation Servers <em class="rfc2119" title="MAY">MAY</em> support the management of related resources independently from the Annotations. If a server supports the management of these resources, it <em class="rfc2119" title="SHOULD">SHOULD</em> do this with one or more separate Containers. Resources that are not Annotations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be included in an Annotation Container, as Annotation Clients would not expect to find arbitrary content when dereferencing the IRIs.
+      <!-- Additional but insanity reducing constraint -->Containers for related resources <em class="rfc2119" title="MAY">MAY</em> contain both RDF Sources and Non-RDF Sources. No restrictions are placed on the type or configuration of the Container beyond those of the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>].</p>
 
-    <p>Containers for related resources <em title="MUST" class="rfc2119">MUST</em> support the same HTTP methods as described above for the Annotation Container, and <em title="MUST" class="rfc2119">MUST</em> support identifying their type with a <code>Link</code> header. The <code>constrainedBy</code> link header on the response when dereferencing the Container <em title="SHOULD" class="rfc2119">SHOULD</em> refer to a server specific set of constraints listing the types of content that are acceptable.
+    <p>Containers for related resources <em class="rfc2119" title="MUST">MUST</em> support the same HTTP methods as described above for the Annotation Container, and <em class="rfc2119" title="MUST">MUST</em> support identifying their type with a <code>Link</code> header. The <code>constrainedBy</code> link header on the response when dereferencing the Container <em class="rfc2119" title="SHOULD">SHOULD</em> refer to a server specific set of constraints listing the types of content that are acceptable.
       <!-- LDP -->
     </p>
 
   </section>
 
-  <section property="bibo:hasPart" resource="#changed-from-previous-versions" typeof="bibo:Chapter" id="changed-from-previous-versions" class="appendix informative changelog">
+  <section class="appendix informative changelog" id="changed-from-previous-versions" typeof="bibo:Chapter" resource="#changed-from-previous-versions" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-changed-from-previous-versions" id="h-changed-from-previous-versions"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Changed from Previous Versions</span></h2>
+    <h2 id="h-changed-from-previous-versions" resource="#h-changed-from-previous-versions"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Changed from Previous Versions</span></h2>
     <p><em>This section is non-normative.</em></p>
 
-    <section property="bibo:hasPart" resource="#changes-from-the-working-draft-of-2016-03-31" typeof="bibo:Chapter" id="changes-from-the-working-draft-of-2016-03-31">
-      <h3 resource="#h-changes-from-the-working-draft-of-2016-03-31" id="h-changes-from-the-working-draft-of-2016-03-31"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</span></h3>
+    <section id="changes-from-the-working-draft-of-2016-03-31" typeof="bibo:Chapter" resource="#changes-from-the-working-draft-of-2016-03-31" property="bibo:hasPart">
+      <h3 id="h-changes-from-the-working-draft-of-2016-03-31" resource="#h-changes-from-the-working-draft-of-2016-03-31"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</span></h3>
 
       <p>Significant technical changes in this specification from the <a href="https://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">Working Draft Published of 2016-03-31</a> are:</p>
 
@@ -1395,9 +1410,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </section>
 
 
-  <section property="bibo:hasPart" resource="#acknowledgments" typeof="bibo:Chapter" id="acknowledgments" class="appendix">
+  <section class="appendix" id="acknowledgments" typeof="bibo:Chapter" resource="#acknowledgments" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-acknowledgments" id="h-acknowledgments"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>Acknowledgments</span></h2>
+    <h2 id="h-acknowledgments" resource="#h-acknowledgments"><span property="xhv:role" resource="xhv:heading"><span class="secno">B. </span>Acknowledgments</span></h2>
 
     <p>The Web Annotation Working Group gratefully acknowledges the contributions of the <a href="http://www.w3.org/community/openannotation/">Open Annotation Community Group</a>. The <a href="http://www.openannotation.org/spec/core">output</a> of the Community Group was fundamental to the current data model and protocol.
     </p>
@@ -1413,34 +1428,34 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 
 
-  <section property="bibo:hasPart" resource="#references" typeof="bibo:Chapter" id="references" class="appendix">
+  <section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart">
     <!--OddPage-->
-    <h2 resource="#h-references" id="h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>References</span></h2>
+    <h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">C. </span>References</span></h2>
 
-    <section property="bibo:hasPart" resource="#normative-references" typeof="bibo:Chapter" id="normative-references">
-      <h3 resource="#h-normative-references" id="h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">C.1 </span>Normative references</span></h3>
-      <dl resource="" class="bibliography"><dt id="bib-RFC2119">[RFC2119]</dt>
-        <dd>S. Bradner. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+    <section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart">
+      <h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">C.1 </span>Normative references</span></h3>
+      <dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt>
+        <dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
         </dd><dt id="bib-activitystreams-core">[activitystreams-core]</dt>
-        <dd>James Snell; Evan Prodromou. W3C. <a property="dc:requires" href="https://www.w3.org/TR/activitystreams-core/"><cite>Activity Streams 2.0</cite></a>. 31 May 2016. W3C Working Draft. URL: <a property="dc:requires" href="https://www.w3.org/TR/activitystreams-core/">https://www.w3.org/TR/activitystreams-core/</a>
+        <dd>James Snell; Evan Prodromou. W3C. <a href="https://www.w3.org/TR/activitystreams-core/" property="dc:requires"><cite>Activity Streams 2.0</cite></a>. 12 July 2016. W3C Working Draft. URL: <a href="https://www.w3.org/TR/activitystreams-core/" property="dc:requires">https://www.w3.org/TR/activitystreams-core/</a>
         </dd><dt id="bib-annotation-model">[annotation-model]</dt>
-        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/CR-annotation-model-20160705/"><cite>Web Annotation Data Model</cite></a>. W3C Candidate Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/CR-annotation-model-20160705/">http://www.w3.org/TR/2016/CR-annotation-model-20160705/</a>
+        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/CR-annotation-model-20160705/" property="dc:requires"><cite>Web Annotation Data Model</cite></a>. W3C Candidate Recommendation. URL: <a href="http://www.w3.org/TR/2016/CR-annotation-model-20160705/" property="dc:requires">http://www.w3.org/TR/2016/CR-annotation-model-20160705/</a>
         </dd><dt id="bib-annotation-vocab">[annotation-vocab]</dt>
-        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/CR-annotation-vocab-20160705/"><cite>Web Annotation Vocabulary</cite></a>. W3C Candidate Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/CR-annotation-vocab-20160705/">http://www.w3.org/TR/2016/CR-annotation-vocab-20160705/</a>
+        <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a href="http://www.w3.org/TR/2016/CR-annotation-vocab-20160705/" property="dc:requires"><cite>Web Annotation Vocabulary</cite></a>. W3C Candidate Recommendation. URL: <a href="http://www.w3.org/TR/2016/CR-annotation-vocab-20160705/" property="dc:requires">http://www.w3.org/TR/2016/CR-annotation-vocab-20160705/</a>
         </dd><dt id="bib-cors">[cors]</dt>
-        <dd>Anne van Kesteren. W3C. <a property="dc:requires" href="https://www.w3.org/TR/cors/"><cite>Cross-Origin Resource Sharing</cite></a>. 16 January 2014. W3C Recommendation. URL: <a property="dc:requires" href="https://www.w3.org/TR/cors/">https://www.w3.org/TR/cors/</a>
+        <dd>Anne van Kesteren. W3C. <a href="https://www.w3.org/TR/cors/" property="dc:requires"><cite>Cross-Origin Resource Sharing</cite></a>. 16 January 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/cors/" property="dc:requires">https://www.w3.org/TR/cors/</a>
         </dd><dt id="bib-ldp">[ldp]</dt>
-        <dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a property="dc:requires" href="https://www.w3.org/TR/ldp/"><cite>Linked Data Platform 1.0</cite></a>. 26 February 2015. W3C Recommendation. URL: <a property="dc:requires" href="https://www.w3.org/TR/ldp/">https://www.w3.org/TR/ldp/</a>
+        <dd>Steve Speicher; John Arwe; Ashok Malhotra. W3C. <a href="https://www.w3.org/TR/ldp/" property="dc:requires"><cite>Linked Data Platform 1.0</cite></a>. 26 February 2015. W3C Recommendation. URL: <a href="https://www.w3.org/TR/ldp/" property="dc:requires">https://www.w3.org/TR/ldp/</a>
         </dd><dt id="bib-rfc3987">[rfc3987]</dt>
-        <dd>M. Duerst; M. Suignard. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc3987"><cite>Internationalized Resource Identifiers (IRIs)</cite></a>. January 2005. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc3987">https://tools.ietf.org/html/rfc3987</a>
+        <dd>M. Duerst; M. Suignard. IETF. <a href="https://tools.ietf.org/html/rfc3987" property="dc:requires"><cite>Internationalized Resource Identifiers (IRIs)</cite></a>. January 2005. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc3987" property="dc:requires">https://tools.ietf.org/html/rfc3987</a>
         </dd><dt id="bib-rfc5988">[rfc5988]</dt>
-        <dd>M. Nottingham. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc5988">https://tools.ietf.org/html/rfc5988</a>
+        <dd>M. Nottingham. IETF. <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires"><cite>Web Linking</cite></a>. October 2010. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc5988" property="dc:requires">https://tools.ietf.org/html/rfc5988</a>
         </dd><dt id="bib-rfc7230">[rfc7230]</dt>
-        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc7230"><cite>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</cite></a>. June 2014. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc7230">https://tools.ietf.org/html/rfc7230</a>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7230" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7230" property="dc:requires">https://tools.ietf.org/html/rfc7230</a>
         </dd><dt id="bib-rfc7231">[rfc7231]</dt>
-        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc7231"><cite>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</cite></a>. June 2014. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7231" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231" property="dc:requires">https://tools.ietf.org/html/rfc7231</a>
         </dd><dt id="bib-rfc7232">[rfc7232]</dt>
-        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc7232"><cite>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</cite></a>. June 2014. Proposed Standard. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc7232">https://tools.ietf.org/html/rfc7232</a>
+        <dd>R. Fielding, Ed.; J. Reschke, Ed.. IETF. <a href="https://tools.ietf.org/html/rfc7232" property="dc:requires"><cite>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</cite></a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7232" property="dc:requires">https://tools.ietf.org/html/rfc7232</a>
         </dd>
       </dl>
     </section>

--- a/protocol/wd/index.html
+++ b/protocol/wd/index.html
@@ -804,7 +804,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <li>If the client prefers to receive complete Annotation descriptions, either in the current Container response or future paged responses, then it <em class="rfc2119" title="MUST">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
         </ol>
 
-        <p>The client <em class="rfc2119" title="MAY">MAY</em> send multiple preferences. The client <em class="rfc2119" title="MUST NOT">MUST NOT</em> include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server <em class="rfc2119" title="MAY">MAY</em> respond with the first page of Annotations embedded within the Container response or it <em class="rfc2119" title="MAY">MAY</em> provide links to the first and last pages. If no preference is given by the client, the server <em class="rfc2119" title="SHOULD">SHOULD</em> default to the <code>PreferContainedDescriptions</code> behavior. The server <em class="rfc2119" title="MAY">MAY</em> ignore the client's preferences.</p>
+        <p>The client <em class="rfc2119" title="MAY">MAY</em> send multiple preferences as the value of the <code>include</code> parameter as defined by the Linked Data Platform [<cite><a class="bibref" href="#bib-ldp">ldp</a></cite>]. However, the client <em class="rfc2119" title="MUST NOT">MUST NOT</em> include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server <em class="rfc2119" title="MAY">MAY</em> respond with the first page of Annotations embedded within the Container response or it <em class="rfc2119" title="MAY">MAY</em> provide links to the first and last pages. If no preference is given by the client, the server <em class="rfc2119" title="SHOULD">SHOULD</em> default to the <code>PreferContainedDescriptions</code> behavior. The server <em class="rfc2119" title="MAY">MAY</em> ignore the client's preferences.</p>
 
       </section>
 
@@ -825,8 +825,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             <div class="example-title marker"><span>Example 4</span><span style="text-transform: none">: Container Request without Annotations</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
-<span class="hljs-attribute">Prefer</span>: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"
-<span class="hljs-attribute">Prefer</span>: return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</pre></div>
+<span class="hljs-attribute">Prefer</span>: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer http://www.w3.org/ns/oa#PreferContainedIRIs"</pre></div>
 
           Response:
           <div class="example">

--- a/protocol/wd/index.html
+++ b/protocol/wd/index.html
@@ -328,6 +328,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-CR">
   <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
+  <meta name="generator" content="ReSpec 4.4.0">
   <script id="initialUserConfig" type="application/json">
     {
       "specStatus": "CR",
@@ -393,24 +394,24 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </script>
 </head>
 
-<body class="h-entry toc-inline" role="document" id="respecDocument">
+<body class="h-entry" role="document" id="respecDocument">
   <div class="head" role="contentinfo" id="respecHeader">
     <p>
-      <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
+      <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Web Annotation Protocol</h1>
     <h2 id="w3c-candidate-recommendation-12-july-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Candidate Recommendation <time property="dcterms:issued" class="dt-published" datetime="2016-07-12">12 July 2016</time></h2>
     <dl>
       <dt>This version:</dt>
-      <dd><a class="u-url" href="http://www.w3.org/TR/2016/CR-annotation-protocol-20160712/">http://www.w3.org/TR/2016/CR-annotation-protocol-20160712/</a></dd>
+      <dd><a class="u-url" href="https://www.w3.org/TR/2016/CR-annotation-protocol-20160712/">https://www.w3.org/TR/2016/CR-annotation-protocol-20160712/</a></dd>
       <dt>Latest published version:</dt>
-      <dd><a href="http://www.w3.org/TR/annotation-protocol/">http://www.w3.org/TR/annotation-protocol/</a></dd>
+      <dd><a href="https://www.w3.org/TR/annotation-protocol/">https://www.w3.org/TR/annotation-protocol/</a></dd>
       <dt>Latest editor's draft:</dt>
       <dd><a href="http://w3c.github.io/web-annotation/protocol/wd/">http://w3c.github.io/web-annotation/protocol/wd/</a></dd>
       <dt>Implementation report:</dt>
       <dd><a href=" https://w3c.github.io/test-results/annotation-protocol/all.html"> https://w3c.github.io/test-results/annotation-protocol/all.html</a></dd>
       <dt>Previous version:</dt>
-      <dd><a rel="dcterms:replaces" href="http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">http://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a></dd>
+      <dd><a rel="dcterms:replaces" href="https://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">https://www.w3.org/TR/2016/WD-annotation-protocol-20160331/</a></dd>
       <dt>Editor:</dt>
       <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Robert Sanderson</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.stanford.edu/">Stanford University</a>, <span class="ed_mailto"><a class="u-email email" property="foaf:mbox" href="mailto:azaroth42@gmail.com">azaroth42@gmail.com</a></span></span>
         <span property="rdf:rest" resource="rdf:nil"></span>
@@ -424,14 +425,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </dd>
     </dl>
     <p class="copyright">
-      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016
+      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016
 
-      <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-      <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-      <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
-      <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-      <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+      <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+      <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+      <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+      <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
     </p>
     <hr title="Separator for header">
   </div>
@@ -448,7 +449,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   <section id="sotd" class="introductory">
     <h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
     <p>
-      <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
+      <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at https://www.w3.org/TR/.</em>
     </p>
 
     <p>
@@ -459,7 +460,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <p>
       This document was published by the <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> as a Candidate Recommendation. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation. If you wish to make comments regarding this document, please send them to
       <a href="mailto:public-annotation@w3.org">public-annotation@w3.org</a> (<a href="mailto:public-annotation-request@w3.org?subject=subscribe">subscribe</a>,
-      <a href="http://lists.w3.org/Archives/Public/public-annotation/">archives</a>).
+      <a href="https://lists.w3.org/Archives/Public/public-annotation/">archives</a>).
 
       <abbr title="World Wide Web Consortium">W3C</abbr> publishes a Candidate Recommendation to indicate that the document is believed to be stable and to encourage implementation by the developer community. This Candidate Recommendation is expected to advance to Proposed Recommendation no earlier than 30 September 2016. All comments are welcome.
     </p>
@@ -472,69 +473,70 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     </p>
     <p>
       This document was produced by a group operating under the
-      <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+      <a id="sotd_patent" property="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
               Policy</a>.
       <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/73180/status" rel="disclosure">public list of any patent
                 disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains
-      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+      <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
               Claim(s)</a> must disclose the information in accordance with
-      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+      <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
               6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
     </p>
-    <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+    <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
     </p>
 
   </section>
   <nav id="toc">
     <h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
-    <ul class="toc" role="directory">
+    <ol class="toc" role="directory">
       <li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a>
-        <ul class="toc">
+        <ol class="toc">
           <li class="tocline"><a href="#aims-of-the-protocol" class="tocxref"><span class="secno">1.1 </span>Aims of the Protocol</a></li>
           <li class="tocline"><a href="#summary" class="tocxref"><span class="secno">1.2 </span>Summary</a></li>
           <li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">1.3 </span>Conformance</a></li>
           <li class="tocline"><a href="#terminology" class="tocxref"><span class="secno">1.4 </span>Terminology</a></li>
-        </ul>
+        </ol>
       </li>
       <li class="tocline"><a href="#web-annotation-protocol-principles" class="tocxref"><span class="secno">2. </span>Web Annotation Protocol Principles</a></li>
       <li class="tocline"><a href="#annotation-retrieval" class="tocxref"><span class="secno">3. </span>Annotation Retrieval</a></li>
       <li class="tocline"><a href="#annotation-containers" class="tocxref"><span class="secno">4. </span>Annotation Containers</a>
-        <ul class="toc">
+        <ol class="toc">
           <li class="tocline"><a href="#container-retrieval" class="tocxref"><span class="secno">4.1 </span>Container Retrieval</a></li>
           <li class="tocline"><a href="#container-representations" class="tocxref"><span class="secno">4.2 </span>Container Representations</a>
-            <ul class="toc">
+            <ol class="toc">
               <li class="tocline"><a href="#container-representation-preferences" class="tocxref"><span class="secno">4.2.1 </span>Container Representation Preferences</a></li>
               <li class="tocline"><a href="#representations-without-annotations" class="tocxref"><span class="secno">4.2.2 </span>Representations without Annotations</a></li>
               <li class="tocline"><a href="#representations-with-annotation-iris" class="tocxref"><span class="secno">4.2.3 </span>Representations with Annotation IRIs</a></li>
               <li class="tocline"><a href="#representations-with-annotation-descriptions" class="tocxref"><span class="secno">4.2.4 </span>Representations with Annotation Descriptions</a></li>
-            </ul>
+            </ol>
           </li>
           <li class="tocline"><a href="#annotation-pages" class="tocxref"><span class="secno">4.3 </span>Annotation Pages</a></li>
           <li class="tocline"><a href="#discovery-of-annotation-containers" class="tocxref"><span class="secno">4.4 </span>Discovery of Annotation Containers</a></li>
-        </ul>
+        </ol>
       </li>
       <li class="tocline"><a href="#creation-updating-and-deletion-of-annotations" class="tocxref"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</a>
-        <ul class="toc">
+        <ol class="toc">
           <li class="tocline"><a href="#create-a-new-annotation" class="tocxref"><span class="secno">5.1 </span>Create a New Annotation</a></li>
           <li class="tocline"><a href="#suggesting-an-iri-for-an-annotation" class="tocxref"><span class="secno">5.2 </span>Suggesting an IRI for an Annotation</a></li>
           <li class="tocline"><a href="#update-an-existing-annotation" class="tocxref"><span class="secno">5.3 </span>Update an Existing Annotation</a></li>
           <li class="tocline"><a href="#delete-an-existing-annotation" class="tocxref"><span class="secno">5.4 </span>Delete an Existing Annotation</a></li>
-        </ul>
+        </ol>
       </li>
       <li class="tocline"><a href="#error-conditions" class="tocxref"><span class="secno">6. </span>Error Conditions</a></li>
       <li class="tocline"><a href="#containers-for-related-resources" class="tocxref"><span class="secno">7. </span>Containers for Related Resources</a></li>
       <li class="tocline"><a href="#changed-from-previous-versions" class="tocxref"><span class="secno">A. </span>Changed from Previous Versions</a>
-        <ul class="toc">
-          <li class="tocline"><a href="#changes-from-the-working-draft-of-2016-03-31" class="tocxref"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</a></li>
-        </ul>
+        <ol class="toc">
+          <li class="tocline"><a href="#changes-from-the-candidate-recommendation-of-2016-06-12" class="tocxref"><span class="secno">A.1 </span>Changes from the Candidate Recommendation of 2016-06-12</a></li>
+          <li class="tocline"><a href="#changes-from-the-working-draft-of-2016-03-31" class="tocxref"><span class="secno">A.2 </span>Changes from the Working Draft of 2016-03-31</a></li>
+        </ol>
       </li>
       <li class="tocline"><a href="#acknowledgments" class="tocxref"><span class="secno">B. </span>Acknowledgments</a></li>
       <li class="tocline"><a href="#references" class="tocxref"><span class="secno">C. </span>References</a>
-        <ul class="toc">
+        <ol class="toc">
           <li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">C.1 </span>Normative references</a></li>
-        </ul>
+        </ol>
       </li>
-    </ul>
+    </ol>
   </nav>
 
 
@@ -1392,8 +1394,20 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <h2 id="h-changed-from-previous-versions" resource="#h-changed-from-previous-versions"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>Changed from Previous Versions</span></h2>
     <p><em>This section is non-normative.</em></p>
 
+    <section id="changes-from-the-candidate-recommendation-of-2016-06-12" typeof="bibo:Chapter" resource="#changes-from-the-candidate-recommendation-of-2016-06-12" property="bibo:hasPart">
+      <h3 id="h-changes-from-the-candidate-recommendation-of-2016-06-12" resource="#h-changes-from-the-candidate-recommendation-of-2016-06-12"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Changes from the Candidate Recommendation of 2016-06-12</span></h3>
+
+      <p>Significant technical changes in this specification from the <a href="http://www.w3.org/TR/2016/CR-annotation-protocol-20160712/">Candidate Recommendation of 2016-06-12</a> are:</p>
+
+      <ul>
+        <li>Editorial restructuring of the Pagination content.</li>
+        <li>Clarified requirements for Annotation Server's representation preference handling.</li>
+        <li>Explained the proper use of the <code>Prefer</code> header when the client has multiple preferences.</li>
+      </ul>
+    </section>
+
     <section id="changes-from-the-working-draft-of-2016-03-31" typeof="bibo:Chapter" resource="#changes-from-the-working-draft-of-2016-03-31" property="bibo:hasPart">
-      <h3 id="h-changes-from-the-working-draft-of-2016-03-31" resource="#h-changes-from-the-working-draft-of-2016-03-31"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Changes from the Working Draft of 2016-03-31</span></h3>
+      <h3 id="h-changes-from-the-working-draft-of-2016-03-31" resource="#h-changes-from-the-working-draft-of-2016-03-31"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Changes from the Working Draft of 2016-03-31</span></h3>
 
       <p>Significant technical changes in this specification from the <a href="https://www.w3.org/TR/2016/WD-annotation-protocol-20160331/">Working Draft Published of 2016-03-31</a> are:</p>
 

--- a/protocol/wd/index.html
+++ b/protocol/wd/index.html
@@ -496,14 +496,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <li class="tocline"><a class="tocxref" href="#annotation-retrieval"><span class="secno">3. </span>Annotation Retrieval</a></li>
       <li class="tocline"><a class="tocxref" href="#annotation-containers"><span class="secno">4. </span>Annotation Containers</a>
         <ul class="toc">
-          <li class="tocline"><a class="tocxref" href="#container-retrieval"><span class="secno">4.1 </span>Container Retrieval</a>
+          <li class="tocline"><a class="tocxref" href="#container-retrieval"><span class="secno">4.1 </span>Container Retrieval</a></li>
+          <li class="tocline"><a class="tocxref" href="#container-representations"><span class="secno">4.2 </span>Container Representations</a>
             <ul class="toc">
-              <li class="tocline"><a class="tocxref" href="#client-preferences"><span class="secno">4.1.1 </span>Client Preferences</a></li>
-              <li class="tocline"><a class="tocxref" href="#responses-without-annotations"><span class="secno">4.1.2 </span>Responses without Annotations</a></li>
-              <li class="tocline"><a class="tocxref" href="#responses-with-annotations"><span class="secno">4.1.3 </span>Responses with Annotations</a></li>
+              <li class="tocline"><a class="tocxref" href="#client-representation-preferences"><span class="secno">4.2.1 </span>Client Representation Preferences</a></li>
+              <li class="tocline"><a class="tocxref" href="#representations-without-annotations"><span class="secno">4.2.2 </span>Representations without Annotations</a></li>
+              <li class="tocline"><a class="tocxref" href="#representations-with-annotation-iris"><span class="secno">4.2.3 </span>Representations with Annotation IRIs</a></li>
+              <li class="tocline"><a class="tocxref" href="#representations-with-annotation-descriptions"><span class="secno">4.2.4 </span>Representations with Annotation Descriptions</a></li>
             </ul>
           </li>
-          <li class="tocline"><a class="tocxref" href="#discovery-of-annotation-containers"><span class="secno">4.2 </span>Discovery of Annotation Containers</a></li>
+          <li class="tocline"><a class="tocxref" href="#annotation-pages"><span class="secno">4.3 </span>Annotation Pages</a></li>
+          <li class="tocline"><a class="tocxref" href="#discovery-of-annotation-containers"><span class="secno">4.4 </span>Discovery of Annotation Containers</a></li>
         </ul>
       </li>
       <li class="tocline"><a class="tocxref" href="#creation-updating-and-deletion-of-annotations"><span class="secno">5. </span>Creation, Updating and Deletion of Annotations</a>
@@ -573,7 +576,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <p>
         As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
       </p>
-      <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a href="#bib-RFC2119" class="bibref">RFC2119</a></cite>].
+      <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>, <em class="rfc2119" title="SHOULD">SHOULD</em>, and <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> are to be interpreted as described in [<cite><a href="#bib-RFC2119" class="bibref">RFC2119</a></cite>].
       </p>
 
     </section>
@@ -653,15 +656,15 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use the 200 HTTP status code when no errors occurred while processing the request to retrieve an Annotation, and <em title="MAY" class="rfc2119">MAY</em> use 3XX HTTP status codes to redirect to a new location.</p>
 
     <p>The response from the Annotation Server <em title="MUST" class="rfc2119">MUST</em> have a <code>Link</code> header entry
-      <!-- LDP 4.2.1.4 -->where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>. The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> <em title="MAY" class="rfc2119">MAY</em> also be added with the same <code>rel</code> type.</p>
+      <!-- LDP 4.2.1.4 -->where the target IRI is <code>http://www.w3.org/ns/ldp#Resource</code> and the <code>rel</code> parameter value is <code>type</code>. The Annotation type of <code>http://www.w3.org/ns/oa#Annotation</code> <em title="MAY" class="rfc2119">MAY</em> also be added with the same <code>rel</code> type. This is to let client systems know that the retrieved representation is a Resource and an Annotation, even if the client cannot process the representation's format.</p>
 
     <p>The response <em title="MUST" class="rfc2119">MUST</em> have an <code>ETag</code> header
-      <!-- LDP 4.2.1.3 -->with an entity reference value that implements the notion of entity tags from HTTP [<cite><a href="#bib-rfc7232" class="bibref">rfc7232</a></cite>].</p>
+      <!-- LDP 4.2.1.3 -->with an entity reference value that implements the notion of entity tags from HTTP [<cite><a href="#bib-rfc7232" class="bibref">rfc7232</a></cite>]. This value will be used by the client when sending <a href="#update-an-existing-annotation">update</a> or <a href="#delete-an-existing-annotation">delete</a> requests.</p>
 
     <p>The response <em title="MUST" class="rfc2119">MUST</em> have an <code>Allow</code> header
-      <!-- LDP 4.2.8.2 from 4.2.2.2 -->that lists the HTTP methods available for the Annotation [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>].</p>
+      <!-- LDP 4.2.8.2 from 4.2.2.2 -->that lists the HTTP methods available for interacting with the Annotation [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>].</p>
 
-    <p>If the server supports content negotiation by format or JSON-LD profile, the response <em title="MUST" class="rfc2119">MUST</em> have a <code>Vary</code> header with <code>Accept</code> in the value. [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>]
+    <p>If the server supports content negotiation by format or JSON-LD profile, the response <em title="MUST" class="rfc2119">MUST</em> have a <code>Vary</code> header with <code>Accept</code> in the value [<cite><a href="#bib-rfc7231" class="bibref">rfc7231</a></cite>]. This is to ensure that caches understand that the representation changes based on the value of that request header.
       <!-- HTTP + LDP 4.3.2.1 -->
     </p>
 
@@ -704,12 +707,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       If the Annotation Server supports the management of Annotations, including one or more of creating, updating, and deleting them, then the following section's requirements apply. The Annotation Protocol is a use of the Linked Data Platform [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] specification, with some additional constraints derived from the Web Annotation Data Model [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].
     </p>
 
-    <p>An Annotation Server <em title="MUST" class="rfc2119">MUST</em> provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] (a service for managing Annotations) and a Collection [<cite><a href="#bib-activitystreams-core" class="bibref">activitystreams-core</a></cite>] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.</p>
+    <p>An Annotation Server <em title="MUST" class="rfc2119">MUST</em> provide one or more Containers within which Annotations can be managed: an Annotation Container. An Annotation Container is at the same time both a Container [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>] (a service for managing Annotations) and an OrderedCollection [<cite><a href="#bib-activitystreams-core" class="bibref">activitystreams-core</a></cite>] (an ordered list of Annotations). It can have descriptive and technical information associated with it to allow clients to present it to a user in order to allow her to decide if it should be used or not.</p>
     <p>
 
     </p>
     <p>
-      Annotation Containers <em title="SHOULD" class="rfc2119">SHOULD</em> implement the LDP Basic Container specification, but <em title="MAY" class="rfc2119">MAY</em> instead implement another type of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers <em title="MAY" class="rfc2119">MAY</em> have any IRI, but <em title="MUST" class="rfc2119">MUST</em> end in a <code>"/"</code> character. The Annotations <em title="MUST" class="rfc2119">MUST</em> be assigned IRIs with an additional path component below the Container's IRI.
+      Annotation Containers <em title="SHOULD" class="rfc2119">SHOULD</em> implement the LDP Basic Container specification, but <em title="MAY" class="rfc2119">MAY</em> instead implement another type of Container, such as a Direct or Indirect Container, to fulfill business needs. Annotation Containers <em title="MAY" class="rfc2119">MAY</em> have any IRI, but it <em title="MUST" class="rfc2119">MUST</em> end in a <code>"/"</code> character.
     </p>
 
     <p>Implementations <em title="SHOULD" class="rfc2119">SHOULD</em> use HTTPS rather than HTTP for all interactions with Annotation Containers.</p>
@@ -723,8 +726,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <p>
         The Annotation Server <em title="MUST" class="rfc2119">MUST</em> support the following HTTP methods on the Annotation Container's IRI:
-
       </p>
+
       <ul>
         <li><code>GET</code> (retrieve the description of the Container and the list of its contents, described below), </li>
         <li><code>HEAD</code> (retrieve the headers of the Container without an entity-body),</li>
@@ -736,11 +739,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         When an HTTP GET request is issued against the Annotation Container, the server <em title="MUST" class="rfc2119">MUST</em> return a description of the container. That description <em title="MUST" class="rfc2119">MUST</em> be available in JSON-LD, <em title="SHOULD" class="rfc2119">SHOULD</em> be available in Turtle, and <em title="MAY" class="rfc2119">MAY</em> be available in other formats. The JSON-LD serialization of the Container's description <em title="SHOULD" class="rfc2119">SHOULD</em> use both the LDP context (<code>http://www.w3c.org/ns/ldp.jsonld</code>), and the Web Annotation's profile and context [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>], unless the request would determine otherwise.
       </p>
 
-      <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences. If redirection is required, then the server <em title="SHOULD" class="rfc2119">SHOULD</em> use a 3XX HTTP status code instead.</p>
-
-      <p>
-        Clients that have a preference for JSON-LD <em title="SHOULD" class="rfc2119">SHOULD</em> explicitly request it using an <code>Accept</code> header on the request. If the <code>Accept</code> header is absent from the request, then Annotation Servers <em title="MUST" class="rfc2119">MUST</em> respond with the JSON-LD representation of the Annotation Container.
-      </p>
+      <p>Servers <em title="SHOULD" class="rfc2119">SHOULD</em> use the 200 HTTP status code if the request is successfully completed without errors and does not require redirection based on the client's preferences.</p>
 
       <p>
         All supported methods for interacting with the Annotation Container <em title="SHOULD" class="rfc2119">SHOULD</em> be advertised in the <code>Allow</code> header of the <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> responses from the container's IRI
@@ -755,10 +754,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <p></p>
 
       <p>
-        All HTTP responses from Annotation Containers <em title="MUST" class="rfc2119">MUST</em> include an <code>ETag</code> header that implements the notion of entity tags from HTTP [<cite><a href="#bib-rfc7230" class="bibref">rfc7230</a></cite>].</p>
+        All HTTP responses from Annotation Containers <em title="MUST" class="rfc2119">MUST</em> include an <code>ETag</code> header that implements the notion of entity tags from HTTP [<cite><a href="#bib-rfc7230" class="bibref">rfc7230</a></cite>]. This value will be used by administrative clients when updating the container by including it in an <code>If-Match</code> request header in the same way as clients wanting to update an Annotation.</p>
 
       <p>
-        If the server supports content negotiation by format or JSON-LD profile, the response from the Annotation Container <em title="MUST" class="rfc2119">MUST</em> have a <code>Vary</code> header that includes <code>Accept</code> in the value.</p>
+        If the <code>Accept</code> header is absent from the request, then Annotation Servers <em title="MUST" class="rfc2119">MUST</em> respond with a JSON-LD representation of the Annotation Container, however clients with a preference for JSON-LD <em title="SHOULD" class="rfc2119">SHOULD</em> explicitly request it using an <code>Accept</code> request header.
+      </p>
+
+      <p>
+        If the server supports content negotiation by format or JSON-LD profile, the response from the Annotation Container <em title="MUST" class="rfc2119">MUST</em> have a <code>Vary</code> header that includes <code>Accept</code> in the value to ensure that caches can determine that the representation will change based on the value of this header in requests.</p>
 
       <p>Responses from Annotation Containers that support the use of the POST method to create Annotations <em title="SHOULD" class="rfc2119">SHOULD</em> include an <code>Accept-Post</code> header on responses to GET, HEAD and OPTIONS requests. The value is a comma separated list of media-types that are acceptable for the client to send via POST [<cite><a href="#bib-ldp" class="bibref">ldp</a></cite>].</p>
 
@@ -772,24 +775,43 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 <span class="hljs-attribute">Accept-Post</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld", text/turtle</pre></div>
       </div>
 
-      <section property="bibo:hasPart" resource="#client-preferences" typeof="bibo:Chapter" id="client-preferences">
-        <h4 resource="#h-client-preferences" id="h-client-preferences"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.1 </span>Client Preferences</span></h4> There are three possibilities for the request that will govern the server's response:
+    </section>
+
+    <section property="bibo:hasPart" resource="#container-representations" typeof="bibo:Chapter" id="container-representations">
+      <h3 resource="#h-container-representations" id="h-container-representations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Container Representations</span></h3>
+
+      <p>As there are likely to be many Annotations in a single Container, the Annotation Protocol adopts the ActivityStreams <a href="https://www.w3.org/TR/activitystreams-core/#collections">paging mechanism</a> for returning the contents of the Container. Each page contains an ordered list with a subset of the managed Annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container. The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages. The feature or features by which the Annotations are sorted are not explicit in the response.</p>
+
+      <p>If there are greater than zero Annotations in the Container, he representation <em title="MUST" class="rfc2119">MUST</em> either include a link to the first page of Annotations as the value of the <code>first</code> property, or include the representation of the first page embedded within the response. If there is more than one page of Annotations, then the representation <em title="SHOULD" class="rfc2119">SHOULD</em> have a link to the last page using the <code>last</code> property.</p>
+
+      <p>The representation of the Container <em title="SHOULD" class="rfc2119">SHOULD</em> include the <code>total</code> property with the total number of annotations in the Container.</p>
+
+      <p>The IRI of the Container provided in the response <em title="SHOULD" class="rfc2119">SHOULD</em> differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations. It is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> that this be done with a query parameter. The server <em title="MAY" class="rfc2119">MAY</em> redirect the client to this IRI and deliver the response there, otherwise it <em title="MUST" class="rfc2119">MUST</em> include a <code>Content-Location</code> header with the IRI as its value.</p>
+
+      <section property="bibo:hasPart" resource="#client-representation-preferences" typeof="bibo:Chapter" id="client-representation-preferences">
+        <h4 resource="#h-client-representation-preferences" id="h-client-representation-preferences"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.1 </span>Client Representation Preferences</span></h4>
+
+        <p>
+          There are three preferences for the request that will govern the representation in the server's responses:</p>
 
         <ol>
-          <li>If the client prefers to only receive the Container description and no annotations, then it <em title="MUST" class="rfc2119">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
-          <li>If the client prefers to receive the list of annotations only as IRIs, then it <em title="MUST" class="rfc2119">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
-          <li>If the client prefers to receive the complete annotation description, then it <em title="MUST" class="rfc2119">MUST</em> include the <code>Prefer</code> request header set to the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
+          <li>If the client prefers to only receive the Container description and no Annotations in the current response, then it <em title="MUST" class="rfc2119">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</code>.</li>
+          <li>If the client prefers to receive the list of Annotations only as IRIs, either in the current or future paged responses, then it <em title="MUST" class="rfc2119">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</code>.</li>
+          <li>If the client prefers to receive complete Annotation descriptions, either in the current or future paged responses, then it <em title="MUST" class="rfc2119">MUST</em> include a <code>Prefer</code> request header with the value <code>return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</code>.</li>
         </ol>
 
-        If no preference is given by the client, the server <em title="SHOULD" class="rfc2119">SHOULD</em> return the full annotation descriptions. The server <em title="MAY" class="rfc2119">MAY</em> ignore the client's preference.
+        <p>The client <em title="MUST NOT" class="rfc2119">MUST NOT</em> include both the <code>PreferContainedIRIs</code> and <code>PreferContainedDescriptions</code> preferences on the same request, as the server cannot honor both at the same time. If the <code>PreferMinimalContainer</code> preference is not given, then the server <em title="MAY" class="rfc2119">MAY</em> respond with the first page of Annotations embedded within the Container response or it <em title="MAY" class="rfc2119">MAY</em> provide links to the first and last pages. If no preference is given by the client, the server <em title="SHOULD" class="rfc2119">SHOULD</em> default to the <code>PreferContainedDescriptions</code> behavior. The server <em title="MAY" class="rfc2119">MAY</em> ignore the client's preferences.</p>
 
       </section>
 
-      <section property="bibo:hasPart" resource="#responses-without-annotations" typeof="bibo:Chapter" id="responses-without-annotations">
-        <h4 resource="#h-responses-without-annotations" id="h-responses-without-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.2 </span>Responses without Annotations</span></h4>
 
-        <p>The Client may request the description of the Annotation Container without any included Annotations.</p>
-        <p>The response <em title="SHOULD" class="rfc2119">SHOULD</em> include links to the first and last AnnotationPages in the Collection, and without either the <code>ldp:contains</code> predicate or the first page of annotations embedded.</p>
+      <section property="bibo:hasPart" resource="#representations-without-annotations" typeof="bibo:Chapter" id="representations-without-annotations">
+        <h4 resource="#h-representations-without-annotations" id="h-representations-without-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.2 </span>Representations without Annotations</span></h4>
+
+        <p>If the client requested the minimal representation of the Annotation Container, the response <em title="MUST NOT" class="rfc2119">MUST NOT</em> include either the <code>ldp:contains</code> predicate or the first page of Annotations embedded within the response. The linked pages <em title="SHOULD" class="rfc2119">SHOULD</em> follow any preference provided for whether they include only the IRIs or the full descriptions of the Annotations.
+        </p>
+
+        <p>The server <em title="MAY" class="rfc2119">MAY</em> return a representation without embedded Annotations, even if the <code>PreferMinimalContainer</code> preference is not supplied.</p>
 
         <div>
 
@@ -798,7 +820,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             <div class="example-title marker"><span>Example 4</span><span style="text-transform: none">: Container Request without Annotations</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
-<span class="hljs-attribute">Prefer</span>: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"</pre></div>
+<span class="hljs-attribute">Prefer</span>: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"
+<span class="hljs-attribute">Prefer</span>: return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</pre></div>
 
           Response:
           <div class="example">
@@ -816,40 +839,33 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span>,
     <span class="hljs-string">"http://www.w3.org/ns/ldp.jsonld"</span>
   ],
-  <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/"</span>,
+  <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=1"</span>,
   <span class="hljs-string">"type"</span>: [<span class="hljs-string">"BasicContainer"</span>, <span class="hljs-string">"AnnotationCollection"</span>],
   <span class="hljs-string">"total"</span>: <span class="hljs-number">42023</span>,
   <span class="hljs-string">"label"</span>: <span class="hljs-string">"A Container for Web Annotations"</span>,
-  <span class="hljs-string">"first"</span>: <span class="hljs-string">"http://example.org/annotations/?page=0"</span>,
-  <span class="hljs-string">"last"</span>: <span class="hljs-string">"http://example.org/annotations/?page=42"</span>
+  <span class="hljs-string">"first"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=1&amp;page=0"</span>,
+  <span class="hljs-string">"last"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=1&amp;page=42"</span>
 }</span></pre></div>
         </div>
       </section>
 
-      <section property="bibo:hasPart" resource="#responses-with-annotations" typeof="bibo:Chapter" id="responses-with-annotations">
+      <section property="bibo:hasPart" resource="#representations-with-annotation-iris" typeof="bibo:Chapter" id="representations-with-annotation-iris">
 
-        <h4 resource="#h-responses-with-annotations" id="h-responses-with-annotations"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1.3 </span>Responses with Annotations</span></h4>
+        <h4 resource="#h-representations-with-annotation-iris" id="h-representations-with-annotation-iris"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.3 </span>Representations with Annotation IRIs</span></h4>
 
-        <p>If the client requests a response that would include the Annotations, either by IRI or embedded in the response, then the server <em title="MUST" class="rfc2119">MUST</em> use the paged collection model. Each page, described below, will contain an ordered list with a subset of the managed annotations, such that if every page is traversed, a client can reconstruct the complete, ordered contents of the container. The number of IRIs or Annotation descriptions included on each page is at the server's discretion, and may be inconsistent between pages. The feature or features by which the annotations are sorted are not explicit in the response.
-        </p>
-
-        <p>
-          The Collection <em title="SHOULD" class="rfc2119">SHOULD</em> include the <code>total</code> property with the total number of annotations in the container. It <em title="MUST" class="rfc2119">MUST</em> also have a link to the first page of its contents using <code>first</code>, and <em title="SHOULD" class="rfc2119">SHOULD</em> have a link to the last page of its contents using <code>last</code>.
-        </p>
-
-        <p>The IRI of the Collection in the response should differentiate between whether the pages contain just the IRIs, or the full descriptions of the Annotations. It is <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em> that this be done with a query parameter. The server <em title="MAY" class="rfc2119">MAY</em> redirect the client to this IRI and deliver the response there, otherwise it <em title="MUST" class="rfc2119">MUST</em> include a <code>Content-Location</code> header with the IRI as its value. The server <em title="SHOULD" class="rfc2119">SHOULD</em> include <code>Prefer</code> in the <code>Vary</code> response header to assist with caching.</p>
+        <p></p>
 
         <div>
           Request for embedded IRIs:
           <div class="example">
-            <div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: Collection Request</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
+            <div class="example-title marker"><span>Example 6</span><span style="text-transform: none">: Container Request (Embedded IRIs)</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">Prefer</span>: return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"</pre></div>
 
           Response:
           <div class="example">
-            <div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: Collection Response</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
+            <div class="example-title marker"><span>Example 7</span><span style="text-transform: none">: Container Response (Embedded IRIs)</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
 <span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">Content-Location</span>: http://example.org/annotations/?iris=1
 <span class="hljs-attribute">ETag</span>: "_87e52ce123123"
@@ -868,47 +884,117 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   <span class="hljs-string">"type"</span>: [<span class="hljs-string">"BasicContainer"</span>, <span class="hljs-string">"AnnotationCollection"</span>],
   <span class="hljs-string">"total"</span>: <span class="hljs-number">42023</span>,
   <span class="hljs-string">"label"</span>: <span class="hljs-string">"A Container for Web Annotations"</span>,
-  <span class="hljs-string">"first"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=1&amp;page=0"</span>,
+  <span class="hljs-string">"first"</span>: {
+    <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=1&amp;page=0"</span>,
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"AnnotationPage"</span>,
+    <span class="hljs-string">"next"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=1&amp;page=1"</span>,
+    <span class="hljs-string">"items"</span>: [
+      <span class="hljs-string">"http://example.org/annotations/anno1"</span>,
+      <span class="hljs-string">"http://example.org/annotations/anno2"</span>,
+      <span class="hljs-string">"http://example.org/annotations/anno3"</span>,
+      <span class="hljs-string">"http://example.org/annotations/anno4"</span>,
+      <span class="hljs-string">"http://example.org/annotations/anno5"</span>,
+      <span class="hljs-string">"http://example.org/annotations/anno6"</span>,
+      ...
+      <span class="hljs-string">"http://example.org/annotations/anno999"</span>,
+    ]
+  },
   <span class="hljs-string">"last"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=1&amp;page=42"</span>
 }</span></pre></div>
+        </div>
+      </section>
 
-          Request for embedded descriptions:
-          <div class="example">
-            <div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: Collection Request</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
+      <section property="bibo:hasPart" resource="#representations-with-annotation-descriptions" typeof="bibo:Chapter" id="representations-with-annotation-descriptions">
+        <h4 resource="#h-representations-with-annotation-descriptions" id="h-representations-with-annotation-descriptions"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2.4 </span>Representations with Annotation Descriptions</span></h4>
+        <p></p>
+
+
+        Request for embedded descriptions:
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 8</span><span style="text-transform: none">: Container Request (Embedded Descriptions)</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">Prefer</span>: return=representation;include="http://www.w3.org/ns/oa#PreferContainedDescriptions"</pre></div>
 
-          This request would generate a very similar response to the one above, just with some way to distinguish that the pages should embed the Annotations rather than just their IRIs.
+        <div class="example">
+          <div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: Container Response (Embedded Descriptions)</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
+<span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
+<span class="hljs-attribute">Allow</span>: GET,OPTIONS,HEAD
+<span class="hljs-attribute">Vary</span>: Accept, Prefer
+<span class="hljs-attribute">Content-Length</span>: 924
 
-        </div>
+<span class="xquery">{
+  <span class="hljs-string">"@context"</span>: [
+    <span class="hljs-string">"http://www.w3.org/ns/anno.jsonld"</span>,
+    <span class="hljs-string">"http://www.w3.org/ns/ldp.jsonld"</span>
+  ],
+  <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=0"</span>,
+  <span class="hljs-string">"type"</span>: [<span class="hljs-string">"BasicContainer"</span>, <span class="hljs-string">"AnnotationCollection"</span>],
+  <span class="hljs-string">"total"</span>: <span class="hljs-number">42023</span>,
+  <span class="hljs-string">"label"</span>: <span class="hljs-string">"A Container for Web Annotations"</span>,
+  <span class="hljs-string">"first"</span>: {
+    <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=0&amp;page=0"</span>,
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"AnnotationPage"</span>,
+    <span class="hljs-string">"next"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=0&amp;page=1"</span>,
+    <span class="hljs-string">"items"</span>: [
+      {
+        <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/anno1"</span>,
+        <span class="hljs-string">"type"</span>: <span class="hljs-string">"Annotation"</span>,
+        <span class="hljs-string">"body"</span>: <span class="hljs-string">"http://example.net/body1"</span>,
+        <span class="hljs-string">"target"</span>: <span class="hljs-string">"http://example.com/page1"</span>
+      },
+      {
+        <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/anno2"</span>,
+        <span class="hljs-string">"type"</span>: <span class="hljs-string">"Annotation"</span>,
+        <span class="hljs-string">"body"</span>: {
+          <span class="hljs-string">"type"</span>: <span class="hljs-string">"TextualBody"</span>,
+          <span class="hljs-string">"value"</span>: <span class="hljs-string">"I like this!"</span>
+        },
+        <span class="hljs-string">"target"</span>: <span class="hljs-string">"http://example.com/book1"</span>
+      }
+      // ...
+      {
+        <span class="hljs-string">"id"</span>: <span class="hljs-string">"http://example.org/annotations/anno50"</span>,
+        <span class="hljs-string">"type"</span>: <span class="hljs-string">"Annotation"</span>,
+        <span class="hljs-string">"body"</span> : <span class="hljs-string">"http://example.org/texts/description1"</span>,
+        <span class="hljs-string">"target"</span>: <span class="hljs-string">"http://example.com/images/image1"</span>
+      }
+    ]
+  },
+  <span class="hljs-string">"last"</span>: <span class="hljs-string">"http://example.org/annotations/?iris=0&amp;page=840"</span>
+}</span></pre></div>
 
-        <h4 id="page-response">Page Response</h4>
-        <p>
-          Individual pages are instances of <code>CollectionPage</code>. The page contains the Annotations, either via their IRIs or full descriptions, in the <code>items</code> property.</p>
+      </section>
+    </section>
 
-        <p>Each page <em title="MUST" class="rfc2119">MUST</em> have a link to the container that it is part of, using the <code>partOf</code> property. If it is not the first page, it <em title="MUST" class="rfc2119">MUST</em> have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it <em title="MUST" class="rfc2119">MUST</em> have a link to the next page in the sequence, using the <code>next</code> property. The response <em title="MAY" class="rfc2119">MAY</em> include properties of the Collection in the response, including the total number of items or first and last page links.
-        </p>
+    <section property="bibo:hasPart" resource="#annotation-pages" typeof="bibo:Chapter" id="annotation-pages">
+      <h3 resource="#h-annotation-pages" id="h-annotation-pages"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.3 </span>Annotation Pages</span></h3>
+      <p>
+        Individual pages are instances of <code>CollectionPage</code>. The page contains the Annotations, either via their IRIs or full descriptions, in the <code>items</code> property.</p>
 
-        <p>
-          The client <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> send the <code>Prefer</code> header when requesting the page, as it has already been taken into account when requesting the Container.
-        </p>
+      <p>Each page <em title="MUST" class="rfc2119">MUST</em> have a link to the container that it is part of, using the <code>partOf</code> property. If it is not the first page, it <em title="MUST" class="rfc2119">MUST</em> have a link to the previous page in the sequence, using the <code>prev</code> property. If it is not the last page, it <em title="MUST" class="rfc2119">MUST</em> have a link to the next page in the sequence, using the <code>next</code> property. The response <em title="MAY" class="rfc2119">MAY</em> include properties of the Collection in the response, including the total number of items or first and last page links.
+      </p>
 
-        <p>This specification does not require any particular functionality when a client makes requests other than GET, HEAD or OPTIONS to a page.</p>
+      <p>
+        The client <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> send the <code>Prefer</code> header when requesting the page, as it has already been taken into account when requesting the Container.
+      </p>
 
-        <p>As the <code>CollectionPage</code> is not a Container, it does not have the requirement to include a <code>Link</code> header with a type. That the URLs can be constructed with query parameters added to the Container's IRI is an implementation convenience, and does not imply the type of the resource.</p>
+      <p>This specification does not require any particular functionality when a client makes requests other than GET, HEAD or OPTIONS to a page.</p>
 
-        <div>
+      <p>As the <code>CollectionPage</code> is not a Container, it does not have the requirement to include a <code>Link</code> header with a type. That the URLs can be constructed with query parameters added to the Container's IRI is an implementation convenience, and does not imply the type of the resource.</p>
 
-          Request:
-          <div class="example">
-            <div class="example-title marker"><span>Example 9</span><span style="text-transform: none">: Page Request</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/?iris=1&amp;page=0</span> HTTP/1.1
+      <div>
+
+        Request:
+        <div class="example">
+          <div class="example-title marker"><span>Example 10</span><span style="text-transform: none">: Page Request</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/?iris=1&amp;page=0</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</pre></div>
 
-          Response:
-          <div class="example">
-            <div class="example-title marker"><span>Example 10</span><span style="text-transform: none">: Page Response</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
+        Response:
+        <div class="example">
+          <div class="example-title marker"><span>Example 11</span><span style="text-transform: none">: Page Response (Embedded IRIs)</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
 <span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">Allow</span>: GET,OPTIONS,HEAD
 <span class="hljs-attribute">Vary</span>: Accept, Prefer
@@ -935,9 +1021,15 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   ]
 }</span></pre></div>
 
-          A request for the same set of Annotations, with the descriptions embedded might return fewer Annotations. Response:
-          <div class="example">
-            <div class="example-title marker"><span>Example 11</span><span style="text-transform: none">: Page Response</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
+
+        Request:
+        <div class="example">
+          <div class="example-title marker"><span>Example 12</span><span style="text-transform: none">: Page Request (Embedded Descriptions)</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/annotations/?iris=0&amp;page=0</span> HTTP/1.1
+<span class="hljs-attribute">Host</span>: example.org
+<span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"</pre></div>
+
+        <div class="example">
+          <div class="example-title marker"><span>Example 13</span><span style="text-transform: none">: Page Response (Embedded Descriptions)</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
 <span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">Allow</span>: GET,OPTIONS,HEAD
 <span class="hljs-attribute">Vary</span>: Accept, Prefer
@@ -978,12 +1070,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   ]
 }</span></pre></div>
 
-        </div>
-      </section>
+      </div>
     </section>
 
     <section property="bibo:hasPart" resource="#discovery-of-annotation-containers" typeof="bibo:Chapter" id="discovery-of-annotation-containers">
-      <h3 resource="#h-discovery-of-annotation-containers" id="h-discovery-of-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Discovery of Annotation Containers</span></h3>
+      <h3 resource="#h-discovery-of-annotation-containers" id="h-discovery-of-annotation-containers"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.4 </span>Discovery of Annotation Containers</span></h3>
 
       <p>As the IRI for Annotation Containers <em title="MAY" class="rfc2119">MAY</em> be any IRI, and it is unlikely that every Web Server will support the functionality, it is important to be able to discover the availability of these services.</p>
 
@@ -996,11 +1087,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
         Request:
         <div class="example">
-          <div class="example-title marker"><span>Example 12</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/images/logo.jpg</span> HTTP/1.1
+          <div class="example-title marker"><span>Example 14</span></div><pre class="highlight hljs http"><span class="hljs-keyword">GET</span> <span class="hljs-string">/images/logo.jpg</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.com</pre></div>
         Response:
         <div class="example">
-          <div class="example-title marker"><span>Example 13</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
+          <div class="example-title marker"><span>Example 15</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
 <span class="hljs-attribute">Content-Type</span>: image/jpeg
 <span class="hljs-attribute">Link</span>: &lt;http://example.org/annotations/&gt;; rel="http://www.w3.org/ns/oa#annotationService"
 <span class="hljs-attribute">Allow</span>: GET
@@ -1022,7 +1113,10 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <p>New Annotations are created via a POST request to an Annotation Container. The Annotation, serialized as JSON-LD, is sent in the body of the request. All of the known information about the Annotation <em title="SHOULD" class="rfc2119">SHOULD</em> be sent, and if there are already IRIs associated with the resources, they <em title="SHOULD" class="rfc2119">SHOULD</em> be included. The serialization <em title="SHOULD" class="rfc2119">SHOULD</em> use the Web Annotation JSON-LD profile, and servers <em title="MAY" class="rfc2119">MAY</em> reject other contexts even if they would otherwise produce the same model. The server <em title="MAY" class="rfc2119">MAY</em> reject content that is not considered an Annotation according to the Web Annotation specification [<cite><a href="#bib-annotation-model" class="bibref">annotation-model</a></cite>].</p>
 
-      <p>Upon receipt of an Annotation, the server <em title="MAY" class="rfc2119">MAY</em> assign IRIs to any resource or blank node in the Annotation, and <em title="MUST" class="rfc2119">MUST</em> assign an IRI to the Annotation resource in the <code>id</code> property, even if it already has one provided. The server <em title="SHOULD" class="rfc2119">SHOULD</em> use HTTPS IRIs when those resources are able to be retrieved individually. The server <em title="MAY" class="rfc2119">MAY</em> also add additional information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, additional types and formats.</p>
+      <p>Upon receipt of an Annotation, the server <em title="MAY" class="rfc2119">MAY</em> assign IRIs to any resource or blank node in the Annotation, and <em title="MUST" class="rfc2119">MUST</em> assign an IRI to the Annotation resource in the <code>id</code> property, even if it already has one provided. The server <em title="SHOULD" class="rfc2119">SHOULD</em> use HTTPS IRIs when those resources are able to be retrieved individually. The IRI for the Annotation <em title="MUST" class="rfc2119">MUST</em> be the IRI of the Container with an additional component added to the end.
+      </p>
+
+      <p>The server <em title="MAY" class="rfc2119">MAY</em> add information to the Annotation. Possible additional information includes the agent that created it, the time of the Annotation's creation, or additional types and formats of the constituent resources.</p>
 
       <p>If the Annotation contains a <code>canonical</code> link, then it <em title="MUST" class="rfc2119">MUST</em> be maintained without change. If the Annotation has an IRI in the <code>id</code> property, then it <em title="SHOULD" class="rfc2119">SHOULD</em> be copied to the <code>via</code> property, and the IRI assigned by the server, at which the Annotation will be available, <em title="MUST" class="rfc2119">MUST</em> be put in the <code>id</code> field to replace it.</p>
 
@@ -1031,7 +1125,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <div>
         Request:
         <div class="example">
-          <div class="example-title marker"><span>Example 14</span></div><pre class="highlight hljs http"><span class="hljs-keyword">POST</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
+          <div class="example-title marker"><span>Example 16</span></div><pre class="highlight hljs http"><span class="hljs-keyword">POST</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
@@ -1049,7 +1143,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
         Response:
         <div class="example">
-          <div class="example-title marker"><span>Example 15</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">201</span> CREATED
+          <div class="example-title marker"><span>Example 17</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">201</span> CREATED
 <span class="hljs-attribute">Allow</span>: PUT,GET,OPTIONS,HEAD,DELETE,PATCH
 <span class="hljs-attribute">Location</span>: http://example.org/annotations/anno1
 <span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
@@ -1077,7 +1171,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <div>
         Request:
         <div class="example">
-          <div class="example-title marker"><span>Example 16</span></div><pre class="highlight hljs http"><span class="hljs-keyword">POST</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
+          <div class="example-title marker"><span>Example 18</span></div><pre class="highlight hljs http"><span class="hljs-keyword">POST</span> <span class="hljs-string">/annotations/</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
@@ -1096,7 +1190,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
         Response:
         <div class="example">
-          <div class="example-title marker"><span>Example 17</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">201</span> CREATED
+          <div class="example-title marker"><span>Example 19</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">201</span> CREATED
 <span class="hljs-attribute">Link</span>: &lt;http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"
 <span class="hljs-attribute">Allow</span>: PUT,GET,OPTIONS,HEAD,DELETE,PATCH
 <span class="hljs-attribute">Location</span>: http://example.org/annotations/my_first_annotation
@@ -1136,7 +1230,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <div>
         Request:
         <div class="example">
-          <div class="example-title marker"><span>Example 18</span></div><pre class="highlight hljs http"><span class="hljs-keyword">PUT</span> <span class="hljs-string">/annotations/anno1</span> HTTP/1.1
+          <div class="example-title marker"><span>Example 20</span></div><pre class="highlight hljs http"><span class="hljs-keyword">PUT</span> <span class="hljs-string">/annotations/anno1</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">Accept</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
@@ -1157,7 +1251,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
         Response:
         <div class="example">
-          <div class="example-title marker"><span>Example 19</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
+          <div class="example-title marker"><span>Example 21</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">200</span> OK
 <span class="hljs-attribute">Content-Type</span>: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
 <span class="hljs-attribute">ETag</span>: "_87e52ce234234"
 <span class="hljs-attribute">Link</span>: &lt;http://www.w3.org/ns/ldp#Resource&gt;; rel="type"
@@ -1194,12 +1288,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <div>
         Request:
         <div class="example">
-          <div class="example-title marker"><span>Example 20</span></div><pre class="highlight hljs http"><span class="hljs-keyword">DELETE</span> <span class="hljs-string">/annotations/anno1</span> HTTP/1.1
+          <div class="example-title marker"><span>Example 22</span></div><pre class="highlight hljs http"><span class="hljs-keyword">DELETE</span> <span class="hljs-string">/annotations/anno1</span> HTTP/1.1
 <span class="hljs-attribute">Host</span>: example.org
 <span class="hljs-attribute">If-Match</span>: "_87e52ce126126"</pre></div>
         Response:
         <div class="example">
-          <div class="example-title marker"><span>Example 21</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">204</span> NO CONTENT
+          <div class="example-title marker"><span>Example 23</span></div><pre class="highlight hljs http">HTTP/1.1 <span class="hljs-number">204</span> NO CONTENT
 <span class="hljs-attribute">Content-Length</span>: 0</pre></div>
       </div>
     </section>
@@ -1295,6 +1389,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <li>Rename PreferContainedURIs to PreferContainedIRIs.</li>
         <li>Add recommendation for Accept-Post, with example.</li>
         <li>Clarify expected status codes for successful interactions.</li>
+        <li>Restructure Container Retrieval section and promote Container Representations and Annotation Pages sections.</li>
       </ul>
     </section>
   </section>
@@ -1327,7 +1422,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <dl resource="" class="bibliography"><dt id="bib-RFC2119">[RFC2119]</dt>
         <dd>S. Bradner. IETF. <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a property="dc:requires" href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
         </dd><dt id="bib-activitystreams-core">[activitystreams-core]</dt>
-        <dd>James Snell; Evan Prodromou. W3C. <a property="dc:requires" href="https://www.w3.org/TR/activitystreams-core/"><cite>Activity Streams 2.0</cite></a>. 6 July 2016. W3C Working Draft. URL: <a property="dc:requires" href="https://www.w3.org/TR/activitystreams-core/">https://www.w3.org/TR/activitystreams-core/</a>
+        <dd>James Snell; Evan Prodromou. W3C. <a property="dc:requires" href="https://www.w3.org/TR/activitystreams-core/"><cite>Activity Streams 2.0</cite></a>. 31 May 2016. W3C Working Draft. URL: <a property="dc:requires" href="https://www.w3.org/TR/activitystreams-core/">https://www.w3.org/TR/activitystreams-core/</a>
         </dd><dt id="bib-annotation-model">[annotation-model]</dt>
         <dd>Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. <a property="dc:requires" href="http://www.w3.org/TR/2016/CR-annotation-model-20160705/"><cite>Web Annotation Data Model</cite></a>. W3C Candidate Recommendation. URL: <a property="dc:requires" href="http://www.w3.org/TR/2016/CR-annotation-model-20160705/">http://www.w3.org/TR/2016/CR-annotation-model-20160705/</a>
         </dd><dt id="bib-annotation-vocab">[annotation-vocab]</dt>


### PR DESCRIPTION
NOTE: this PR "stacks" on the other existing PRs. I've sent. Let me know if/when rebasing is needed.

This fixes #333 by changing the text to match the definition of the [`include` parameter for `Prefer` which is defined by LDP](https://www.w3.org/TR/ldp/#h-prefer-include).

In the end, this actually avoids the multiple Prefer header situation entirely, though it does mean that implementors who supported the multi-Prefer header situation will need to change code to use this space-delimited URI list stored inside a single `Prefer` header.

Let me know if it needs tweaks. :smile: 
