### PR TITLE
minor errors in JSON-LD examples

### DIFF
--- a/protocol/wd/index-respec.html
+++ b/protocol/wd/index-respec.html
@@ -538,8 +538,8 @@ Content-Length: 924
           "value": "I like this!"
         },
         "target": "http://example.com/book1"
-      }
-      // ...
+      },
+      ...
       {
         "id": "http://example.org/annotations/anno50",
         "type": "Annotation",
@@ -659,8 +659,8 @@ Content-Length: 924
         "value": "I like this!"
       },
       "target": "http://example.com/book1"
-    }
-    // ...
+    },
+    ...
     {
       "id": "http://example.org/annotations/anno50",
       "type": "Annotation",
@@ -871,7 +871,7 @@ Content-Length: 331
   "id": "http://example.org/annotations/anno1",
   "type": "Annotation",
   "created": "2015-02-01T10:13:40Z",
-  "modified": "2015-02-02T20:43:19Z"
+  "modified": "2015-02-02T20:43:19Z",
   "body": {
     "type": "TextualBody",
     "value": "I REALLY like this page!"


### PR DESCRIPTION
There is a minor syntactical error in one JSON-LD example (a missing comma).

There is also an inconsistency in how elided JSON-LD is represented (both `// ...` and `...` appear in the examples). This PR changes instances of `// ...` to `...`, making the WA examples consistent with how elided JSON-LD is represented in the JSON-LD specification.