### PR TITLE
fix dcterms:creator to be a foaf:Person, not a literal

### DIFF
--- a/vocab/wd/ontology/oa.jsonld
+++ b/vocab/wd/ontology/oa.jsonld
@@ -5,6 +5,7 @@
         "creator": "dcterms:creator",
         "dc": "http://purl.org/dc/elements/1.1/",
         "dcterms": "http://purl.org/dc/terms/",
+        "foaf": "http://xmlns.com/foaf/0.1/",
         "definedBy": {
             "@id": "rdfs:isDefinedBy",
             "@type": "@id"
@@ -496,9 +497,9 @@
         {
             "comment": "The Web Annotation ontology defines the terms of the Web Annotation vocabulary. Any changes to this document MUST be from a Working Group in the W3C that has established expertise in the area.",
             "creator": [
-                "Paolo Ciccarese",
-                "Benjamin Young",
-                "Robert Sanderson"
+                {"@type": "foaf:Person", "foaf:name": "Paolo Ciccarese"},
+                {"@type": "foaf:Person", "foaf:name": "Benjamin Young"},
+                {"@type": "foaf:Person", "foaf:name": "Robert Sanderson"}
             ],
             "id": "oa:",
             "modified": "2016-11-12T21:28:11Z",

--- a/vocab/wd/ontology/oa.rdf
+++ b/vocab/wd/ontology/oa.rdf
@@ -6,6 +6,7 @@
   xmlns:oa="http://www.w3.org/ns/oa#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
 >
   <rdf:Property rdf:about="http://www.w3.org/ns/oa#sourceDateStart">
     <rdfs:comment>The start timestamp of the interval over which the Source resource should be interpreted as being applicable to the Annotation.</rdfs:comment>
@@ -13,12 +14,12 @@
     <rdfs:isDefinedBy>
       <owl:Ontology rdf:about="http://www.w3.org/ns/oa#">
         <owl:versionInfo>2016-11-12T21:28:11Z</owl:versionInfo>
-        <dcterms:creator>Paolo Ciccarese</dcterms:creator>
-        <dcterms:creator>Robert Sanderson</dcterms:creator>
+        <dcterms:creator rdf:type="foaf:Person"><foaf:name>Paolo Ciccarese</foaf:name></dcterms:creator>
+        <dcterms:creator rdf:type="foaf:Person"><foaf:name>Robert Sanderson</foaf:name></dcterms:creator>
         <rdfs:comment>The Web Annotation ontology defines the terms of the Web Annotation vocabulary. Any changes to this document MUST be from a Working Group in the W3C that has established expertise in the area.</rdfs:comment>
         <owl:previousVersionURI rdf:resource="http://www.openannotation.org/spec/core/20130208/oa.owl"/>
         <rdfs:seeAlso rdf:resource="http://www.w3.org/TR/annotation-vocab/"/>
-        <dcterms:creator>Benjamin Young</dcterms:creator>
+        <dcterms:creator rdf:type="foaf:Person"><foaf:name>Benjamin Young</foaf:name></dcterms:creator>
         <dcterms:modified>2016-11-12T21:28:11Z</dcterms:modified>
         <dc:title>Web Annotation Ontology</dc:title>
       </owl:Ontology>

--- a/vocab/wd/ontology/oa.rdf
+++ b/vocab/wd/ontology/oa.rdf
@@ -14,12 +14,12 @@
     <rdfs:isDefinedBy>
       <owl:Ontology rdf:about="http://www.w3.org/ns/oa#">
         <owl:versionInfo>2016-11-12T21:28:11Z</owl:versionInfo>
-        <dcterms:creator rdf:type="foaf:Person"><foaf:name>Paolo Ciccarese</foaf:name></dcterms:creator>
-        <dcterms:creator rdf:type="foaf:Person"><foaf:name>Robert Sanderson</foaf:name></dcterms:creator>
+        <dcterms:creator><foaf:Person><foaf:name>Paolo Ciccarese</foaf:name></foaf:Person></dcterms:creator>
+        <dcterms:creator><foaf:Person><foaf:name>Robert Sanderson</foaf:name></foaf:Person></dcterms:creator>
         <rdfs:comment>The Web Annotation ontology defines the terms of the Web Annotation vocabulary. Any changes to this document MUST be from a Working Group in the W3C that has established expertise in the area.</rdfs:comment>
         <owl:previousVersionURI rdf:resource="http://www.openannotation.org/spec/core/20130208/oa.owl"/>
         <rdfs:seeAlso rdf:resource="http://www.w3.org/TR/annotation-vocab/"/>
-        <dcterms:creator rdf:type="foaf:Person"><foaf:name>Benjamin Young</foaf:name></dcterms:creator>
+        <dcterms:creator><foaf:Person><foaf:name>Benjamin Young</foaf:name></foaf:Person></dcterms:creator>
         <dcterms:modified>2016-11-12T21:28:11Z</dcterms:modified>
         <dc:title>Web Annotation Ontology</dc:title>
       </owl:Ontology>

--- a/vocab/wd/ontology/oa.ttl
+++ b/vocab/wd/ontology/oa.ttl
@@ -419,9 +419,9 @@ oa:via a rdf:Property ;
 
 oa: a owl:Ontology ;
     dc:title "Web Annotation Ontology" ;
-    dcterms:creator "Benjamin Young",
-        "Paolo Ciccarese",
-        "Robert Sanderson" ;
+    dcterms:creator [a foaf:Person; foaf:name "Benjamin Young"],
+        [a foaf:Person; foaf:name "Paolo Ciccarese"],
+        [a foaf:Person; foaf:name "Robert Sanderson"] ;
     dcterms:modified "2016-11-12T21:28:11Z" ;
     rdfs:comment "The Web Annotation ontology defines the terms of the Web Annotation vocabulary. Any changes to this document MUST be from a Working Group in the W3C that has established expertise in the area." ;
     rdfs:seeAlso <http://www.w3.org/TR/annotation-vocab/> ;


### PR DESCRIPTION
This fixes a semantic issue with the manifests as noted in previous communication. Note that this does not touch mk-ontology.py, which should be updated to also output nodes.