### PR TITLE
Fix the selectors-states ref Anno in HTML note

### DIFF
--- a/serialization-html-note/index-respec.html
+++ b/serialization-html-note/index-respec.html
@@ -240,7 +240,7 @@
                  "Benjamin Young"
               ],
               title: "Selectors and States",
-              href: "http://www.w3.org/TR/selectors-state/",
+              href: "http://www.w3.org/TR/selectors-states/",
               publisher: "W3C",
               rawDate: "2017-02-23",
               status: "W3C Reference Note"

--- a/serialization-html-note/index-turtle-not-highlight.html
+++ b/serialization-html-note/index-turtle-not-highlight.html
@@ -172,7 +172,7 @@
                  "Benjamin Young"
               ],
               title: "Selectors and States",
-              href: "http://www.w3.org/TR/selectors-state/",
+              href: "https://www.w3.org/TR/selectors-states/",
               publisher: "W3C",
               rawDate: "2017-02-23",
               status: "W3C Reference Note"

--- a/serialization-html-note/index.html
+++ b/serialization-html-note/index.html
@@ -1211,7 +1211,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             "Benjamin Young"
           ],
           "title": "Selectors and States",
-          "href": "http://www.w3.org/TR/selectors-state/",
+          "href": "http://www.w3.org/TR/selectors-states/",
           "publisher": "W3C",
           "rawDate": "2017-02-23",
           "status": "W3C Reference Note"
@@ -1710,7 +1710,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <h2 id="h-web-annotation-based-citation-urls" resource="#h-web-annotation-based-citation-urls"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Web Annotation-based Citation URLs</span>
     </h2>
     <p>The Selectors and States Note [<cite><a class="bibref" href="#bib-selectors-states">selectors-states</a></cite>] published by the Web Annotation Working Group includes information on encoding
-      <a href="http://www.w3.org/TR/selectors-state/#frags">Web Annotation Selectors and State classes as IRI Fragment Identifiers</a>. The following examples show how these URLs could be used to reference portions of a Specific Resource on the Web via IRIs:
+      <a href="http://www.w3.org/TR/selectors-states/#frags">Web Annotation Selectors and State classes as IRI Fragment Identifiers</a>. The following examples show how these URLs could be used to reference portions of a Specific Resource on the Web via IRIs:
     </p>
 
     <section id="example-using-blockquote-and-q-tags" typeof="bibo:Chapter" resource="#example-using-blockquote-and-q-tags" property="bibo:hasPart">
@@ -1807,7 +1807,7 @@ an annotation is considered to be a set of what things?<span class="hljs-tag">&l
         </dd><dt id="bib-rfc3987">[rfc3987]</dt>
         <dd><a href="https://tools.ietf.org/html/rfc3987" property="dc:references"><cite>Internationalized Resource Identifiers (IRIs)</cite></a>. M. Duerst; M. Suignard. IETF. January 2005. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc3987" property="dc:references">https://tools.ietf.org/html/rfc3987</a>
         </dd><dt id="bib-selectors-states">[selectors-states]</dt>
-        <dd><a href="http://www.w3.org/TR/selectors-state/" property="dc:references"><cite>Selectors and States</cite></a>. Ivan Herman; Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. W3C Reference Note. URL: <a href="http://www.w3.org/TR/selectors-state/" property="dc:references">http://www.w3.org/TR/selectors-state/</a>
+        <dd><a href="http://www.w3.org/TR/selectors-states/" property="dc:references"><cite>Selectors and States</cite></a>. Ivan Herman; Robert Sanderson; Paolo Ciccarese; Benjamin Young. W3C. W3C Reference Note. URL: <a href="http://www.w3.org/TR/selectors-states/" property="dc:references">http://www.w3.org/TR/selectors-states/</a>
         </dd><dt id="bib-turtle">[turtle]</dt>
         <dd><a href="https://www.w3.org/TR/turtle/" property="dc:references"><cite>RDF 1.1 Turtle</cite></a>. Eric Prud'hommeaux; Gavin Carothers. W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/turtle/" property="dc:references">https://www.w3.org/TR/turtle/</a>
         </dd>


### PR DESCRIPTION
So...this is likely my fault...so I fixed the mess.

Not sure how the post-pub fixes work, but here it is all the same @iherman.