### PR TITLE
Fixed some typos in Example 29 and 30.

### DIFF
--- a/selector-note/index.html
+++ b/selector-note/index.html
@@ -2454,8 +2454,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <div class="example-title marker"><span>Example 29</span><span style="text-transform: none">: Text Quote Selector in Japanese as an IRI and a URL, respectively</span></div>
         <pre class="nohighlight">http://jp.example.org/page1
     #selector(type=TextQuoteSelector,
-	      exact=ぺんを,
-	      prefix=私は,
+	      exact=ペンを,
+	      prefix=私は、,
 	      suffix=持っています)
 
 http://jp.example.org/page1
@@ -2473,7 +2473,7 @@ http://jp.example.org/page1
 
 http://example.org/page1
     #selector(type=TextQuoteSelector,exact=annotation,
-	      prefix=this%2520is%2520an%2520,=%2520that%2520has%2520some)</pre>
+	      prefix=this%2520is%2520an%2520,suffix=%2520that%2520has%2520some)</pre>
       </div>
 
       <p>Note that the IRI may also contain an internationalized domain name, which must be encoded as well (see [<cite><a class="bibref" href="#bib-rfc3490">rfc3490</a></cite>]).</p>


### PR DESCRIPTION
Fixed Japanese text, to make it correspond exactly to the percent
encoded string.
Added ’suffix’ property name, it was missing.